### PR TITLE
fix: tier-check branch support and draft/extension scoring

### DIFF
--- a/.claude/skills/mcp-sdk-tier-audit/SKILL.md
+++ b/.claude/skills/mcp-sdk-tier-audit/SKILL.md
@@ -117,8 +117,8 @@ Combine the deterministic scorecard (from the CLI) with the evaluation results (
 
 ### Tier 1 requires ALL of:
 
-- Server conformance test pass rate == 100%
-- Client conformance test pass rate == 100%
+- Server conformance test pass rate == 100% (date-versioned scenarios only; `draft` and `extension` are informational and not scored)
+- Client conformance test pass rate == 100% (date-versioned scenarios only; `draft` and `extension` are informational and not scored)
 - Issue triage compliance >= 90% within 2 business days
 - All P0 bugs resolved within 7 days
 - Stable release >= 1.0.0 with no pre-release suffix
@@ -129,8 +129,8 @@ Combine the deterministic scorecard (from the CLI) with the evaluation results (
 
 ### Tier 2 requires ALL of:
 
-- Server conformance test pass rate >= 80%
-- Client conformance test pass rate >= 80%
+- Server conformance test pass rate >= 80% (date-versioned scenarios only)
+- Client conformance test pass rate >= 80% (date-versioned scenarios only)
 - Issue triage compliance >= 80% within 1 month
 - P0 bugs resolved within 2 weeks
 - At least one stable release >= 1.0.0
@@ -153,11 +153,19 @@ The **full suite** pass rates (server total, client total) are used for tier thr
 
 Example:
 
-|              | 2025-03-26 | 2025-06-18 | 2025-11-25 | draft | extension | All\*        |
-| ------------ | ---------- | ---------- | ---------- | ----- | --------- | ------------ |
-| Server       | —          | 26/26      | 4/4        | —     | —         | 30/30 (100%) |
-| Client: Core | —          | 2/2        | 2/2        | —     | —         | 4/4 (100%)   |
-| Client: Auth | 0/2        | 3/3        | 6/11       | 0/1   | 0/2       | 9/19 (47%)   |
+|              | 2025-03-26 | 2025-06-18 | 2025-11-25 | All\*        |
+| ------------ | ---------- | ---------- | ---------- | ------------ |
+| Server       | —          | 26/26      | 4/4        | 30/30 (100%) |
+| Client: Core | —          | 2/2        | 2/2        | 4/4 (100%)   |
+| Client: Auth | 2/2        | 3/3        | 6/11       | 8/16 (50%)   |
+
+Informational (not scored for tier):
+
+|              | draft | extension |
+| ------------ | ----- | --------- |
+| Client: Auth | 0/1   | 0/2       |
+
+The tier-scoring table only includes date-versioned scenarios. `draft` and `extension` scenarios are shown separately as informational — they do not affect tier advancement.
 
 This immediately shows where failures concentrate. Failures clustered in Client: Auth / `2025-11-25` means "new auth features not yet implemented" — a scope gap, not a quality problem. Failures in Server or Client: Core are more concerning.
 
@@ -207,14 +215,20 @@ After the subagents finish, output a short executive summary directly to the use
 
 Conformance:
 
-|              | 2025-03-26 | 2025-06-18 | 2025-11-25 | draft | extension | All* | T2 | T1 |
-|--------------|------------|------------|------------|-------|-----------|-------|----|----|
-| Server       | —          | pass/total | pass/total | —     | —         | pass/total (rate%) | ✓/✗ | ✓/✗ |
-| Client: Core | —          | pass/total | pass/total | —     | —         | pass/total (rate%) | — | — |
-| Client: Auth | pass/total | pass/total | pass/total | pass/total | pass/total | pass/total (rate%) | — | — |
-| **Client Total** | | | | | | **pass/total (rate%)** | **✓/✗** | **✓/✗** |
+|              | 2025-03-26 | 2025-06-18 | 2025-11-25 | All* | T2 | T1 |
+|--------------|------------|------------|------------|------|----|----|
+| Server       | —          | pass/total | pass/total | pass/total (rate%) | ✓/✗ | ✓/✗ |
+| Client: Core | —          | pass/total | pass/total | pass/total (rate%) | — | — |
+| Client: Auth | pass/total | pass/total | pass/total | pass/total (rate%) | — | — |
+| **Client Total** | | | | **pass/total (rate%)** | **✓/✗** | **✓/✗** |
 
 \* unique scenarios — a scenario may apply to multiple spec versions
+
+Informational (not scored for tier):
+
+|              | draft | extension |
+|--------------|-------|-----------|
+| Client: Auth | pass/total | pass/total |
 
 If a baseline file was found, add a note below the conformance table:
 > **Baseline**: {N} failures in `baseline.yml` ({list by cell, e.g. "6 in Client: Auth/2025-11-25, 2 in Client: Auth/extension"}).


### PR DESCRIPTION
Two fixes for the tier-check CLI and tier-audit skill:

## Motivation and Context
1. The tier-audit skill was not forwarding `--branch` to the tier-check CLI, so policy signal checks always ran against the repo's default branch. Files on feature branches showed as "Not found."
2. SEP-1730 says date-versioned scenarios count toward tier scoring while `draft` and `extension` are informational. The CLI was including all scenarios in `pass_rate`, causing extension-only failures to block Tier 1.

How it looks like now with a clear split between dated versions and draft/extension being purely informational:

<img width="830" height="426" alt="CleanShot 2026-02-17 at 12 48 45" src="https://github.com/user-attachments/assets/b1300a36-9d4c-4e04-aa4a-85821973c94c" />

## How Has This Been Tested?
Ran tier-check against `modelcontextprotocol/typescript-sdk` with `--branch fweinberger/v1x-governance-docs` and verified:
- Policy signals correctly detect files on the feature branch
- Extension scenario failure appears only in informational section, not in tier-scoring `All*` column
- Server and client conformance both show 100% for date-versioned scenarios

## Breaking Changes
None — the CLI output format changes but the JSON structure is unchanged.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed