### PR TITLE
add permissions to test github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     pull_request:
 
 permissions:
-  contents: read
+    contents: read
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/modelcontextprotocol/conformance/security/code-scanning/1](https://github.com/modelcontextprotocol/conformance/security/code-scanning/1)

**General fix:**  
Add an explicit `permissions` block to the workflow to restrict the `GITHUB_TOKEN`'s access, using the narrowest set of permissions required.

**Detailed fix:**  
Since this workflow only checks out code and runs node tasks (no publishing, no deployment, no pull-request modification), the minimal required permission is `contents: read`. This should be set near the top of the workflow, ideally at the root level, so it applies to all jobs.

**Where/how to change:**  
- Add the following block directly below the workflow's `on:` section (after line 5 or line 6):

```yaml
permissions:
  contents: read
```

**What's needed:**  
- Just add a `permissions` key to the workflow; no imports or external changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
