### PR TITLE
fix: don't leak escalated scopes in PRM for step-up test

### DIFF
--- a/src/scenarios/client/auth/scope-handling.ts
+++ b/src/scenarios/client/auth/scope-handling.ts
@@ -418,7 +418,7 @@ export class ScopeStepUpAuthScenario implements Scenario {
       {
         prmPath: '/.well-known/oauth-protected-resource/mcp',
         requiredScopes: escalatedScopes,
-        scopesSupported: escalatedScopes,
+        scopesSupported: [initialScope],
         includeScopeInWwwAuth: true,
         authMiddleware: stepUpMiddleware,
         tokenVerifier


### PR DESCRIPTION
The scope-step-up scenario sets `scopesSupported: escalatedScopes` in the PRM, which leaks the escalated scope (`mcp:write`) via discovery. This lets clients pass the test by just re-authenticating and picking up `scopes_supported` from the PRM — without actually handling the 403 `insufficient_scope` response.

Fix: set `scopesSupported: [initialScope]` so only `mcp:basic` is advertised in the PRM. The escalated scope (`mcp:basic mcp:write`) is only available from the 403 WWW-Authenticate header on `tools/call`.