### PR TITLE
Add conformance tests for SEP-1036 URL mode elicitation

### DIFF
--- a/examples/servers/typescript/everything-server.ts
+++ b/examples/servers/typescript/everything-server.ts
@@ -16,7 +16,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import {
   ElicitResultSchema,
   McpError,
-  ErrorCode
+  ErrorCode,
   ListToolsRequestSchema,
   type ListToolsResult,
   type Tool

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@modelcontextprotocol/sdk": "^1.22.0",
         "commander": "^14.0.2",
         "express": "^5.1.0",
-        "lefthook": "^2.0.2",
         "zod": "^3.25.76"
       },
       "bin": {
@@ -26,6 +25,7 @@
         "cors": "^2.8.5",
         "eslint": "^9.8.0",
         "eslint-config-prettier": "^10.1.8",
+        "lefthook": "^2.0.2",
         "prettier": "3.6.2",
         "tsdown": "^0.15.12",
         "tsx": "^4.7.0",
@@ -3635,6 +3635,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lefthook/-/lefthook-2.0.2.tgz",
       "integrity": "sha512-2lrSva53G604ZWjK5kHYvDdwb5GzbhciIPWhebv0A8ceveqSsnG2JgVEt+DnhOPZ4VfNcXvt3/ohFBPNpuAlVw==",
+      "dev": true,
       "hasInstallScript": true,
       "bin": {
         "lefthook": "bin/index.js"
@@ -3659,6 +3660,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3672,6 +3674,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3685,6 +3688,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3698,6 +3702,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3711,6 +3716,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3724,6 +3730,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3737,6 +3744,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3750,6 +3758,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3763,6 +3772,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3776,6 +3786,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/src/scenarios/index.ts
+++ b/src/scenarios/index.ts
@@ -52,7 +52,9 @@ import { listMetadataScenarios } from './client/auth/discovery-metadata.js';
 // Pending client scenarios (not yet fully tested/implemented)
 const pendingClientScenariosList: ClientScenario[] = [
   // Elicitation scenarios (SEP-1330)
-  new ElicitationEnumsScenario()
+  new ElicitationEnumsScenario(),
+  // Elicitation scenarios (SEP-1036) - URL mode (pending SDK release)
+  new ElicitationUrlModeScenario()
 ];
 
 // All client scenarios
@@ -80,10 +82,7 @@ const allClientScenariosList: ClientScenario[] = [
   // Elicitation scenarios (SEP-1034)
   new ElicitationDefaultsScenario(),
 
-  // Elicitation scenarios (SEP-1036) - URL mode
-  new ElicitationUrlModeScenario(),
-
-  // Elicitation scenarios (SEP-1330) - pending
+  // Elicitation scenarios (SEP-1330, SEP-1036) - pending
   ...pendingClientScenariosList,
 
   // Resources scenarios

--- a/src/scenarios/index.ts
+++ b/src/scenarios/index.ts
@@ -56,7 +56,7 @@ const pendingClientScenariosList: ClientScenario[] = [
   // Elicitation scenarios (SEP-1330)
   new ElicitationEnumsScenario(),
   // Elicitation scenarios (SEP-1036) - URL mode (pending SDK release)
-  new ElicitationUrlModeScenario()
+  new ElicitationUrlModeScenario(),
 
   // JSON Schema 2020-12 (SEP-1613)
   // This test is pending until the SDK includes PR #1135 which preserves

--- a/src/scenarios/index.ts
+++ b/src/scenarios/index.ts
@@ -27,6 +27,7 @@ import {
 
 import { ElicitationDefaultsScenario } from './server/elicitation-defaults.js';
 import { ElicitationEnumsScenario } from './server/elicitation-enums.js';
+import { ElicitationUrlModeScenario } from './server/elicitation-url.js';
 
 import {
   ResourcesListScenario,
@@ -78,6 +79,9 @@ const allClientScenariosList: ClientScenario[] = [
 
   // Elicitation scenarios (SEP-1034)
   new ElicitationDefaultsScenario(),
+
+  // Elicitation scenarios (SEP-1036) - URL mode
+  new ElicitationUrlModeScenario(),
 
   // Elicitation scenarios (SEP-1330) - pending
   ...pendingClientScenariosList,

--- a/src/scenarios/server/client-helper.ts
+++ b/src/scenarios/server/client-helper.ts
@@ -47,6 +47,40 @@ export async function connectToServer(
 }
 
 /**
+ * Create and connect an MCP client with URL elicitation capability (SEP-1036)
+ */
+export async function connectToServerWithUrlElicitation(
+  serverUrl: string
+): Promise<MCPClientConnection> {
+  const client = new Client(
+    {
+      name: 'conformance-test-client',
+      version: '1.0.0'
+    },
+    {
+      capabilities: {
+        // Client capabilities
+        sampling: {},
+        elicitation: {
+          url: {}
+        }
+      }
+    }
+  );
+
+  const transport = new StreamableHTTPClientTransport(new URL(serverUrl));
+
+  await client.connect(transport);
+
+  return {
+    client,
+    close: async () => {
+      await client.close();
+    }
+  };
+}
+
+/**
  * Helper to collect notifications (logging and progress)
  */
 export class NotificationCollector {

--- a/src/scenarios/server/elicitation-url.ts
+++ b/src/scenarios/server/elicitation-url.ts
@@ -6,10 +6,20 @@ import { ClientScenario, ConformanceCheck } from '../../types.js';
 import { connectToServerWithUrlElicitation } from './client-helper.js';
 import {
   ElicitRequestSchema,
-  ElicitationCompleteNotificationSchema,
   ErrorCode,
-  McpError
+  McpError,
+  NotificationSchema
 } from '@modelcontextprotocol/sdk/types.js';
+import { z } from 'zod';
+
+// Define locally until SDK releases this schema
+const ElicitationCompleteNotificationSchema = NotificationSchema.extend({
+  method: z.literal('notifications/elicitation/complete'),
+  params: z.object({
+    _meta: z.object({}).passthrough().optional(),
+    elicitationId: z.string()
+  })
+});
 
 export class ElicitationUrlModeScenario implements ClientScenario {
   name = 'elicitation-sep1036-url-mode';

--- a/src/scenarios/server/elicitation-url.ts
+++ b/src/scenarios/server/elicitation-url.ts
@@ -1,0 +1,422 @@
+/**
+ * SEP-1036: URL mode elicitation test scenarios for MCP servers
+ */
+
+import { ClientScenario, ConformanceCheck } from '../../types.js';
+import { connectToServerWithUrlElicitation } from './client-helper.js';
+import {
+  ElicitRequestSchema,
+  ErrorCode,
+  McpError
+} from '@modelcontextprotocol/sdk/types.js';
+
+export class ElicitationUrlModeScenario implements ClientScenario {
+  name = 'elicitation-sep1036-url-mode';
+  description = `Test URL mode elicitation per SEP-1036.
+
+**Server Implementation Requirements:**
+
+Implement two tools:
+
+1. \`test_elicitation_sep1036_url\` (no arguments) - Requests URL mode elicitation from client with:
+   - \`mode\`: "url"
+   - \`message\`: Human-readable explanation (non-empty string)
+   - \`url\`: Valid URL (e.g., "https://mcp.example.com/test")
+   - \`elicitationId\`: Unique identifier (non-empty string)
+
+   **Returns**: Text content with the elicitation action received
+
+2. \`test_elicitation_sep1036_error\` (no arguments) - Throws URLElicitationRequiredError:
+   - Error code: -32042
+   - Error data contains \`elicitations\` array with URL mode elicitation objects
+
+**Example elicitation request:**
+\`\`\`json
+{
+  "method": "elicitation/create",
+  "params": {
+    "mode": "url",
+    "message": "Please complete authorization",
+    "url": "https://mcp.example.com/test",
+    "elicitationId": "sep1036-test-uuid"
+  }
+}
+\`\`\``;
+
+  async run(serverUrl: string): Promise<ConformanceCheck[]> {
+    const checks: ConformanceCheck[] = [];
+
+    try {
+      const connection = await connectToServerWithUrlElicitation(serverUrl);
+
+      // Part 1: Test URL mode elicitation request flow
+      let capturedRequest: any = null;
+      connection.client.setRequestHandler(
+        ElicitRequestSchema,
+        async (request) => {
+          capturedRequest = request;
+          // URL mode response should have action but no content
+          return {
+            action: 'accept'
+          };
+        }
+      );
+
+      await connection.client.callTool({
+        name: 'test_elicitation_sep1036_url',
+        arguments: {}
+      });
+
+      // Validate that elicitation was requested
+      if (!capturedRequest) {
+        checks.push({
+          id: 'sep1036-url-general',
+          name: 'URLElicitationSEP1036General',
+          description: 'Server requests URL mode elicitation',
+          status: 'FAILURE',
+          timestamp: new Date().toISOString(),
+          errorMessage: 'Server did not request elicitation from client',
+          specReferences: [
+            {
+              id: 'SEP-1036',
+              url: 'https://github.com/modelcontextprotocol/modelcontextprotocol/pull/887'
+            }
+          ]
+        });
+        await connection.close();
+        return checks;
+      }
+
+      const params = capturedRequest.params;
+
+      // Check 1: Validate mode is "url"
+      const modeErrors: string[] = [];
+      if (!params?.mode) {
+        modeErrors.push('Missing mode parameter');
+      } else if (params.mode !== 'url') {
+        modeErrors.push(`Expected mode "url", got "${params.mode}"`);
+      }
+
+      checks.push({
+        id: 'sep1036-url-mode',
+        name: 'URLModeRequired',
+        description: 'URL elicitation request specifies mode as "url"',
+        status: modeErrors.length === 0 ? 'SUCCESS' : 'FAILURE',
+        timestamp: new Date().toISOString(),
+        errorMessage: modeErrors.length > 0 ? modeErrors.join('; ') : undefined,
+        specReferences: [
+          {
+            id: 'SEP-1036',
+            url: 'https://github.com/modelcontextprotocol/modelcontextprotocol/pull/887'
+          }
+        ],
+        details: {
+          mode: params?.mode
+        }
+      });
+
+      // Check 2: Validate message is present and non-empty
+      const messageErrors: string[] = [];
+      if (!params?.message) {
+        messageErrors.push('Missing message parameter');
+      } else if (typeof params.message !== 'string') {
+        messageErrors.push(
+          `Expected string message, got ${typeof params.message}`
+        );
+      } else if (params.message.trim() === '') {
+        messageErrors.push('Message is empty');
+      }
+
+      checks.push({
+        id: 'sep1036-url-message',
+        name: 'URLMessagePresent',
+        description: 'URL elicitation request includes human-readable message',
+        status: messageErrors.length === 0 ? 'SUCCESS' : 'FAILURE',
+        timestamp: new Date().toISOString(),
+        errorMessage:
+          messageErrors.length > 0 ? messageErrors.join('; ') : undefined,
+        specReferences: [
+          {
+            id: 'SEP-1036',
+            url: 'https://github.com/modelcontextprotocol/modelcontextprotocol/pull/887'
+          }
+        ],
+        details: {
+          message: params?.message
+        }
+      });
+
+      // Check 3: Validate url is present and valid
+      const urlErrors: string[] = [];
+      if (!params?.url) {
+        urlErrors.push('Missing url parameter');
+      } else if (typeof params.url !== 'string') {
+        urlErrors.push(`Expected string url, got ${typeof params.url}`);
+      } else {
+        try {
+          const urlObj = new URL(params.url);
+          // URL should use HTTP or HTTPS protocol
+          if (urlObj.protocol !== 'https:' && urlObj.protocol !== 'http:') {
+            urlErrors.push(
+              `URL must use HTTP or HTTPS protocol, got "${urlObj.protocol}"`
+            );
+          }
+        } catch {
+          urlErrors.push(`Invalid URL format: ${params.url}`);
+        }
+      }
+
+      checks.push({
+        id: 'sep1036-url-field',
+        name: 'URLFieldValid',
+        description: 'URL elicitation request includes valid URL',
+        status: urlErrors.length === 0 ? 'SUCCESS' : 'FAILURE',
+        timestamp: new Date().toISOString(),
+        errorMessage: urlErrors.length > 0 ? urlErrors.join('; ') : undefined,
+        specReferences: [
+          {
+            id: 'SEP-1036',
+            url: 'https://github.com/modelcontextprotocol/modelcontextprotocol/pull/887'
+          }
+        ],
+        details: {
+          url: params?.url
+        }
+      });
+
+      // Check 4: Validate elicitationId is present and valid
+      const idErrors: string[] = [];
+      if (!params?.elicitationId) {
+        idErrors.push('Missing elicitationId parameter');
+      } else if (typeof params.elicitationId !== 'string') {
+        idErrors.push(
+          `Expected string elicitationId, got ${typeof params.elicitationId}`
+        );
+      } else if (params.elicitationId.trim() === '') {
+        idErrors.push('elicitationId is empty');
+      }
+
+      checks.push({
+        id: 'sep1036-url-elicitation-id',
+        name: 'URLElicitationIdPresent',
+        description: 'URL elicitation request includes unique elicitationId',
+        status: idErrors.length === 0 ? 'SUCCESS' : 'FAILURE',
+        timestamp: new Date().toISOString(),
+        errorMessage: idErrors.length > 0 ? idErrors.join('; ') : undefined,
+        specReferences: [
+          {
+            id: 'SEP-1036',
+            url: 'https://github.com/modelcontextprotocol/modelcontextprotocol/pull/887'
+          }
+        ],
+        details: {
+          elicitationId: params?.elicitationId
+        }
+      });
+
+      // Check 5: URL mode response has action (this is implicitly tested by the tool completing)
+      // We successfully returned { action: 'accept' } and the tool completed
+      checks.push({
+        id: 'sep1036-url-response-action',
+        name: 'URLResponseAction',
+        description: 'Client response has action field',
+        status: 'SUCCESS',
+        timestamp: new Date().toISOString(),
+        specReferences: [
+          {
+            id: 'SEP-1036',
+            url: 'https://github.com/modelcontextprotocol/modelcontextprotocol/pull/887'
+          }
+        ],
+        details: {
+          action: 'accept'
+        }
+      });
+
+      // Check 6: URL mode response should not have content field
+      // Our handler returned { action: 'accept' } without content, which is correct
+      checks.push({
+        id: 'sep1036-url-response-no-content',
+        name: 'URLResponseNoContent',
+        description: 'URL mode response omits content field',
+        status: 'SUCCESS',
+        timestamp: new Date().toISOString(),
+        specReferences: [
+          {
+            id: 'SEP-1036',
+            url: 'https://github.com/modelcontextprotocol/modelcontextprotocol/pull/887'
+          }
+        ],
+        details: {
+          note: 'Response contained action only, no content field'
+        }
+      });
+
+      // Part 2: Test URLElicitationRequiredError flow
+      let errorReceived: McpError | null = null;
+      try {
+        await connection.client.callTool({
+          name: 'test_elicitation_sep1036_error',
+          arguments: {}
+        });
+        // If we get here, the tool didn't throw an error as expected
+        checks.push({
+          id: 'sep1036-url-error-code',
+          name: 'URLErrorCode',
+          description:
+            'Server returns URLElicitationRequiredError (code -32042)',
+          status: 'FAILURE',
+          timestamp: new Date().toISOString(),
+          errorMessage:
+            'Tool did not throw URLElicitationRequiredError as expected',
+          specReferences: [
+            {
+              id: 'SEP-1036',
+              url: 'https://github.com/modelcontextprotocol/modelcontextprotocol/pull/887'
+            }
+          ]
+        });
+      } catch (error) {
+        if (error instanceof McpError) {
+          errorReceived = error;
+        } else if (error instanceof Error && 'code' in error) {
+          // Handle case where error might not be McpError instance but has code
+          errorReceived = error as unknown as McpError;
+        }
+
+        // Check 7: Validate error code is -32042
+        const errorCodeErrors: string[] = [];
+        if (!errorReceived) {
+          errorCodeErrors.push('Did not receive an MCP error');
+        } else if (errorReceived.code !== ErrorCode.UrlElicitationRequired) {
+          errorCodeErrors.push(
+            `Expected error code ${ErrorCode.UrlElicitationRequired} (-32042), got ${errorReceived.code}`
+          );
+        }
+
+        checks.push({
+          id: 'sep1036-url-error-code',
+          name: 'URLErrorCode',
+          description:
+            'Server returns URLElicitationRequiredError (code -32042)',
+          status: errorCodeErrors.length === 0 ? 'SUCCESS' : 'FAILURE',
+          timestamp: new Date().toISOString(),
+          errorMessage:
+            errorCodeErrors.length > 0 ? errorCodeErrors.join('; ') : undefined,
+          specReferences: [
+            {
+              id: 'SEP-1036',
+              url: 'https://github.com/modelcontextprotocol/modelcontextprotocol/pull/887'
+            }
+          ],
+          details: {
+            errorCode: errorReceived?.code
+          }
+        });
+
+        // Check 8: Validate error data contains elicitations array
+        const elicitationsErrors: string[] = [];
+        const errorData = errorReceived?.data as
+          | { elicitations?: unknown[] }
+          | undefined;
+        if (!errorData?.elicitations) {
+          elicitationsErrors.push('Error data missing elicitations array');
+        } else if (!Array.isArray(errorData.elicitations)) {
+          elicitationsErrors.push('elicitations is not an array');
+        } else if (errorData.elicitations.length === 0) {
+          elicitationsErrors.push('elicitations array is empty');
+        }
+
+        checks.push({
+          id: 'sep1036-url-error-elicitations',
+          name: 'URLErrorElicitations',
+          description: 'Error data contains elicitations array',
+          status: elicitationsErrors.length === 0 ? 'SUCCESS' : 'FAILURE',
+          timestamp: new Date().toISOString(),
+          errorMessage:
+            elicitationsErrors.length > 0
+              ? elicitationsErrors.join('; ')
+              : undefined,
+          specReferences: [
+            {
+              id: 'SEP-1036',
+              url: 'https://github.com/modelcontextprotocol/modelcontextprotocol/pull/887'
+            }
+          ],
+          details: {
+            elicitationsCount: errorData?.elicitations?.length
+          }
+        });
+
+        // Check 9: Validate each elicitation has required URL mode fields
+        const structureErrors: string[] = [];
+        if (errorData?.elicitations && Array.isArray(errorData.elicitations)) {
+          for (let i = 0; i < errorData.elicitations.length; i++) {
+            const elicit = errorData.elicitations[i] as Record<string, unknown>;
+            if (!elicit.mode || elicit.mode !== 'url') {
+              structureErrors.push(
+                `Elicitation[${i}]: missing or invalid mode (expected "url")`
+              );
+            }
+            if (!elicit.url || typeof elicit.url !== 'string') {
+              structureErrors.push(
+                `Elicitation[${i}]: missing or invalid url field`
+              );
+            }
+            if (
+              !elicit.elicitationId ||
+              typeof elicit.elicitationId !== 'string'
+            ) {
+              structureErrors.push(
+                `Elicitation[${i}]: missing or invalid elicitationId field`
+              );
+            }
+            if (!elicit.message || typeof elicit.message !== 'string') {
+              structureErrors.push(
+                `Elicitation[${i}]: missing or invalid message field`
+              );
+            }
+          }
+        }
+
+        checks.push({
+          id: 'sep1036-url-error-structure',
+          name: 'URLErrorStructure',
+          description: 'Each elicitation has required URL mode fields',
+          status: structureErrors.length === 0 ? 'SUCCESS' : 'FAILURE',
+          timestamp: new Date().toISOString(),
+          errorMessage:
+            structureErrors.length > 0 ? structureErrors.join('; ') : undefined,
+          specReferences: [
+            {
+              id: 'SEP-1036',
+              url: 'https://github.com/modelcontextprotocol/modelcontextprotocol/pull/887'
+            }
+          ],
+          details: {
+            elicitations: errorData?.elicitations
+          }
+        });
+      }
+
+      await connection.close();
+    } catch (error) {
+      checks.push({
+        id: 'sep1036-url-general',
+        name: 'URLElicitationSEP1036General',
+        description: 'Server requests URL mode elicitation',
+        status: 'FAILURE',
+        timestamp: new Date().toISOString(),
+        errorMessage: `Failed: ${error instanceof Error ? error.message : String(error)}`,
+        specReferences: [
+          {
+            id: 'SEP-1036',
+            url: 'https://github.com/modelcontextprotocol/modelcontextprotocol/pull/887'
+          }
+        ]
+      });
+    }
+
+    return checks;
+  }
+}


### PR DESCRIPTION
Adds conformance tests for SEP-1036 which introduces URL mode elicitation for out-of-band user interactions.

## Summary
- Server test: validates URL mode elicitation request structure (mode, message, url, elicitationId)
- Server test: validates URLElicitationRequiredError (code -32042) with elicitations array
- Server test: validates completion notification (notifications/elicitation/complete)
- Fixed everything-server to use `elicitInput()` instead of raw `request()` for proper capability checking

## Motivation and Context
SEP-1036 introduces URL mode elicitation, allowing servers to direct users to external URLs for out-of-band authentication, payment confirmation, or other interactions. These conformance tests ensure SDK implementations correctly handle the URL elicitation flow including the completion notification.

## How Has This Been Tested?
- All conformance checks pass against TypeScript SDK implementation (requires SDK with SEP-1036 support)
- Tests verify: mode validation, URL validity, elicitationId presence, error code, completion notification flow

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Note
This PR requires SDK version with SEP-1036 support (not yet released in 1.22.0). Currently tested with linked local SDK.