### PR TITLE
fix: tools-call-simple-text now fails when tool returns isError: true

### DIFF
--- a/src/scenarios/server/tools.ts
+++ b/src/scenarios/server/tools.ts
@@ -127,6 +127,8 @@ Implement tool \`test_simple_text\` with no arguments that returns:
 
       // Validate response
       const errors: string[] = [];
+      if ((result as any).isError === true)
+        errors.push('Tool returned an error instead of content');
       const content = (result as any).content;
       if (!content) errors.push('Missing content array');
       if (!Array.isArray(content)) errors.push('content is not an array');

--- a/src/scenarios/server/tools.ts
+++ b/src/scenarios/server/tools.ts
@@ -121,8 +121,14 @@ Implement tool \`test_simple_text\` with no arguments that returns:
       const connection = await connectToServer(serverUrl);
 
       const result = await connection.client.callTool({
-        name: 'test_simple_text'
-        /* omit arguments as it is not required in the schema */
+        name: 'test_simple_text',
+        // Per MCP spec, `arguments` is optional when the tool's inputSchema
+        // has no required fields. But the typescript-sdk server (<= 1.29.x)
+        // rejects undefined `arguments` against any inputSchema, returning
+        // isError: true. Fix merged into main (PR #1404) but not backported
+        // to the 1.x line — see modelcontextprotocol/typescript-sdk#1869.
+        // Passing `{}` explicitly until the fix is released.
+        arguments: {}
       });
 
       // Validate response


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->
Added an `isError` check to `ToolsCallSimpleTextScenario`, so the test `tools-call-simple-text` correctly fails when the tool returns an error result instead of a successful text response.

## Motivation and Context
The test `tools-call-simple-text` was passing for servers that don't implement `test_simple_text` at all.
When an unknown tool is called, MCP frameworks return `{ isError: true, content: [{ type: "text", text: "Tool not found: ..." }] }`. The existing assertions only checked for a non-empty text content item, which the "Tool not found" error message satisfies. The missing assertion was that `result.isError` must not be true.

## How Has This Been Tested?
Verified against the existing everything-server reference implementation, which correctly implements `test_simple_text` and continues to pass. Confirmed that servers without `test_simple_text` now correctly fail the test.

## Breaking Changes
Servers that were previously passing `tools-call-simple-text` without implementing `test_simple_text` will now correctly fail.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
