### PR TITLE
feat: add token refresh and rotation conformance scenarios

### DIFF
--- a/src/scenarios/client/auth/helpers/mockTokenVerifier.ts
+++ b/src/scenarios/client/auth/helpers/mockTokenVerifier.ts
@@ -4,23 +4,71 @@ import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.
 import type { ConformanceCheck } from '../../../../types';
 import { SpecReferences } from '../spec-references';
 
+interface TokenEntry {
+  scopes: string[];
+  /** Unix timestamp (seconds) when the token was issued. */
+  issuedAt: number;
+  /** Token lifetime in seconds. */
+  expiresIn: number;
+}
+
 export class MockTokenVerifier implements OAuthTokenVerifier {
-  private tokenScopes: Map<string, string[]> = new Map();
+  private tokenEntries: Map<string, TokenEntry> = new Map();
+
+  /**
+   * Default token lifetime for registerToken calls that don't specify one.
+   * Set to a small value for token refresh lifecycle tests.
+   */
+  public defaultExpiresIn = 3600;
 
   constructor(
     private checks: ConformanceCheck[],
     private expectedScopes: string[] = []
   ) {}
 
-  registerToken(token: string, scopes: string[]) {
-    this.tokenScopes.set(token, scopes);
+  registerToken(token: string, scopes: string[], expiresIn?: number) {
+    this.tokenEntries.set(token, {
+      scopes,
+      issuedAt: Math.floor(Date.now() / 1000),
+      expiresIn: expiresIn ?? this.defaultExpiresIn,
+    });
+  }
+
+  /** Legacy getter for code that reads token scopes directly. */
+  get tokenScopes(): Map<string, string[]> {
+    const result = new Map<string, string[]>();
+    for (const [token, entry] of this.tokenEntries) {
+      result.set(token, entry.scopes);
+    }
+    return result;
   }
 
   async verifyAccessToken(token: string): Promise<AuthInfo> {
     // Accept tokens that start with known prefixes
     if (token.startsWith('test-token') || token.startsWith('cc-token')) {
-      // Get scopes for this token, or use empty array
-      const scopes = this.tokenScopes.get(token) || [];
+      const entry = this.tokenEntries.get(token);
+      const scopes = entry?.scopes || [];
+
+      // Check expiration if entry exists with a finite lifetime
+      if (entry) {
+        const now = Math.floor(Date.now() / 1000);
+        const expiresAt = entry.issuedAt + entry.expiresIn;
+        if (now > expiresAt) {
+          this.checks.push({
+            id: 'expired-bearer-token',
+            name: 'ExpiredBearerToken',
+            description: 'Client presented an expired access token',
+            status: 'INFO',
+            timestamp: new Date().toISOString(),
+            specReferences: [SpecReferences.MCP_ACCESS_TOKEN_USAGE],
+            details: {
+              token: token.substring(0, 15) + '...',
+              expiredSecondsAgo: now - expiresAt,
+            }
+          });
+          throw new InvalidTokenError('Token expired');
+        }
+      }
 
       this.checks.push({
         id: 'valid-bearer-token',
@@ -34,11 +82,16 @@ export class MockTokenVerifier implements OAuthTokenVerifier {
           scopes
         }
       });
+
+      const expiresAt = entry
+        ? entry.issuedAt + entry.expiresIn
+        : Math.floor(Date.now() / 1000) + 3600;
+
       return {
         token,
         clientId: 'test-client',
         scopes,
-        expiresAt: Math.floor(Date.now() / 1000) + 3600
+        expiresAt,
       };
     }
 

--- a/src/scenarios/client/auth/helpers/mockTokenVerifier.ts
+++ b/src/scenarios/client/auth/helpers/mockTokenVerifier.ts
@@ -1,5 +1,6 @@
 import { OAuthTokenVerifier } from '@modelcontextprotocol/sdk/server/auth/provider.js';
 import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import { InvalidTokenError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import type { ConformanceCheck } from '../../../../types';
 import { SpecReferences } from '../spec-references';
 
@@ -53,6 +54,6 @@ export class MockTokenVerifier implements OAuthTokenVerifier {
         token: token ? token.substring(0, 10) + '...' : 'missing'
       }
     });
-    throw new Error('Invalid token');
+    throw new InvalidTokenError('Invalid token');
   }
 }

--- a/src/scenarios/client/auth/index.ts
+++ b/src/scenarios/client/auth/index.ts
@@ -23,6 +23,10 @@ import {
 } from './client-credentials';
 import { ResourceMismatchScenario } from './resource-mismatch';
 import { PreRegistrationScenario } from './pre-registration';
+import {
+  TokenRefreshBasicScenario,
+  TokenRefreshRotationScenario
+} from './token-refresh';
 
 // Auth scenarios (required for tier 1)
 export const authScenariosList: Scenario[] = [
@@ -37,7 +41,9 @@ export const authScenariosList: Scenario[] = [
   new ClientSecretPostAuthScenario(),
   new PublicClientAuthScenario(),
   new ResourceMismatchScenario(),
-  new PreRegistrationScenario()
+  new PreRegistrationScenario(),
+  new TokenRefreshBasicScenario(),
+  new TokenRefreshRotationScenario()
 ];
 
 // Back-compat scenarios (optional - backward compatibility with older spec versions)

--- a/src/scenarios/client/auth/spec-references.ts
+++ b/src/scenarios/client/auth/spec-references.ts
@@ -88,5 +88,13 @@ export const SpecReferences: { [key: string]: SpecReference } = {
   MCP_PKCE: {
     id: 'MCP-PKCE-requirement',
     url: 'https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#authorization-code-protection'
+  },
+  OAUTH_2_1_REFRESH_TOKEN: {
+    id: 'OAUTH-2.1-refresh-token',
+    url: 'https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-13.html#section-6'
+  },
+  OAUTH_2_1_TOKEN_ROTATION: {
+    id: 'OAUTH-2.1-token-rotation',
+    url: 'https://www.ietf.org/archive/id/draft-ietf-oauth-v2-1-13.html#section-6.1'
   }
 };

--- a/src/scenarios/client/auth/token-refresh.ts
+++ b/src/scenarios/client/auth/token-refresh.ts
@@ -1,0 +1,275 @@
+import type { Scenario, ConformanceCheck } from '../../../types';
+import { ScenarioUrls } from '../../../types';
+import { createAuthServer } from './helpers/createAuthServer';
+import { createServer } from './helpers/createServer';
+import { ServerLifecycle } from './helpers/serverLifecycle';
+import { SpecReferences } from './spec-references';
+import { MockTokenVerifier } from './helpers/mockTokenVerifier';
+
+/**
+ * Scenario: Token Refresh Basic
+ *
+ * Tests that clients correctly use the refresh_token grant to obtain a new
+ * access token when the current one expires.
+ *
+ * Flow:
+ *   1. Client authenticates via authorization_code grant
+ *   2. Server issues access_token (short-lived, 2s) + refresh_token
+ *   3. Client makes a successful MCP request (tools/list)
+ *   4. Access token expires
+ *   5. Client's next request gets 401
+ *   6. Client MUST send grant_type=refresh_token to the token endpoint
+ *   7. Client MUST use the new access_token for subsequent requests
+ *
+ * Spec references:
+ *   - OAuth 2.1 §6: Refreshing an Access Token
+ *   - OAuth 2.1 §4.3.1: Token rotation for public clients
+ */
+export class TokenRefreshBasicScenario implements Scenario {
+  name = 'auth/token-refresh-basic';
+  description =
+    'Tests that client uses refresh_token grant to obtain new access token when current one expires (OAuth 2.1 §6)';
+  private authServer = new ServerLifecycle();
+  private server = new ServerLifecycle();
+  private checks: ConformanceCheck[] = [];
+
+  async start(): Promise<ScenarioUrls> {
+    this.checks = [];
+
+    const tokenVerifier = new MockTokenVerifier(this.checks, []);
+    // Short-lived tokens — 2 seconds
+    tokenVerifier.defaultExpiresIn = 2;
+
+    let refreshGrantCount = 0;
+    let refreshedAccessTokenUsed = false;
+
+    const authApp = createAuthServer(this.checks, this.authServer.getUrl, {
+      tokenVerifier,
+      accessTokenExpiresIn: 2,
+      issueRefreshToken: true,
+      rotateRefreshTokens: false,
+      onRefreshTokenRequest: (data) => {
+        refreshGrantCount++;
+        this.checks.push({
+          id: 'refresh-token-grant-used',
+          name: 'Client used refresh_token grant',
+          description:
+            'Client correctly used grant_type=refresh_token to obtain new access token after expiry',
+          status: 'SUCCESS',
+          timestamp: data.timestamp,
+          specReferences: [SpecReferences.OAUTH_2_1_REFRESH_TOKEN],
+          details: {
+            refreshAttempt: refreshGrantCount,
+            refreshTokenPrefix: data.refreshToken.substring(0, 20) + '...',
+          }
+        });
+      },
+    });
+
+    await this.authServer.start(authApp);
+
+    const app = createServer(
+      this.checks,
+      this.server.getUrl,
+      this.authServer.getUrl,
+      {
+        prmPath: '/.well-known/oauth-protected-resource/mcp',
+        requiredScopes: [],
+        tokenVerifier,
+        perRequestServer: true,
+      }
+    );
+
+    await this.server.start(app);
+
+    return { serverUrl: `${this.server.getUrl()}/mcp` };
+  }
+
+  async stop() {
+    await this.authServer.stop();
+    await this.server.stop();
+  }
+
+  getChecks(): ConformanceCheck[] {
+    // Check if the client ever used the refresh_token grant
+    const hasRefreshCheck = this.checks.some(
+      (c) => c.id === 'refresh-token-grant-used'
+    );
+    const hasRefreshGrant = this.checks.some(
+      (c) => c.id === 'refresh-token-grant-received'
+    );
+
+    if (!hasRefreshGrant && !hasRefreshCheck) {
+      this.checks.push({
+        id: 'refresh-token-grant-used',
+        name: 'Client used refresh_token grant',
+        description:
+          'Client did not use grant_type=refresh_token after access token expired. ' +
+          'Clients MUST use refresh tokens when available (OAuth 2.1 §6).',
+        status: 'FAILURE',
+        timestamp: new Date().toISOString(),
+        specReferences: [SpecReferences.OAUTH_2_1_REFRESH_TOKEN],
+      });
+    }
+
+    // Check if the client successfully used a refreshed token
+    const validTokenChecks = this.checks.filter(
+      (c) => c.id === 'valid-bearer-token'
+    );
+    const expiredTokenChecks = this.checks.filter(
+      (c) => c.id === 'expired-bearer-token'
+    );
+
+    if (validTokenChecks.length >= 2 && hasRefreshCheck) {
+      this.checks.push({
+        id: 'refreshed-token-used-successfully',
+        name: 'Refreshed access token used successfully',
+        description:
+          'Client obtained a new access token via refresh and used it for a subsequent MCP request',
+        status: 'SUCCESS',
+        timestamp: new Date().toISOString(),
+        specReferences: [SpecReferences.OAUTH_2_1_REFRESH_TOKEN],
+        details: {
+          totalValidTokenUses: validTokenChecks.length,
+          totalExpiredTokenRejections: expiredTokenChecks.length,
+        }
+      });
+    }
+
+    return this.checks;
+  }
+}
+
+/**
+ * Scenario: Token Refresh with Rotation
+ *
+ * Tests that clients store rotated refresh tokens when the server issues
+ * a new refresh_token in the token response (OAuth 2.1 §4.3.1).
+ *
+ * Flow:
+ *   1-6. Same as TokenRefreshBasic
+ *   7. Server returns a NEW refresh_token alongside the new access_token
+ *   8. Client MUST store the new refresh_token
+ *   9. When the new access_token expires, client uses the NEW refresh_token
+ *
+ * If the client reuses the OLD refresh_token, the server rejects it.
+ */
+export class TokenRefreshRotationScenario implements Scenario {
+  name = 'auth/token-refresh-rotation';
+  description =
+    'Tests that client stores rotated refresh tokens per OAuth 2.1 §4.3.1';
+  private authServer = new ServerLifecycle();
+  private server = new ServerLifecycle();
+  private checks: ConformanceCheck[] = [];
+
+  async start(): Promise<ScenarioUrls> {
+    this.checks = [];
+
+    const tokenVerifier = new MockTokenVerifier(this.checks, []);
+    tokenVerifier.defaultExpiresIn = 2;
+
+    let refreshGrantCount = 0;
+
+    const authApp = createAuthServer(this.checks, this.authServer.getUrl, {
+      tokenVerifier,
+      accessTokenExpiresIn: 2,
+      issueRefreshToken: true,
+      rotateRefreshTokens: true,
+      onRefreshTokenRequest: (data) => {
+        refreshGrantCount++;
+        this.checks.push({
+          id: `refresh-rotation-attempt-${refreshGrantCount}`,
+          name: `Refresh attempt ${refreshGrantCount} (with rotation)`,
+          description:
+            `Client sent refresh_token grant (attempt ${refreshGrantCount}). ` +
+            'Server will rotate the refresh token.',
+          status: 'SUCCESS',
+          timestamp: data.timestamp,
+          specReferences: [
+            SpecReferences.OAUTH_2_1_REFRESH_TOKEN,
+            SpecReferences.OAUTH_2_1_TOKEN_ROTATION,
+          ],
+          details: {
+            refreshTokenPrefix: data.refreshToken.substring(0, 20) + '...',
+            attemptNumber: refreshGrantCount,
+          }
+        });
+      },
+    });
+
+    await this.authServer.start(authApp);
+
+    const app = createServer(
+      this.checks,
+      this.server.getUrl,
+      this.authServer.getUrl,
+      {
+        prmPath: '/.well-known/oauth-protected-resource/mcp',
+        requiredScopes: [],
+        tokenVerifier,
+        perRequestServer: true,
+      }
+    );
+
+    await this.server.start(app);
+
+    return { serverUrl: `${this.server.getUrl()}/mcp` };
+  }
+
+  async stop() {
+    await this.authServer.stop();
+    await this.server.stop();
+  }
+
+  getChecks(): ConformanceCheck[] {
+    const rotationAttempts = this.checks.filter(
+      (c) => c.id.startsWith('refresh-rotation-attempt-')
+    );
+    const invalidRefreshChecks = this.checks.filter(
+      (c) => c.id === 'refresh-token-invalid'
+    );
+
+    if (rotationAttempts.length === 0) {
+      this.checks.push({
+        id: 'refresh-rotation-result',
+        name: 'Token rotation test result',
+        description:
+          'Client did not attempt to use refresh_token grant. ' +
+          'Cannot test token rotation without refresh flow.',
+        status: 'FAILURE',
+        timestamp: new Date().toISOString(),
+        specReferences: [SpecReferences.OAUTH_2_1_TOKEN_ROTATION],
+      });
+    } else if (invalidRefreshChecks.length > 0) {
+      this.checks.push({
+        id: 'refresh-rotation-result',
+        name: 'Token rotation test result',
+        description:
+          'Client reused an old refresh token after rotation. ' +
+          'Clients MUST store the new refresh_token when the server rotates it.',
+        status: 'FAILURE',
+        timestamp: new Date().toISOString(),
+        specReferences: [SpecReferences.OAUTH_2_1_TOKEN_ROTATION],
+        details: {
+          totalRefreshAttempts: rotationAttempts.length,
+          invalidRefreshTokenUses: invalidRefreshChecks.length,
+        }
+      });
+    } else if (rotationAttempts.length >= 1) {
+      this.checks.push({
+        id: 'refresh-rotation-result',
+        name: 'Token rotation test result',
+        description:
+          'Client correctly stored and used rotated refresh token',
+        status: 'SUCCESS',
+        timestamp: new Date().toISOString(),
+        specReferences: [SpecReferences.OAUTH_2_1_TOKEN_ROTATION],
+        details: {
+          totalRefreshAttempts: rotationAttempts.length,
+        }
+      });
+    }
+
+    return this.checks;
+  }
+}


### PR DESCRIPTION
## Summary

Adds two new client auth conformance scenarios that test OAuth 2.1 refresh token behavior:

- **`auth/token-refresh-basic`** — Tests that clients use the `refresh_token` grant to obtain a new access token when the current one expires (OAuth 2.1 §6). Server issues 2-second TTL access tokens + refresh token; client must detect 401, send `grant_type=refresh_token`, and use the new access token successfully.

- **`auth/token-refresh-rotation`** — Same flow but the server rotates the refresh token on each use (OAuth 2.1 §6.1). Client must store the new refresh token and not reuse the old one.

## Motivation

Multiple MCP client implementations have been reported as not handling token refresh reliably — leading to auth loops, death spirals, and excessive retry RPM when access tokens expire. These scenarios provide a concrete conformance check against the OAuth 2.1 refresh token spec.

## Changes

| File | Change |
|---|---|
| `token-refresh.ts` | New file: `TokenRefreshBasicScenario` and `TokenRefreshRotationScenario` |
| `createAuthServer.ts` | `issueRefreshToken`, `rotateRefreshTokens`, `accessTokenExpiresIn`, `onRefreshTokenRequest` options; full `grant_type=refresh_token` handler |
| `createServer.ts` | `perRequestServer` option (fresh MCP Server per request, needed because `server.close()` on response end breaks subsequent requests across token boundaries) |
| `mockTokenVerifier.ts` | Token expiration tracking (`issuedAt`, `expiresIn` per token); expired tokens throw `InvalidTokenError` with INFO conformance check |
| `spec-references.ts` | `OAUTH_2_1_REFRESH_TOKEN` (§6) and `OAUTH_2_1_TOKEN_ROTATION` (§6.1) |
| `index.ts` | Register both new scenarios |
| `everything-client.ts` | `runTokenRefreshClient` exercising the full refresh flow |

## Test plan

- [x] All 79 tests pass (77 existing + 2 new token refresh scenarios)
- [x] `auth/token-refresh-basic` passes in ~3s (2s token TTL + 1s buffer)
- [x] `auth/token-refresh-rotation` passes in ~3s
- [x] `tsc --noEmit` clean

## Dependencies

Depends on #138 (`InvalidTokenError` fix) — without it, expired tokens return 500 instead of 401 and the refresh flow never triggers.


Made with [Cursor](https://cursor.com)