### PR TITLE
Add dependabot config with 7-day dependency cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Adds Dependabot configuration with 7-day cooldown for both `npm` and `github-actions` ecosystems
- Dependency cooldowns delay automatic updates until packages have been published for a set period, protecting against supply chain attacks

## Background
According to [this analysis](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns), 8 out of 10 recent supply chain attacks had exploitation windows under one week. A 7-day cooldown would have prevented the vast majority of these attacks from reaching end users.

## Test plan
- [x] Dependabot config is valid YAML
- [ ] Verify Dependabot picks up the config after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)