### PR TITLE
chore: enforce LF line endings for x-plat consistency

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Enforce LF line endings for all text files
+* text=auto eol=lf
+

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,5 @@
 {
+  "endOfLine": "lf",
   "singleQuote": true,
   "trailingComma": "none",
   "overrides": [


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
Ensures line ending consistency across platforms.

On Windows, setting `git config core.autocrlf=true` is a common default. This clashes with Prettier's default, which results in `npm run lint:fix` making many spurious edits.

## How Has This Been Tested?
`npm run lint:fix` is now clean, as expected.

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

