### PR TITLE
feat: move march back-compat auth tests to optional backcompat suite

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,8 @@ import {
   listAuthScenarios,
   listMetadataScenarios,
   listCoreScenarios,
-  listExtensionScenarios
+  listExtensionScenarios,
+  listBackcompatScenarios
 } from './scenarios';
 import { ConformanceCheck } from './types';
 import { ClientOptionsSchema, ServerOptionsSchema } from './schemas';
@@ -69,6 +70,7 @@ program
           all: listScenarios,
           core: listCoreScenarios,
           extensions: listExtensionScenarios,
+          backcompat: listBackcompatScenarios,
           auth: listAuthScenarios,
           metadata: listMetadataScenarios,
           'sep-835': () =>
@@ -182,7 +184,7 @@ program
         console.error('\nAvailable client scenarios:');
         listScenarios().forEach((s) => console.error(`  - ${s}`));
         console.error(
-          '\nAvailable suites: all, core, extensions, auth, metadata, sep-835'
+          '\nAvailable suites: all, core, extensions, backcompat, auth, metadata, sep-835'
         );
         process.exit(1);
       }

--- a/src/scenarios/client/auth/index.test.ts
+++ b/src/scenarios/client/auth/index.test.ts
@@ -1,4 +1,4 @@
-import { authScenariosList } from './index';
+import { authScenariosList, backcompatScenariosList } from './index';
 import {
   runClientAgainstScenario,
   InlineClientRunner
@@ -44,6 +44,19 @@ describe('Client Auth Scenarios', () => {
       await runClientAgainstScenario(runner, scenario.name, {
         allowClientError: allowClientErrorScenarios.has(scenario.name)
       });
+    });
+  }
+});
+
+describe('Client Back-compat Scenarios', () => {
+  for (const scenario of backcompatScenariosList) {
+    test(`${scenario.name} passes`, async () => {
+      const clientFn = getHandler(scenario.name);
+      if (!clientFn) {
+        throw new Error(`No handler registered for scenario: ${scenario.name}`);
+      }
+      const runner = new InlineClientRunner(clientFn);
+      await runClientAgainstScenario(runner, scenario.name);
     });
   }
 });

--- a/src/scenarios/client/auth/index.ts
+++ b/src/scenarios/client/auth/index.ts
@@ -28,8 +28,6 @@ import { PreRegistrationScenario } from './pre-registration';
 export const authScenariosList: Scenario[] = [
   ...metadataScenarios,
   new AuthBasicCIMDScenario(),
-  new Auth20250326OAuthMetadataBackcompatScenario(),
-  new Auth20250326OEndpointFallbackScenario(),
   new ScopeFromWwwAuthenticateScenario(),
   new ScopeFromScopesSupportedScenario(),
   new ScopeOmittedWhenUndefinedScenario(),
@@ -40,6 +38,12 @@ export const authScenariosList: Scenario[] = [
   new PublicClientAuthScenario(),
   new ResourceMismatchScenario(),
   new PreRegistrationScenario()
+];
+
+// Back-compat scenarios (optional - backward compatibility with older spec versions)
+export const backcompatScenariosList: Scenario[] = [
+  new Auth20250326OAuthMetadataBackcompatScenario(),
+  new Auth20250326OEndpointFallbackScenario()
 ];
 
 // Extension scenarios (optional for tier 1 - protocol extensions)

--- a/src/scenarios/index.ts
+++ b/src/scenarios/index.ts
@@ -53,7 +53,11 @@ import {
 
 import { DNSRebindingProtectionScenario } from './server/dns-rebinding';
 
-import { authScenariosList, extensionScenariosList } from './client/auth/index';
+import {
+  authScenariosList,
+  backcompatScenariosList,
+  extensionScenariosList
+} from './client/auth/index';
 import { listMetadataScenarios } from './client/auth/discovery-metadata';
 
 // Pending client scenarios (not yet fully tested/implemented)
@@ -137,13 +141,14 @@ export const clientScenarios = new Map<string, ClientScenario>(
   allClientScenariosList.map((scenario) => [scenario.name, scenario])
 );
 
-// All client test scenarios (core + extensions)
+// All client test scenarios (core + backcompat + extensions)
 const scenariosList: Scenario[] = [
   new InitializeScenario(),
   new ToolsCallScenario(),
   new ElicitationClientDefaultsScenario(),
   new SSERetryScenario(),
   ...authScenariosList,
+  ...backcompatScenariosList,
   ...extensionScenariosList
 ];
 
@@ -199,6 +204,10 @@ export function listCoreScenarios(): string[] {
 
 export function listExtensionScenarios(): string[] {
   return extensionScenariosList.map((scenario) => scenario.name);
+}
+
+export function listBackcompatScenarios(): string[] {
+  return backcompatScenariosList.map((scenario) => scenario.name);
 }
 
 export { listMetadataScenarios };


### PR DESCRIPTION
Move `auth/2025-03-26-oauth-metadata-backcompat` and `auth/2025-03-26-oauth-endpoint-fallback` out of the required `authScenariosList` into a new `backcompatScenariosList` category.

These test backward compatibility with the old 2025-03-26 auth spec (no PRM, OAuth metadata at server root) which is not part of the current spec requirements.

## Changes

- New `backcompatScenariosList` in `src/scenarios/client/auth/index.ts`
- New `backcompat` client suite available via `--suite backcompat`
- Back-compat scenarios removed from `core` and `auth` suites
- Back-compat scenarios still included in `all` suite
- Separate test describe block for back-compat scenarios

Closes #126