### PR TITLE
chore: update Node.js version in the conformance action to 22

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -28,9 +28,9 @@ inputs:
     required: false
     default: 'false'
   node-version:
-    description: 'Node.js version to use (default: 20)'
+    description: 'Node.js version to use (default: 22)'
     required: false
-    default: '20'
+    default: '22'
 runs:
   using: 'composite'
   steps:


### PR DESCRIPTION


<!-- Provide a brief summary of your changes -->

## Motivation and Context
With Node.js 20 the action fails with:

```
SyntaxError: The requested module 'fs' does not provide an export named 'globSync'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:213:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:320:5)
    at async ModuleLoader.import (node:internal/modules/esm/loader:606:24)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:117:5)
```

`fs.globSync` was added in Node.js 22.

## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Successful conformance runs with this parameter overridden to `22` in https://github.com/modelcontextprotocol/go-sdk/pull/814.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->
I believe none.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
