### PR TITLE
Use --bin flag for pkg.pr.new to show npx commands

### DIFF
--- a/.github/workflows/pr-publish.yml
+++ b/.github/workflows/pr-publish.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Build
         run: npm run build
       - name: Publish
-        run: npx pkg-pr-new publish
+        run: npx pkg-pr-new publish --bin


### PR DESCRIPTION
## Summary
- Adds `--bin` flag to pkg.pr.new publish command so PR comments show `npx conformance@...` instead of `npm i ...`

## Test plan
- [x] Verify PR comments from pkg.pr.new now show npx syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)