### PR TITLE
doc: Add example of testing against TS SDK

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,19 +28,44 @@ This repo uses **npm** — don't commit `pnpm-lock.yaml` or `yarn.lock`.
 
 ## Running your scenario
 
+Run a client scenario against the bundled example client:
+
 ```sh
-# Against the bundled TypeScript example
 npm run build
 node dist/index.js client --command "tsx examples/clients/typescript/everything-client.ts" --scenario <your-scenario>
+```
 
+Run a server scenario against any server running locally (replace 3000 with your server's port, if necessary):
+
+```sh
 # Against a server
 node dist/index.js server --url http://localhost:3000/mcp --scenario <your-scenario>
 ```
 
-See the [README](./README.md) for full CLI options and the [SDK Integration Guide](./SDK_INTEGRATION.md) for testing against a real SDK.
+Run a server scenario against the latest TypeScript SDK:
+
+```sh
+# In another directory, clone and prepare the SDK once
+cd ..
+git clone https://github.com/modelcontextprotocol/typescript-sdk.git
+cd typescript-sdk
+pnpm install
+pnpm run build:all
+
+# Start the SDK's conformance server in one terminal
+cd test/conformance
+PORT=3100 pnpm run test:conformance:server:run
+
+# Back in this repo, run your local conformance build against it
+cd /path/to/conformance
+npm run build
+node dist/index.js server --url http://localhost:3100/mcp --scenario <your-scenario>
+```
+
+See the [README](./README.md) for full CLI options and the [SDK Integration Guide](./SDK_INTEGRATION.md) for more on testing against a real SDK.
 
 ## Pull requests
 
 - Register your scenario in the right suite in `src/scenarios/index.ts`
-- Run against at least one real SDK before opening the PR — we'll ask what the output looked like
+- Run against at least one real SDK (see above) before opening the PR — we'll ask what the output looked like
 - Keep PRs focused; one feature or scenario group at a time


### PR DESCRIPTION
The CONTRIBUTING.md doc says new scenarios must be tested against a real SDK, but doesn't show an example of doing this. Reformatted the examples section and added a quick example of testing against the latest TS SDK.

## Motivation and Context
Clearer instructions for a new contributor.

## How Has This Been Tested?
I put myself in the shoes of a new contributor. 🙂 

## Breaking Changes
None

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [x] I have added or updated documentation as needed

