### PR TITLE
feat: add conformance scenario for SEP-2164 resource-not-found error code

### DIFF
--- a/src/scenarios/index.ts
+++ b/src/scenarios/index.ts
@@ -40,7 +40,8 @@ import {
   ResourcesReadBinaryScenario,
   ResourcesTemplateReadScenario,
   ResourcesSubscribeScenario,
-  ResourcesUnsubscribeScenario
+  ResourcesUnsubscribeScenario,
+  ResourcesNotFoundErrorScenario
 } from './server/resources';
 
 import {
@@ -116,6 +117,9 @@ const allClientScenariosList: ClientScenario[] = [
   new ResourcesTemplateReadScenario(),
   new ResourcesSubscribeScenario(),
   new ResourcesUnsubscribeScenario(),
+
+  // Resources error handling (SEP-2164)
+  new ResourcesNotFoundErrorScenario(),
 
   // Prompts scenarios
   new PromptsListScenario(),

--- a/src/scenarios/server/resources.ts
+++ b/src/scenarios/server/resources.ts
@@ -6,7 +6,8 @@ import { ClientScenario, ConformanceCheck, SpecVersion } from '../../types';
 import { connectToServer } from './client-helper';
 import {
   TextResourceContents,
-  BlobResourceContents
+  BlobResourceContents,
+  McpError
 } from '@modelcontextprotocol/sdk/types.js';
 
 export class ResourcesListScenario implements ClientScenario {
@@ -431,6 +432,150 @@ Example request:
       });
     }
 
+    return checks;
+  }
+}
+
+export class ResourcesNotFoundErrorScenario implements ClientScenario {
+  name = 'sep-2164-resource-not-found';
+  specVersions: SpecVersion[] = ['draft'];
+  description = `Test error handling for non-existent resources (SEP-2164).
+
+**Server Implementation Requirements:**
+
+**Endpoint**: \`resources/read\`
+
+When a client requests a URI that does not correspond to any resource, the server:
+
+- **MUST** return a JSON-RPC error with code \`-32602\` (Invalid Params)
+- **MUST NOT** return a result with an empty \`contents\` array
+- **SHOULD** include the requested \`uri\` in the error \`data\` field
+
+Example error response:
+
+\`\`\`json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "error": {
+    "code": -32602,
+    "message": "Resource not found",
+    "data": {
+      "uri": "test://nonexistent-resource-for-conformance-testing"
+    }
+  }
+}
+\`\`\`
+
+This scenario does not require the server to register any specific resource — it tests behavior when reading a URI the server does not recognize.`;
+
+  async run(serverUrl: string): Promise<ConformanceCheck[]> {
+    const checks: ConformanceCheck[] = [];
+    const nonexistentUri =
+      'test://nonexistent-resource-for-conformance-testing';
+    const specReferences = [
+      {
+        id: 'SEP-2164',
+        url: 'https://modelcontextprotocol.io/specification/draft/server/resources#error-handling'
+      }
+    ];
+
+    let connection;
+    try {
+      connection = await connectToServer(serverUrl);
+    } catch (error) {
+      checks.push({
+        id: 'sep-2164-error-code',
+        name: 'ResourcesNotFoundErrorCode',
+        description:
+          'Server returns -32602 (Invalid Params) for non-existent resource',
+        status: 'FAILURE',
+        timestamp: new Date().toISOString(),
+        errorMessage: `Failed to connect: ${error instanceof Error ? error.message : String(error)}`,
+        specReferences
+      });
+      return checks;
+    }
+
+    let caughtError: unknown;
+    let result: { contents: unknown[] } | undefined;
+    try {
+      result = await connection.client.readResource({ uri: nonexistentUri });
+    } catch (error) {
+      caughtError = error;
+    }
+
+    // Check 1: MUST return -32602 error code (not empty contents, not other codes)
+    const errorCode =
+      caughtError instanceof McpError ? caughtError.code : undefined;
+    const errorCodeErrors: string[] = [];
+    if (result !== undefined) {
+      errorCodeErrors.push(
+        `Server returned a result instead of an error (contents length: ${result.contents?.length ?? 'undefined'}). Servers MUST NOT return an empty contents array for non-existent resources.`
+      );
+    } else if (!(caughtError instanceof McpError)) {
+      errorCodeErrors.push(
+        `Expected a JSON-RPC error, got: ${caughtError instanceof Error ? caughtError.message : String(caughtError)}`
+      );
+    } else if (errorCode !== -32602) {
+      errorCodeErrors.push(
+        `Expected error code -32602 (Invalid Params), got ${errorCode}. ` +
+          (errorCode === -32002
+            ? 'Code -32002 was used in earlier spec versions but SEP-2164 standardizes on -32602.'
+            : '')
+      );
+    }
+
+    checks.push({
+      id: 'sep-2164-error-code',
+      name: 'ResourcesNotFoundErrorCode',
+      description:
+        'Server returns -32602 (Invalid Params) for non-existent resource',
+      status: errorCodeErrors.length === 0 ? 'SUCCESS' : 'FAILURE',
+      timestamp: new Date().toISOString(),
+      errorMessage:
+        errorCodeErrors.length > 0 ? errorCodeErrors.join('; ') : undefined,
+      specReferences,
+      details: {
+        requestedUri: nonexistentUri,
+        receivedErrorCode: errorCode,
+        receivedResult: result !== undefined
+      }
+    });
+
+    // Check 2: SHOULD include uri in error data field
+    const errorData =
+      caughtError instanceof McpError
+        ? (caughtError.data as { uri?: string } | undefined)
+        : undefined;
+    const dataUriMatches = errorData?.uri === nonexistentUri;
+
+    checks.push({
+      id: 'sep-2164-data-uri',
+      name: 'ResourcesNotFoundDataUri',
+      description:
+        'Server includes the requested URI in the error data field (SHOULD)',
+      status:
+        caughtError instanceof McpError
+          ? dataUriMatches
+            ? 'SUCCESS'
+            : 'WARNING'
+          : 'FAILURE',
+      timestamp: new Date().toISOString(),
+      errorMessage:
+        caughtError instanceof McpError
+          ? dataUriMatches
+            ? undefined
+            : `Error data.uri is ${JSON.stringify(errorData?.uri)}, expected "${nonexistentUri}". This is a SHOULD requirement.`
+          : 'No JSON-RPC error received; cannot evaluate data field.',
+      specReferences,
+      details: {
+        requestedUri: nonexistentUri,
+        receivedDataUri: errorData?.uri
+      }
+    });
+
+    await connection.close();
     return checks;
   }
 }

--- a/src/scenarios/server/resources.ts
+++ b/src/scenarios/server/resources.ts
@@ -447,8 +447,8 @@ export class ResourcesNotFoundErrorScenario implements ClientScenario {
 
 When a client requests a URI that does not correspond to any resource, the server:
 
-- **MUST** return a JSON-RPC error with code \`-32602\` (Invalid Params)
 - **MUST NOT** return a result with an empty \`contents\` array
+- **SHOULD** return a JSON-RPC error with code \`-32602\` (Invalid Params)
 - **SHOULD** include the requested \`uri\` in the error \`data\` field
 
 Example error response:
@@ -505,36 +505,51 @@ This scenario does not require the server to register any specific resource — 
       caughtError = error;
     }
 
-    // Check 1: MUST return -32602 error code (not empty contents, not other codes)
+    // Check 1: MUST NOT return an empty contents array
+    const returnedEmptyContents =
+      result !== undefined && (result.contents?.length ?? 0) === 0;
+    checks.push({
+      id: 'sep-2164-no-empty-contents',
+      name: 'ResourcesNotFoundNoEmptyContents',
+      description:
+        'Server does not return an empty contents array for a non-existent resource',
+      status: returnedEmptyContents ? 'FAILURE' : 'SUCCESS',
+      timestamp: new Date().toISOString(),
+      errorMessage: returnedEmptyContents
+        ? 'Server returned a result with an empty contents array. Servers MUST NOT return an empty contents array for non-existent resources.'
+        : undefined,
+      specReferences,
+      details: {
+        requestedUri: nonexistentUri,
+        receivedResult: result !== undefined,
+        contentsLength: result?.contents?.length
+      }
+    });
+
+    // Check 2: SHOULD return JSON-RPC error with code -32602
     const errorCode =
       caughtError instanceof McpError ? caughtError.code : undefined;
-    const errorCodeErrors: string[] = [];
+    let errorCodeMessage: string | undefined;
     if (result !== undefined) {
-      errorCodeErrors.push(
-        `Server returned a result instead of an error (contents length: ${result.contents?.length ?? 'undefined'}). Servers MUST NOT return an empty contents array for non-existent resources.`
-      );
+      errorCodeMessage = `Server returned a result instead of an error (contents length: ${result.contents?.length ?? 'undefined'}). Servers SHOULD return a JSON-RPC error for non-existent resources.`;
     } else if (!(caughtError instanceof McpError)) {
-      errorCodeErrors.push(
-        `Expected a JSON-RPC error, got: ${caughtError instanceof Error ? caughtError.message : String(caughtError)}`
-      );
+      errorCodeMessage = `Expected a JSON-RPC error, got: ${caughtError instanceof Error ? caughtError.message : String(caughtError)}`;
     } else if (errorCode !== -32602) {
-      errorCodeErrors.push(
+      errorCodeMessage =
         `Expected error code -32602 (Invalid Params), got ${errorCode}. ` +
-          (errorCode === -32002
-            ? 'Code -32002 was used in earlier spec versions but SEP-2164 standardizes on -32602.'
-            : '')
-      );
+        (errorCode === -32002
+          ? 'Code -32002 was used in earlier spec versions but SEP-2164 standardizes on -32602.'
+          : '');
     }
 
     checks.push({
       id: 'sep-2164-error-code',
       name: 'ResourcesNotFoundErrorCode',
       description:
-        'Server returns -32602 (Invalid Params) for non-existent resource',
-      status: errorCodeErrors.length === 0 ? 'SUCCESS' : 'FAILURE',
+        'Server returns -32602 (Invalid Params) for non-existent resource (SHOULD)',
+      status: errorCodeMessage === undefined ? 'SUCCESS' : 'WARNING',
       timestamp: new Date().toISOString(),
-      errorMessage:
-        errorCodeErrors.length > 0 ? errorCodeErrors.join('; ') : undefined,
+      errorMessage: errorCodeMessage,
       specReferences,
       details: {
         requestedUri: nonexistentUri,
@@ -543,7 +558,7 @@ This scenario does not require the server to register any specific resource — 
       }
     });
 
-    // Check 2: SHOULD include uri in error data field
+    // Check 3: SHOULD include uri in error data field
     const errorData =
       caughtError instanceof McpError
         ? (caughtError.data as { uri?: string } | undefined)

--- a/src/scenarios/server/sep-2164.yaml
+++ b/src/scenarios/server/sep-2164.yaml
@@ -1,0 +1,9 @@
+sep: 2164
+spec_url: https://modelcontextprotocol.io/specification/draft/server/resources#error-handling
+requirements:
+  - text: 'servers MUST return a JSON-RPC error with code -32602 (Invalid Params)'
+    check: sep-2164-error-code
+  - text: 'Servers MUST NOT return an empty contents array for a non-existent resource'
+    check: sep-2164-error-code
+  - text: 'The data field SHOULD include the uri that was not found'
+    check: sep-2164-data-uri

--- a/src/scenarios/server/sep-2164.yaml
+++ b/src/scenarios/server/sep-2164.yaml
@@ -1,9 +1,9 @@
 sep: 2164
 spec_url: https://modelcontextprotocol.io/specification/draft/server/resources#error-handling
 requirements:
-  - text: 'servers MUST return a JSON-RPC error with code -32602 (Invalid Params)'
-    check: sep-2164-error-code
   - text: 'Servers MUST NOT return an empty contents array for a non-existent resource'
+    check: sep-2164-no-empty-contents
+  - text: 'Servers SHOULD return standard JSON-RPC errors for common failure cases: Resource not found: -32602 (Invalid Params)'
     check: sep-2164-error-code
-  - text: 'The data field SHOULD include the uri that was not found'
-    check: sep-2164-data-uri
+  - text: 'clients SHOULD also accept -32002 as a resource not found error'
+    excluded: 'Client-side error handling is implementation-defined; not protocol-observable'


### PR DESCRIPTION
Adds a conformance scenario for [SEP-2164](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2164), which standardizes the resource-not-found error code from `-32002` to `-32602` (Invalid Params).

## What's tested

The scenario `sep-2164-resource-not-found` attempts to read a URI the server does not recognize and verifies the error response:

| Check ID | Requirement | Level | Status on violation |
|---|---|---|---|
| `sep-2164-error-code` | Server returns `-32602` (not `-32002`, not empty contents) | MUST / MUST NOT | FAILURE |
| `sep-2164-data-uri` | Error `data` includes the requested `uri` | SHOULD | WARNING |

The scenario is scoped to `specVersions: ['draft']` only — it does not run against dated spec versions until SEP-2164 is incorporated into a release.

## Traceability

Includes `src/scenarios/server/sep-2164.yaml` mapping each normative requirement to its check, following the format proposed in [SEP-2484](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2484).

## Verification

- Passes against the TypeScript SDK everything-server (returns `-32602`; `data.uri` yields WARNING since the SDK doesn't populate it yet)
- Error message for legacy `-32002` explicitly references SEP-2164 to guide SDK maintainers during migration
- Adversarially verified to correctly FAIL on `-32002`, `-32603`, empty contents, and non-JSON-RPC errors