### PR TITLE
Add test_elicitation_sep1034_defaults to SERVER_REQUIREMENTS.md

### DIFF
--- a/SERVER_REQUIREMENTS.md
+++ b/SERVER_REQUIREMENTS.md
@@ -397,6 +397,72 @@ If no progress token provided, just execute with delays.
 
 **Implementation Note**: If the client doesn't support elicitation (no `elicitation` capability), return an error.
 
+#### `test_elicitation_sep1034_defaults`
+
+**Arguments**: None
+
+**Behavior**: Request user input from the client using `elicitation/create` with default values for all primitive types (SEP-1034)
+
+**Elicitation Request**:
+
+```json
+{
+  "method": "elicitation/create",
+  "params": {
+    "message": "Please review and update the form fields with defaults",
+    "requestedSchema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "User name",
+          "default": "John Doe"
+        },
+        "age": {
+          "type": "integer",
+          "description": "User age",
+          "default": 30
+        },
+        "score": {
+          "type": "number",
+          "description": "User score",
+          "default": 95.5
+        },
+        "status": {
+          "type": "string",
+          "description": "User status",
+          "enum": ["active", "inactive", "pending"],
+          "default": "active"
+        },
+        "verified": {
+          "type": "boolean",
+          "description": "Verification status",
+          "default": true
+        }
+      },
+      "required": []
+    }
+  }
+}
+```
+
+**Returns**: Text content with the elicitation result
+
+```json
+{
+  "content": [
+    {
+      "type": "text",
+      "text": "Elicitation completed: action=<accept/decline/cancel>, content={...}"
+    }
+  ]
+}
+```
+
+**Implementation Note**: This tool tests SEP-1034 support for default values across all primitive types (string, integer, number, enum, boolean). If the client doesn't support elicitation (no `elicitation` capability), return an error.
+
+**Reference**: [SEP-1034](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1034)
+
 ---
 
 ## 3. Resources Requirements


### PR DESCRIPTION
Documents the required tool for SEP-1034 conformance testing, which tests elicitation with default values for all primitive types.

## Motivation and Context
Addresses @ihrpr's comment from PR #14 (https://github.com/modelcontextprotocol/conformance/pull/14#discussion_r2511385365) to document the `test_elicitation_sep1034_defaults` tool in SERVER_REQUIREMENTS.md.

PR #14 added this tool to the TypeScript reference server and created conformance tests, but the tool wasn't documented in the requirements. This creates a gap where SDK maintainers implementing conformance servers wouldn't know this tool is required.

## Changes
- Added `test_elicitation_sep1034_defaults` tool specification to SERVER_REQUIREMENTS.md
- Documents the complete elicitation request schema with default values for all primitive types:
  - `name` (string, default: "John Doe")
  - `age` (integer, default: 30)
  - `score` (number, default: 95.5)
  - `status` (enum, default: "active")
  - `verified` (boolean, default: true)
- Includes reference to SEP-1034

## How Has This Been Tested?
Documentation only - no functional changes to test.

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] I have added or updated documentation as needed