### PR TITLE
Omit arguments from tool call with no arguments

### DIFF
--- a/src/scenarios/server/tools.ts
+++ b/src/scenarios/server/tools.ts
@@ -119,8 +119,8 @@ Implement tool \`test_simple_text\` with no arguments that returns:
       const connection = await connectToServer(serverUrl);
 
       const result = await connection.client.callTool({
-        name: 'test_simple_text',
-        arguments: {}
+        name: 'test_simple_text'
+        /* omit arguments as it is not required in the schema */
       });
 
       // Validate response


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context

This PR modifies the tools-call-simple-text to omit the "arguments" property in the tool call, which is not required according to the schema.

https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-06-18/schema.json#L133

<img width="1334" height="1050" alt="image" src="https://github.com/user-attachments/assets/f11ff3b2-5ea9-493c-89e1-fb5e0eacee23" />

This will flag server implementations that incorrectly fail tool call requests that do not include "arguments".

## How Has This Been Tested?

All tests, including the modified tools-call-simple-text test, pass when run on a server using the C# MCP SDK.

## Breaking Changes

No breaking change, just a slightly more strict version of the test.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

This might expose a latent conformance bug in the TypeScript SDK.
