### PR TITLE
Change dependabot to monthly grouped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,26 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7
+      interval: monthly
+    groups:
+      all-dependencies:
+        patterns:
+          - '*'
+
+  - package-ecosystem: npm
+    directory: /examples/servers/typescript
+    schedule:
+      interval: monthly
+    groups:
+      all-dependencies:
+        patterns:
+          - '*'
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
-    cooldown:
-      default-days: 7
+      interval: monthly
+    groups:
+      all-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Summary
- Switch from weekly to monthly schedule to reduce PR noise
- Group all npm dependencies into a single PR per directory
- Group all GitHub actions into a single PR
- Add explicit config for examples/servers/typescript directory

This should reduce the number of dependabot PRs significantly while still keeping dependencies up to date.