### PR TITLE
ci: migrate to OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
   pull_request:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      prerelease:
+        description: 'Publish as prerelease (alpha tag). Version must already be bumped in package.json on the branch.'
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -31,7 +37,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    if: github.event_name == 'release'
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.prerelease == 'true')
     environment: release
     needs: [test]
 
@@ -48,6 +54,11 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
-      - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            npm publish --access public --tag alpha
+          else
+            npm publish --access public
+          fi


### PR DESCRIPTION
Migrates npm publishing from NPM_TOKEN secret to OIDC trusted publishing.

## Changes

- Remove `NODE_AUTH_TOKEN` env var from publish step — OIDC handles auth now
- Drop `--provenance` flag (included automatically with trusted publishing)
- Add `workflow_dispatch` trigger with `prerelease` input for testing:
  - When checked, publishes to `alpha` dist-tag so we can verify OIDC works
    without affecting `latest`
  - Normal release event path still publishes to `latest` as before

## Testing

To verify before merging:
1. Register trusted publisher on npmjs (see below)
2. Bump version to e.g. `0.1.12-alpha.0` on a branch  
3. Run workflow manually with `prerelease` checked
4. Verify `npm view @modelcontextprotocol/conformance@alpha` shows the version
5. Unpublish the test version

## npmjs Trusted Publisher Registration

On https://www.npmjs.com/package/@modelcontextprotocol/conformance/settings, add:

| Field | Value |
|---|---|
| Provider | GitHub Actions |
| GitHub owner | modelcontextprotocol |
| Repository | conformance |
| Workflow filename | `ci.yml` |
| Environment | `release` |

Note: environment was renamed from `Release` to `release` (lowercase) via API
to match workflow references. npmjs trusted publisher matching is case-sensitive.