### PR TITLE
feat: make results directory output optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,11 +39,13 @@ program
   .option('--scenario <scenario>', 'Scenario to test')
   .option('--suite <suite>', 'Run a suite of tests in parallel (e.g., "auth")')
   .option('--timeout <ms>', 'Timeout in milliseconds', '30000')
+  .option('-o, --output-dir <path>', 'Save results to this directory')
   .option('--verbose', 'Show verbose output')
   .action(async (options) => {
     try {
       const timeout = parseInt(options.timeout, 10);
       const verbose = options.verbose ?? false;
+      const outputDir = options.outputDir;
 
       // Handle suite mode
       if (options.suite) {
@@ -78,7 +80,8 @@ program
               const result = await runConformanceTest(
                 options.command,
                 scenarioName,
-                timeout
+                timeout,
+                outputDir
               );
               return {
                 scenario: scenarioName,
@@ -163,7 +166,7 @@ program
 
       // If no command provided, run in interactive mode
       if (!validated.command) {
-        await runInteractiveMode(validated.scenario, verbose);
+        await runInteractiveMode(validated.scenario, verbose, outputDir);
         process.exit(0);
       }
 
@@ -171,7 +174,8 @@ program
       const result = await runConformanceTest(
         validated.command,
         validated.scenario,
-        timeout
+        timeout,
+        outputDir
       );
 
       const { overallFailure } = printClientResults(
@@ -209,6 +213,7 @@ program
     'Suite to run: "active" (default, excludes pending), "all", or "pending"',
     'active'
   )
+  .option('-o, --output-dir <path>', 'Save results to this directory')
   .option('--verbose', 'Show verbose output (JSON instead of pretty print)')
   .action(async (options) => {
     try {
@@ -216,12 +221,14 @@ program
       const validated = ServerOptionsSchema.parse(options);
 
       const verbose = options.verbose ?? false;
+      const outputDir = options.outputDir;
 
       // If a single scenario is specified, run just that one
       if (validated.scenario) {
         const result = await runServerConformanceTest(
           validated.url,
-          validated.scenario
+          validated.scenario,
+          outputDir
         );
 
         const { failed } = printServerResults(
@@ -259,7 +266,8 @@ program
           try {
             const result = await runServerConformanceTest(
               validated.url,
-              scenarioName
+              scenarioName,
+              outputDir
             );
             allResults.push({ scenario: scenarioName, checks: result.checks });
           } catch (error) {

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -15,7 +15,6 @@ export {
 
 // Export utilities
 export {
-  ensureResultsDir,
   createResultDir,
   formatPrettyChecks,
   getStatusColor,

--- a/src/runner/utils.ts
+++ b/src/runner/utils.ts
@@ -1,4 +1,3 @@
-import { promises as fs } from 'fs';
 import path from 'path';
 import { ConformanceCheck } from '../types';
 
@@ -51,14 +50,12 @@ export function formatPrettyChecks(checks: ConformanceCheck[]): string {
     .join('\n');
 }
 
-export async function ensureResultsDir(): Promise<string> {
-  const resultsDir = path.join(process.cwd(), 'results');
-  await fs.mkdir(resultsDir, { recursive: true });
-  return resultsDir;
-}
-
-export function createResultDir(scenario: string, prefix = ''): string {
+export function createResultDir(
+  baseDir: string,
+  scenario: string,
+  prefix = ''
+): string {
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
   const dirName = prefix ? `${prefix}-${scenario}` : scenario;
-  return path.join('results', `${dirName}-${timestamp}`);
+  return path.join(baseDir, `${dirName}-${timestamp}`);
 }


### PR DESCRIPTION
## Summary

Makes the results directory output optional. By default, no results directory is created - only console output is shown.

## Changes

- Add `-o, --output-dir <path>` option to both `client` and `server` commands
- When not specified: no results directory is created
- When specified: results are saved to that directory with timestamped subdirectories

## Motivation

Previously, every test run created a `results/<scenario>-<timestamp>/` directory, requiring `results/` to be added to `.gitignore` in every repo where conformance tests are run. The results files (checks.json, stdout.txt, stderr.txt) were rarely needed for debugging.

## Usage

```bash
# Default: no results saved
conformance client --command '...' --scenario initialize

# Save results to a specific directory  
conformance client --command '...' --scenario initialize -o ./my-results
```