### PR TITLE
Add stateless server conformance test

### DIFF
--- a/src/scenarios/client/stateless_server.ts
+++ b/src/scenarios/client/stateless_server.ts
@@ -1,0 +1,334 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema
+} from '@modelcontextprotocol/sdk/types.js';
+import type { Scenario, ConformanceCheck, SpecVersion } from '../../types';
+import express, { Request, Response } from 'express';
+import { ScenarioUrls } from '../../types';
+import { createRequestLogger } from '../request-logger';
+
+function createServer(checks: ConformanceCheck[]): express.Application {
+  // Factory: new Server per request (stateless = no shared state)
+  function getServer(): Server {
+    const server = new Server(
+      {
+        name: 'stateless-server',
+        version: '1.0.0'
+      },
+      {
+        capabilities: {
+          tools: {}
+        }
+      }
+    );
+
+    server.setRequestHandler(ListToolsRequestSchema, async () => {
+      return {
+        tools: [
+          {
+            name: 'add_numbers',
+            description: 'Add two numbers together',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                a: {
+                  type: 'number',
+                  description: 'First number'
+                },
+                b: {
+                  type: 'number',
+                  description: 'Second number'
+                }
+              },
+              required: ['a', 'b']
+            }
+          }
+        ]
+      };
+    });
+
+    server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      if (request.params.name === 'add_numbers') {
+        const { a, b } = request.params.arguments as {
+          a: number;
+          b: number;
+        };
+        const result = a + b;
+
+        checks.push({
+          id: 'stateless-tools-call',
+          name: 'StatelessToolsCall',
+          description:
+            'Validates that the client can call a tool on a stateless server',
+          status: 'SUCCESS',
+          timestamp: new Date().toISOString(),
+          specReferences: [
+            {
+              id: 'MCP-Tools',
+              url: 'https://modelcontextprotocol.io/specification/2025-06-18/server/tools#calling-tools'
+            }
+          ],
+          details: {
+            a,
+            b,
+            result
+          }
+        });
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `The sum of ${a} and ${b} is ${result}`
+            }
+          ]
+        };
+      }
+
+      throw new Error(`Unknown tool: ${request.params.name}`);
+    });
+
+    return server;
+  }
+
+  const app = express();
+  app.use(express.json());
+
+  app.use(
+    createRequestLogger(checks, {
+      incomingId: 'incoming-request',
+      outgoingId: 'outgoing-response',
+      mcpRoute: '/mcp'
+    })
+  );
+
+  let isFirstPost = true;
+
+  app.post('/mcp', async (req: Request, res: Response) => {
+    if (!isFirstPost) {
+      const clientSessionHeader = req.headers['mcp-session-id'];
+      if (clientSessionHeader) {
+        checks.push({
+          id: 'stateless-no-session-header-sent',
+          name: 'StatelessNoSessionHeaderSent',
+          description:
+            'Client omits mcp-session-id when server did not provide one',
+          status: 'FAILURE',
+          timestamp: new Date().toISOString(),
+          errorMessage: `Client sent mcp-session-id: ${clientSessionHeader}`,
+          specReferences: [
+            {
+              id: 'MCP-Session',
+              url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management'
+            }
+          ]
+        });
+      } else if (
+        !checks.find((c) => c.id === 'stateless-no-session-header-sent')
+      ) {
+        checks.push({
+          id: 'stateless-no-session-header-sent',
+          name: 'StatelessNoSessionHeaderSent',
+          description:
+            'Client omits mcp-session-id when server did not provide one',
+          status: 'SUCCESS',
+          timestamp: new Date().toISOString(),
+          specReferences: [
+            {
+              id: 'MCP-Session',
+              url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management'
+            }
+          ]
+        });
+      }
+    }
+    isFirstPost = false;
+
+    const server = getServer();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined
+    });
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+    res.on('close', () => {
+      transport.close();
+      server.close();
+    });
+  });
+
+  app.get('/mcp', async (_req: Request, res: Response) => {
+    checks.push({
+      id: 'stateless-get-405',
+      name: 'StatelessGet405',
+      description:
+        'Stateless server returns 405 for GET (no SSE stream without sessions)',
+      status: 'SUCCESS',
+      timestamp: new Date().toISOString(),
+      specReferences: [
+        {
+          id: 'MCP-Session',
+          url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management'
+        }
+      ]
+    });
+
+    res.writeHead(405).end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: {
+          code: -32000,
+          message: 'Method not allowed.'
+        },
+        id: null
+      })
+    );
+  });
+
+  app.delete('/mcp', async (_req: Request, res: Response) => {
+    checks.push({
+      id: 'stateless-delete-405',
+      name: 'StatelessDelete405',
+      description:
+        'Stateless server returns 405 for DELETE (no session to terminate)',
+      status: 'SUCCESS',
+      timestamp: new Date().toISOString(),
+      specReferences: [
+        {
+          id: 'MCP-Session',
+          url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management'
+        }
+      ]
+    });
+
+    res.writeHead(405).end(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        error: {
+          code: -32000,
+          message: 'Method not allowed.'
+        },
+        id: null
+      })
+    );
+  });
+
+  return app;
+}
+
+export class StatelessServerScenario implements Scenario {
+  name = 'stateless_server';
+  specVersions: SpecVersion[] = ['2025-03-26', '2025-06-18', '2025-11-25'];
+  description = 'Tests that clients handle a stateless server (no session ID)';
+  private app: express.Application | null = null;
+  private httpServer: any = null;
+  private checks: ConformanceCheck[] = [];
+
+  async start(): Promise<ScenarioUrls> {
+    this.checks = [];
+    this.app = createServer(this.checks);
+    this.httpServer = this.app.listen(0);
+    const port = this.httpServer.address().port;
+    return { serverUrl: `http://localhost:${port}/mcp` };
+  }
+
+  async stop() {
+    if (this.httpServer) {
+      await new Promise((resolve) => this.httpServer.close(resolve));
+      this.httpServer = null;
+    }
+    this.app = null;
+  }
+
+  getChecks(): ConformanceCheck[] {
+    // Server never sends mcp-session-id with sessionIdGenerator: undefined
+    if (!this.checks.find((c) => c.id === 'stateless-init-no-session')) {
+      this.checks.push({
+        id: 'stateless-init-no-session',
+        name: 'StatelessInitNoSession',
+        description:
+          'Server response contains no mcp-session-id header (stateless)',
+        status: 'SUCCESS',
+        timestamp: new Date().toISOString(),
+        specReferences: [
+          {
+            id: 'MCP-Session',
+            url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management'
+          }
+        ]
+      });
+    }
+
+    if (!this.checks.find((c) => c.id === 'stateless-no-session-header-sent')) {
+      this.checks.push({
+        id: 'stateless-no-session-header-sent',
+        name: 'StatelessNoSessionHeaderSent',
+        description:
+          'Client omits mcp-session-id when server did not provide one',
+        status: 'SUCCESS',
+        timestamp: new Date().toISOString(),
+        specReferences: [
+          {
+            id: 'MCP-Session',
+            url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management'
+          }
+        ]
+      });
+    }
+
+    if (!this.checks.find((c) => c.id === 'stateless-get-405')) {
+      this.checks.push({
+        id: 'stateless-get-405',
+        name: 'StatelessGet405',
+        description:
+          'Stateless server returns 405 for GET (client did not attempt GET)',
+        status: 'SKIPPED',
+        timestamp: new Date().toISOString(),
+        specReferences: [
+          {
+            id: 'MCP-Session',
+            url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management'
+          }
+        ]
+      });
+    }
+
+    if (!this.checks.find((c) => c.id === 'stateless-delete-405')) {
+      this.checks.push({
+        id: 'stateless-delete-405',
+        name: 'StatelessDelete405',
+        description:
+          'Stateless server returns 405 for DELETE (client did not attempt DELETE)',
+        status: 'SKIPPED',
+        timestamp: new Date().toISOString(),
+        specReferences: [
+          {
+            id: 'MCP-Session',
+            url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management'
+          }
+        ]
+      });
+    }
+
+    if (!this.checks.find((c) => c.id === 'stateless-tools-call')) {
+      this.checks.push({
+        id: 'stateless-tools-call',
+        name: 'StatelessToolsCall',
+        description:
+          'Validates that the client can call a tool on a stateless server',
+        status: 'FAILURE',
+        timestamp: new Date().toISOString(),
+        details: { message: 'Tool was not called by client' },
+        specReferences: [
+          {
+            id: 'MCP-Tools',
+            url: 'https://modelcontextprotocol.io/specification/2025-06-18/server/tools#calling-tools'
+          }
+        ]
+      });
+    }
+
+    return this.checks;
+  }
+}

--- a/src/scenarios/index.ts
+++ b/src/scenarios/index.ts
@@ -58,6 +58,10 @@ import {
 
 import { DNSRebindingProtectionScenario } from './server/dns-rebinding';
 
+import { StatelessServerScenario } from './client/stateless_server';
+
+import { StatelessServerCheckScenario } from './server/stateless';
+
 import {
   authScenariosList,
   backcompatScenariosList,
@@ -76,7 +80,10 @@ const pendingClientScenariosList: ClientScenario[] = [
 
   // On hold until server-side SSE improvements are made
   // https://github.com/modelcontextprotocol/typescript-sdk/pull/1129
-  new ServerSSEPollingScenario()
+  new ServerSSEPollingScenario(),
+
+  // Only for stateless servers - not testable against everything-server
+  new StatelessServerCheckScenario()
 ];
 
 // All client scenarios
@@ -114,6 +121,8 @@ const allClientScenariosList: ClientScenario[] = [
 
   // Elicitation scenarios (SEP-1330) - pending
   new ElicitationEnumsScenario(),
+
+  new StatelessServerCheckScenario(),
 
   // Resources scenarios
   new ResourcesListScenario(),
@@ -171,6 +180,7 @@ const scenariosList: Scenario[] = [
   new ToolsCallScenario(),
   new ElicitationClientDefaultsScenario(),
   new SSERetryScenario(),
+  new StatelessServerScenario(),
   ...authScenariosList,
   ...backcompatScenariosList,
   ...draftScenariosList,

--- a/src/scenarios/server/stateless.ts
+++ b/src/scenarios/server/stateless.ts
@@ -1,0 +1,264 @@
+/**
+ * Stateless server test scenario
+ */
+
+import { ClientScenario, ConformanceCheck, SpecVersion } from '../../types';
+import { connectToServer } from './client-helper';
+
+export class StatelessServerCheckScenario implements ClientScenario {
+  name = 'stateless-server';
+  specVersions: SpecVersion[] = ['2025-03-26', '2025-06-18', '2025-11-25'];
+  description = `Test that a stateless server correctly omits session IDs and rejects GET/DELETE.
+
+**Server Implementation Requirements:**
+
+**Transport**: Streamable HTTP with \`sessionIdGenerator: undefined\`
+
+**Requirements**:
+- MUST NOT include \`Mcp-Session-Id\` in any response headers
+- MUST accept POST requests without \`Mcp-Session-Id\` header
+- MUST return 405 for GET requests
+- MUST return 405 for DELETE requests
+- MUST handle tool calls without session state
+
+This test verifies servers that intentionally omit session management.`;
+
+  async run(serverUrl: string): Promise<ConformanceCheck[]> {
+    const checks: ConformanceCheck[] = [];
+
+    // Initialize via raw fetch and verify no session header
+    try {
+      const initResponse = await fetch(serverUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream'
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-06-18',
+            capabilities: {},
+            clientInfo: {
+              name: 'conformance-stateless-test',
+              version: '1.0.0'
+            }
+          },
+          id: 1
+        })
+      });
+
+      const sessionHeader = initResponse.headers.get('mcp-session-id');
+
+      checks.push({
+        id: 'stateless-server-no-session-header',
+        name: 'StatelessServerNoSessionHeader',
+        description:
+          'Stateless server omits Mcp-Session-Id from initialize response',
+        status: sessionHeader ? 'FAILURE' : 'SUCCESS',
+        timestamp: new Date().toISOString(),
+        errorMessage: sessionHeader
+          ? `Server sent Mcp-Session-Id: ${sessionHeader}`
+          : undefined,
+        specReferences: [
+          {
+            id: 'MCP-Session',
+            url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management'
+          }
+        ],
+        details: { serverUrl }
+      });
+    } catch (error) {
+      checks.push({
+        id: 'stateless-server-no-session-header',
+        name: 'StatelessServerNoSessionHeader',
+        description:
+          'Stateless server omits Mcp-Session-Id from initialize response',
+        status: 'FAILURE',
+        timestamp: new Date().toISOString(),
+        errorMessage: `Failed: ${error instanceof Error ? error.message : String(error)}`,
+        specReferences: [
+          {
+            id: 'MCP-Session',
+            url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management'
+          }
+        ]
+      });
+    }
+
+    // Connect via SDK (POST without session header) and call a tool
+    let connection;
+    try {
+      connection = await connectToServer(serverUrl);
+
+      checks.push({
+        id: 'stateless-server-post-without-session',
+        name: 'StatelessServerPostWithoutSession',
+        description: 'Server accepts requests without Mcp-Session-Id header',
+        status: 'SUCCESS',
+        timestamp: new Date().toISOString(),
+        specReferences: [
+          {
+            id: 'MCP-Session',
+            url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management'
+          }
+        ],
+        details: { serverUrl }
+      });
+    } catch (error) {
+      checks.push({
+        id: 'stateless-server-post-without-session',
+        name: 'StatelessServerPostWithoutSession',
+        description: 'Server accepts requests without Mcp-Session-Id header',
+        status: 'FAILURE',
+        timestamp: new Date().toISOString(),
+        errorMessage: `Failed: ${error instanceof Error ? error.message : String(error)}`,
+        specReferences: [
+          {
+            id: 'MCP-Session',
+            url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management'
+          }
+        ]
+      });
+    }
+
+    // GET returns 405
+    try {
+      const getResponse = await fetch(serverUrl, { method: 'GET' });
+
+      checks.push({
+        id: 'stateless-server-get-405',
+        name: 'StatelessServerGet405',
+        description: 'Stateless server returns 405 for GET requests',
+        status: getResponse.status === 405 ? 'SUCCESS' : 'FAILURE',
+        timestamp: new Date().toISOString(),
+        errorMessage:
+          getResponse.status !== 405
+            ? `Expected 405, got ${getResponse.status}`
+            : undefined,
+        specReferences: [
+          {
+            id: 'MCP-Session',
+            url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management'
+          }
+        ],
+        details: { status: getResponse.status }
+      });
+    } catch (error) {
+      checks.push({
+        id: 'stateless-server-get-405',
+        name: 'StatelessServerGet405',
+        description: 'Stateless server returns 405 for GET requests',
+        status: 'FAILURE',
+        timestamp: new Date().toISOString(),
+        errorMessage: `Failed: ${error instanceof Error ? error.message : String(error)}`,
+        specReferences: [
+          {
+            id: 'MCP-Session',
+            url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management'
+          }
+        ]
+      });
+    }
+
+    // DELETE returns 405
+    try {
+      const deleteResponse = await fetch(serverUrl, { method: 'DELETE' });
+
+      checks.push({
+        id: 'stateless-server-delete-405',
+        name: 'StatelessServerDelete405',
+        description: 'Stateless server returns 405 for DELETE requests',
+        status: deleteResponse.status === 405 ? 'SUCCESS' : 'FAILURE',
+        timestamp: new Date().toISOString(),
+        errorMessage:
+          deleteResponse.status !== 405
+            ? `Expected 405, got ${deleteResponse.status}`
+            : undefined,
+        specReferences: [
+          {
+            id: 'MCP-Session',
+            url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management'
+          }
+        ],
+        details: { status: deleteResponse.status }
+      });
+    } catch (error) {
+      checks.push({
+        id: 'stateless-server-delete-405',
+        name: 'StatelessServerDelete405',
+        description: 'Stateless server returns 405 for DELETE requests',
+        status: 'FAILURE',
+        timestamp: new Date().toISOString(),
+        errorMessage: `Failed: ${error instanceof Error ? error.message : String(error)}`,
+        specReferences: [
+          {
+            id: 'MCP-Session',
+            url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#session-management'
+          }
+        ]
+      });
+    }
+
+    // Call a tool via SDK
+    if (connection) {
+      try {
+        const result = await connection.client.callTool({
+          name: 'start-notification-stream',
+          arguments: { interval: 100, count: 1 }
+        });
+
+        checks.push({
+          id: 'stateless-server-tools-call',
+          name: 'StatelessServerToolsCall',
+          description: 'Tool call completes successfully on a stateless server',
+          status: 'SUCCESS',
+          timestamp: new Date().toISOString(),
+          specReferences: [
+            {
+              id: 'MCP-Tools',
+              url: 'https://modelcontextprotocol.io/specification/2025-06-18/server/tools#calling-tools'
+            }
+          ],
+          details: { result }
+        });
+      } catch (error) {
+        checks.push({
+          id: 'stateless-server-tools-call',
+          name: 'StatelessServerToolsCall',
+          description: 'Tool call completes successfully on a stateless server',
+          status: 'FAILURE',
+          timestamp: new Date().toISOString(),
+          errorMessage: `Failed: ${error instanceof Error ? error.message : String(error)}`,
+          specReferences: [
+            {
+              id: 'MCP-Tools',
+              url: 'https://modelcontextprotocol.io/specification/2025-06-18/server/tools#calling-tools'
+            }
+          ]
+        });
+      }
+
+      await connection.close();
+    } else {
+      checks.push({
+        id: 'stateless-server-tools-call',
+        name: 'StatelessServerToolsCall',
+        description: 'Tool call completes successfully on a stateless server',
+        status: 'FAILURE',
+        timestamp: new Date().toISOString(),
+        errorMessage:
+          'Failed: connection failed earlier, could not test tool call',
+        specReferences: [
+          {
+            id: 'MCP-Tools',
+            url: 'https://modelcontextprotocol.io/specification/2025-06-18/server/tools#calling-tools'
+          }
+        ]
+      });
+    }
+
+    return checks;
+  }
+}


### PR DESCRIPTION
## Motivation and Context

The spec allows servers to omit `Mcp-Session-Id` entirely:

> "A server using the Streamable HTTP transport **MAY** assign a session ID at initialization time"
> — [Spec: Session Management](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management)

The word is MAY (RFC 2119). A compliant server can omit the header. This PR adds conformance coverage for that path, testing both directions.

### Client scenario: `stateless_server`

| Check                              | Description                                                                                       |
| ---------------------------------- | ------------------------------------------------------------------------------------------------- |
| `stateless-init-no-session`        | Server responds to initialize with no `Mcp-Session-Id`. Client MUST NOT error.                    |
| `stateless-no-session-header-sent` | Client's subsequent requests MUST NOT include `Mcp-Session-Id` (nothing to echo).                 |
| `stateless-get-405`                | Server returns 405 for GET (no session, no SSE stream). SKIPPED if client never attempts GET.     |
| `stateless-delete-405`             | Server returns 405 for DELETE (no session to terminate). SKIPPED if client never attempts DELETE. |
| `stateless-tools-call`             | Tool call completes without session state.                                                        |

### Server scenario: `stateless-server`

| Check                                   | Description                                                    |
| --------------------------------------- | -------------------------------------------------------------- |
| `stateless-server-no-session-header`    | Initialize response MUST NOT contain `Mcp-Session-Id`.         |
| `stateless-server-post-without-session` | Server accepts tools/list without `Mcp-Session-Id` in request. |
| `stateless-server-get-405`              | Server returns 405 for GET.                                    |
| `stateless-server-delete-405`           | Server returns 405 for DELETE.                                 |
| `stateless-server-tools-call`           | Tool call completes without session state.                     |

## How Has This Been Tested?

### Client scenario - Python SDK (latest main)

SDK clients need a `stateless_server` handler (identical to `tools_call`).
One-line patch for Python SDK `client.py`:

```diff
 @register("tools_call")
+@register("stateless_server")
 async def run_tools_call(server_url: str) -> None:
```

```bash
$ npm start -- client \
    --command "cd ~/oss/python-sdk && uv run --frozen python .github/actions/conformance/client.py" \
    --scenario stateless_server

Checks:
  [stateless-no-session-header-sent] SUCCESS Client omits mcp-session-id when server did not provide one
  [stateless-tools-call            ] SUCCESS Validates that the client can call a tool on a stateless server
  [stateless-init-no-session       ] SUCCESS Server response contains no mcp-session-id header (stateless)
  [stateless-get-405               ] SKIPPED Stateless server returns 405 for GET (client did not attempt GET)
  [stateless-delete-405            ] SKIPPED Stateless server returns 405 for DELETE (client did not attempt DELETE)

Test Results:
Passed: 3/3, 0 failed, 0 warnings
OVERALL: PASSED
```

### Server scenario - TypeScript SDK stateless example

```bash
# Terminal 1: start TS SDK stateless server
$ cd ~/oss/typescript-sdk
$ npx tsx src/examples/server/simpleStatelessStreamableHttp.ts
MCP Stateless Streamable HTTP Server listening on port 3000

# Terminal 2: run conformance test
$ npm start -- server --url http://localhost:3000/mcp --scenario stateless-server

Checks:
  [stateless-server-no-session-header   ] SUCCESS Stateless server omits Mcp-Session-Id from initialize response
  [stateless-server-post-without-session] SUCCESS Server accepts requests without Mcp-Session-Id header
  [stateless-server-get-405             ] SUCCESS Stateless server returns 405 for GET requests
  [stateless-server-delete-405          ] SUCCESS Stateless server returns 405 for DELETE requests
  [stateless-server-tools-call          ] SUCCESS Tool call completes successfully on a stateless server

Test Results:
Passed: 5/5, 0 failed, 0 warnings
```

## Breaking Changes

None.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

**Design decisions:**

- FAILURE not WARNING: the server's choice to be stateless is MAY, but once it omits sessions, clients MUST handle it correctly.
- GET/DELETE 405 checks use SKIPPED when client never attempts them, since clients are not required to issue GET or DELETE.

**SDK prior art:** Every major SDK already handles stateless servers correctly.

| SDK        | Version                                 | init-no-session                     | get-405                             | no-session-header-sent                 |
| ---------- | --------------------------------------- | ----------------------------------- | ----------------------------------- | -------------------------------------- |
| Go         | [v0.47.1][go-tag] (2026-04-08)          | [SendRequest][go-b1]                | [createGETConnection][go-b2]        | [sendHTTP][go-b3]                      |
| TypeScript | [1.10.0][ts-tag] (2025-04-17)           | [send][ts-b1]                       | [\_startOrAuthSse][ts-b2]           | [\_commonHeaders][ts-b3]               |
| Python     | [v1.8.0][py-tag] (2025-05-08)           | [\_maybe_extract_session_id][py-b1] | [terminate_session][py-b2]          | [\_update_headers_with_session][py-b3] |
| Java       | [v0.18.0][java-tag] (2026-02-18)        | [sendMessage][java-b1]              | [reconnect][java-b2]                | [reconnect][java-b3]                   |
| Kotlin     | [0.7.0][kt-tag] (2025-09-11)            | [start][kt-b1]                      | [start][kt-b2]                      | [applyCommonHeaders][kt-b3]            |
| C#         | [v0.2.0-preview.3][cs-tag] (2025-06-03) | [SendHttpRequestAsync][cs-b1]       | [ReceiveUnsolicitedMessages][cs-b2] | [CopyAdditionalHeaders][cs-b3]         |

[go-tag]: https://github.com/mark3labs/mcp-go/releases/tag/v0.47.1
[go-b1]: https://github.com/mark3labs/mcp-go/blob/v0.47.1/client/transport/streamable_http.go#L332
[go-b2]: https://github.com/mark3labs/mcp-go/blob/v0.47.1/client/transport/streamable_http.go#L693
[go-b3]: https://github.com/mark3labs/mcp-go/blob/v0.47.1/client/transport/streamable_http.go#L389
[ts-tag]: https://github.com/modelcontextprotocol/typescript-sdk/releases/tag/1.10.0
[ts-b1]: https://github.com/modelcontextprotocol/typescript-sdk/blob/1.10.0/src/client/streamableHttp.ts#L399
[ts-b2]: https://github.com/modelcontextprotocol/typescript-sdk/blob/1.10.0/src/client/streamableHttp.ts#L208
[ts-b3]: https://github.com/modelcontextprotocol/typescript-sdk/blob/1.10.0/src/client/streamableHttp.ts#L171
[py-tag]: https://github.com/modelcontextprotocol/python-sdk/releases/tag/v1.8.0
[py-b1]: https://github.com/modelcontextprotocol/python-sdk/blob/v1.8.0/src/mcp/client/streamable_http.py#L134
[py-b2]: https://github.com/modelcontextprotocol/python-sdk/blob/v1.8.0/src/mcp/client/streamable_http.py#L398
[py-b3]: https://github.com/modelcontextprotocol/python-sdk/blob/v1.8.0/src/mcp/client/streamable_http.py#L110
[java-tag]: https://github.com/modelcontextprotocol/java-sdk/releases/tag/v0.18.0
[java-b1]: https://github.com/modelcontextprotocol/java-sdk/blob/v0.18.0/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java#L482
[java-b2]: https://github.com/modelcontextprotocol/java-sdk/blob/v0.18.0/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java#L339
[java-b3]: https://github.com/modelcontextprotocol/java-sdk/blob/v0.18.0/mcp-core/src/main/java/io/modelcontextprotocol/client/transport/HttpClientStreamableHttpTransport.java#L259
[kt-tag]: https://github.com/modelcontextprotocol/kotlin-sdk/releases/tag/0.7.0
[kt-b1]: https://github.com/modelcontextprotocol/kotlin-sdk/blob/0.7.0/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/StreamableHttpClientTransport.kt#L126
[kt-b2]: https://github.com/modelcontextprotocol/kotlin-sdk/blob/0.7.0/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/StreamableHttpClientTransport.kt#L234
[kt-b3]: https://github.com/modelcontextprotocol/kotlin-sdk/blob/0.7.0/kotlin-sdk-client/src/commonMain/kotlin/io/modelcontextprotocol/kotlin/sdk/client/StreamableHttpClientTransport.kt#L249
[cs-tag]: https://github.com/modelcontextprotocol/csharp-sdk/releases/tag/v0.2.0-preview.3
[cs-b1]: https://github.com/modelcontextprotocol/csharp-sdk/blob/v0.2.0-preview.3/src/ModelContextProtocol.Core/Client/StreamableHttpClientSessionTransport.cs#L125
[cs-b2]: https://github.com/modelcontextprotocol/csharp-sdk/blob/v0.2.0-preview.3/src/ModelContextProtocol.Core/Client/StreamableHttpClientSessionTransport.cs#L177
[cs-b3]: https://github.com/modelcontextprotocol/csharp-sdk/blob/v0.2.0-preview.3/src/ModelContextProtocol.Core/Client/StreamableHttpClientSessionTransport.cs#L250
