### PR TITLE
fix(tier-check): swap server/client scenario lists in conformance reconciliation

### DIFF
--- a/src/tier-check/checks/test-conformance-results.ts
+++ b/src/tier-check/checks/test-conformance-results.ts
@@ -211,12 +211,9 @@ export async function checkConformance(options: {
     // Non-zero exit is expected when tests fail — results are still in outputDir
   }
 
-  const activeScenarios = new Set(listActiveClientScenarios());
   const expectedScenarios = options.specVersion
-    ? listClientScenariosForSpec(options.specVersion).filter((s) =>
-        activeScenarios.has(s)
-      )
-    : [...activeScenarios];
+    ? listScenariosForSpec(options.specVersion)
+    : listScenarios();
 
   return reconcileWithExpected(
     parseOutputDir(outputDir),
@@ -268,9 +265,12 @@ export async function checkClientConformance(options: {
     // Non-zero exit is expected when tests fail — results are still in outputDir
   }
 
+  const activeScenarios = new Set(listActiveClientScenarios());
   const expectedScenarios = options.specVersion
-    ? listScenariosForSpec(options.specVersion)
-    : listScenarios();
+    ? listClientScenariosForSpec(options.specVersion).filter((s) =>
+        activeScenarios.has(s)
+      )
+    : [...activeScenarios];
 
   return reconcileWithExpected(parseOutputDir(outputDir), expectedScenarios);
 }


### PR DESCRIPTION
## Summary

`tier-check` reports 0% server conformance even when all server tests pass because `checkConformance` (server check) reconciles results against the **client** scenario list, and `checkClientConformance` (client check) reconciles against the **server** scenario list.

Server scenario names (`initialize`, `tools_call`, etc.) have zero overlap with client scenario names (`server-initialize`, `tools-list`, etc.), so every passed scenario is counted as "missing."

```
Server scenarios: 26 names  (initialize, tools_call, ...)
Client scenarios: 31 names  (server-initialize, tools-list, ...)
Overlap: 0
```

## Fix

Swap the scenario list functions so each check reconciles against its own scenario type:
- `checkConformance` now uses `listScenarios()` / `listScenariosForSpec()` (server scenarios)
- `checkClientConformance` now uses `listActiveClientScenarios()` / `listClientScenariosForSpec()` (client scenarios)

Fixes #182