### PR TITLE
feat: add JSON-based setup option to authorization server conformance…

### DIFF
--- a/authorization-server-settings.json
+++ b/authorization-server-settings.json
@@ -1,0 +1,3 @@
+{
+  "url": "http://auth.example.com"
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 
 import { Command } from 'commander';
 import { ZodError } from 'zod';
+import { readFile } from 'fs/promises';
 import {
   runConformanceTest,
   printClientResults,
@@ -35,6 +36,7 @@ import {
 import type { SpecVersion } from './scenarios';
 import { ConformanceCheck } from './types';
 import {
+  AuthorizationServerFileOptionsSchema,
   AuthorizationServerOptionsSchema,
   ClientOptionsSchema,
   ServerOptionsSchema
@@ -69,6 +71,17 @@ function filterScenariosBySpecVersion(
   }
   const allowed = new Set(versionScenarios);
   return allScenarios.filter((s) => allowed.has(s));
+}
+
+function mergeAuthorizationServerOptions(
+  cli: Record<string, any>,
+  file: Record<string, any>
+) {
+  return {
+    url: cli.url ?? file?.url,
+    outputDir: cli.outputDir,
+    specVersion: cli.specVersion
+  };
 }
 
 const program = new Command();
@@ -460,7 +473,8 @@ program
   .description(
     'Run conformance tests against an authorization server implementation'
   )
-  .requiredOption('--url <url>', 'URL of the authorization server issuer')
+  .option('--file <filename>', 'authorization server settings file')
+  .option('--url <url>', 'URL of the authorization server issuer')
   .option('-o, --output-dir <path>', 'Save results to this directory')
   .option(
     '--spec-version <version>',
@@ -468,11 +482,41 @@ program
   )
   .action(async (options) => {
     try {
+      let fileOptions: Record<string, any> = {};
+      if (options.file) {
+        try {
+          const content = await readFile(options.file, 'utf-8');
+          fileOptions = AuthorizationServerFileOptionsSchema.parse(
+            JSON.parse(content)
+          ) as Record<string, any>;
+        } catch (error) {
+          if (error instanceof SyntaxError) {
+            console.error(`Invalid JSON in setting file: ${options.file}`);
+          } else if (error instanceof ZodError) {
+            const details = error.issues
+              .map((e) => `${e.path.join('.')}: ${e.message}`)
+              .join(', ');
+            console.error(
+              `Invalid setting file format: ${options.file}${details}`
+            );
+          } else {
+            console.error(
+              `Failed to read setting file: ${options.file}` +
+                (error instanceof Error ? `: ${error.message}` : '')
+            );
+          }
+          process.exit(1);
+        }
+      }
+      const mergedOptions = mergeAuthorizationServerOptions(
+        options,
+        fileOptions
+      );
       // Validate options with Zod
-      const validated = AuthorizationServerOptionsSchema.parse(options);
-      const outputDir = options.outputDir;
-      const specVersionFilter = options.specVersion
-        ? resolveSpecVersion(options.specVersion)
+      const validated = AuthorizationServerOptionsSchema.parse(mergedOptions);
+      const outputDir = mergedOptions.outputDir;
+      const specVersionFilter = mergedOptions.specVersion
+        ? resolveSpecVersion(mergedOptions.specVersion)
         : undefined;
 
       let scenarios: string[];

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -47,6 +47,17 @@ export type AuthorizationServerOptions = z.infer<
   typeof AuthorizationServerOptionsSchema
 >;
 
+// Authorization server file options schema
+export const AuthorizationServerFileOptionsSchema = z
+  .object({
+    url: z.string().url().optional()
+  })
+  .strict();
+
+export type AuthorizationServerFileOptions = z.infer<
+  typeof AuthorizationServerFileOptionsSchema
+>;
+
 // Interactive command options schema
 export const InteractiveOptionsSchema = z.object({
   scenario: z


### PR DESCRIPTION
## Motivation and Context
Described in #225

## How Has This Been Tested?
- npm test (Test Files  7 passed, Tests  92 passed)
- npm test -- src/scenarios/authorization-server/authorization-server-metadata.test.ts (Test Files  1 passed, Tests  3 passed)
- npm run start -- authorization --url http://localhost:8080/.well-known/oauth-authorization-server/realms/mcp
- npm run start -- authorization --url http://localhost:8080/.well-known/oauth-authorization-server/realms/mcp --file authorization-server-settings.json
- npm run start -- authorization --file authorization-server-settings.json
- npm run start -- authorization

## Breaking Changes
- add file option for authorization server mode (--file <authorization server settings file>)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed