### PR TITLE
refactor: range-based spec version tagging (introducedIn/removedIn)

### DIFF
--- a/examples/clients/typescript/everything-client.ts
+++ b/examples/clients/typescript/everything-client.ts
@@ -375,20 +375,20 @@ registerScenario('auth/pre-registration', runPreRegistration);
 // ============================================================================
 
 /**
- * Cross-app access: Complete Flow (SEP-990)
+ * Enterprise Managed Auth (SEP-990)
  * Tests the complete flow: IDP ID token -> authorization grant -> access token -> MCP access.
  */
-export async function runCrossAppAccessCompleteFlow(
+export async function runEnterpriseManagedAuth(
   serverUrl: string
 ): Promise<void> {
   const ctx = parseContext();
-  if (ctx.name !== 'auth/cross-app-access-complete-flow') {
+  if (ctx.name !== 'auth/enterprise-managed-auth') {
     throw new Error(
-      `Expected cross-app-access-complete-flow context, got ${ctx.name}`
+      `Expected enterprise-managed-auth context, got ${ctx.name}`
     );
   }
 
-  logger.debug('Starting complete cross-app access flow...');
+  logger.debug('Starting enterprise managed auth flow...');
   logger.debug('IDP Issuer:', ctx.idp_issuer);
   logger.debug('IDP Token Endpoint:', ctx.idp_token_endpoint);
 
@@ -494,7 +494,7 @@ export async function runCrossAppAccessCompleteFlow(
   // Step 3: Use access token to access MCP server
   logger.debug('Step 3: Accessing MCP server with access token...');
   const client = new Client(
-    { name: 'conformance-cross-app-access', version: '1.0.0' },
+    { name: 'conformance-enterprise-managed-auth', version: '1.0.0' },
     { capabilities: {} }
   );
 
@@ -516,13 +516,10 @@ export async function runCrossAppAccessCompleteFlow(
   logger.debug('Successfully called tool');
 
   await transport.close();
-  logger.debug('Complete cross-app access flow completed successfully');
+  logger.debug('Enterprise managed auth flow completed successfully');
 }
 
-registerScenario(
-  'auth/cross-app-access-complete-flow',
-  runCrossAppAccessCompleteFlow
-);
+registerScenario('auth/enterprise-managed-auth', runEnterpriseManagedAuth);
 
 // ============================================================================
 // Main entry point

--- a/examples/clients/typescript/everything-client.ts
+++ b/examples/clients/typescript/everything-client.ts
@@ -375,20 +375,20 @@ registerScenario('auth/pre-registration', runPreRegistration);
 // ============================================================================
 
 /**
- * Enterprise Managed Auth (SEP-990)
+ * Enterprise-Managed Authorization (SEP-990)
  * Tests the complete flow: IDP ID token -> authorization grant -> access token -> MCP access.
  */
-export async function runEnterpriseManagedAuth(
+export async function runEnterpriseManagedAuthorization(
   serverUrl: string
 ): Promise<void> {
   const ctx = parseContext();
-  if (ctx.name !== 'auth/enterprise-managed-auth') {
+  if (ctx.name !== 'auth/enterprise-managed-authorization') {
     throw new Error(
-      `Expected enterprise-managed-auth context, got ${ctx.name}`
+      `Expected enterprise-managed-authorization context, got ${ctx.name}`
     );
   }
 
-  logger.debug('Starting enterprise managed auth flow...');
+  logger.debug('Starting enterprise-managed authorization flow...');
   logger.debug('IDP Issuer:', ctx.idp_issuer);
   logger.debug('IDP Token Endpoint:', ctx.idp_token_endpoint);
 
@@ -494,7 +494,7 @@ export async function runEnterpriseManagedAuth(
   // Step 3: Use access token to access MCP server
   logger.debug('Step 3: Accessing MCP server with access token...');
   const client = new Client(
-    { name: 'conformance-enterprise-managed-auth', version: '1.0.0' },
+    { name: 'conformance-enterprise-managed-authorization', version: '1.0.0' },
     { capabilities: {} }
   );
 
@@ -516,10 +516,13 @@ export async function runEnterpriseManagedAuth(
   logger.debug('Successfully called tool');
 
   await transport.close();
-  logger.debug('Enterprise managed auth flow completed successfully');
+  logger.debug('Enterprise-managed authorization flow completed successfully');
 }
 
-registerScenario('auth/enterprise-managed-auth', runEnterpriseManagedAuth);
+registerScenario(
+  'auth/enterprise-managed-authorization',
+  runEnterpriseManagedAuthorization
+);
 
 // ============================================================================
 // Main entry point

--- a/src/scenarios/authorization-server/authorization-server-metadata.ts
+++ b/src/scenarios/authorization-server/authorization-server-metadata.ts
@@ -4,7 +4,7 @@
 import {
   ClientScenarioForAuthorizationServer,
   ConformanceCheck,
-  SpecVersion
+  DatedSpecVersion
 } from '../../types';
 import { request } from 'undici';
 
@@ -12,7 +12,7 @@ type Status = 'SUCCESS' | 'FAILURE';
 
 export class AuthorizationServerMetadataEndpointScenario implements ClientScenarioForAuthorizationServer {
   name = 'authorization-server-metadata-endpoint';
-  specVersions: SpecVersion[] = ['2025-03-26', '2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-03-26';
   description = `Test authorization server metadata endpoint.
 
 **Authorization Server Implementation Requirements:**

--- a/src/scenarios/authorization-server/authorization-server-metadata.ts
+++ b/src/scenarios/authorization-server/authorization-server-metadata.ts
@@ -3,8 +3,7 @@
  */
 import {
   ClientScenarioForAuthorizationServer,
-  ConformanceCheck,
-  DatedSpecVersion
+  ConformanceCheck
 } from '../../types';
 import { request } from 'undici';
 
@@ -12,7 +11,7 @@ type Status = 'SUCCESS' | 'FAILURE';
 
 export class AuthorizationServerMetadataEndpointScenario implements ClientScenarioForAuthorizationServer {
   name = 'authorization-server-metadata-endpoint';
-  introducedIn: DatedSpecVersion = '2025-03-26';
+  readonly source = { introducedIn: '2025-03-26' } as const;
   description = `Test authorization server metadata endpoint.
 
 **Authorization Server Implementation Requirements:**

--- a/src/scenarios/client/auth/basic-cimd.ts
+++ b/src/scenarios/client/auth/basic-cimd.ts
@@ -1,5 +1,5 @@
 import type { Scenario, ConformanceCheck } from '../../../types';
-import { ScenarioUrls, DatedSpecVersion } from '../../../types';
+import { ScenarioUrls } from '../../../types';
 import { createAuthServer } from './helpers/createAuthServer';
 import { createServer } from './helpers/createServer';
 import { ServerLifecycle } from './helpers/serverLifecycle';
@@ -22,7 +22,7 @@ export const CIMD_CLIENT_METADATA_URL =
  */
 export class AuthBasicCIMDScenario implements Scenario {
   name = 'auth/basic-cimd';
-  introducedIn: DatedSpecVersion = '2025-11-25';
+  readonly source = { introducedIn: '2025-11-25' } as const;
   description =
     'Tests OAuth flow with Client ID Metadata Documents (SEP-991/URL-based client IDs). Server advertises client_id_metadata_document_supported=true and client should use URL as client_id instead of DCR.';
   private authServer = new ServerLifecycle();

--- a/src/scenarios/client/auth/basic-cimd.ts
+++ b/src/scenarios/client/auth/basic-cimd.ts
@@ -1,5 +1,5 @@
 import type { Scenario, ConformanceCheck } from '../../../types';
-import { ScenarioUrls, SpecVersion } from '../../../types';
+import { ScenarioUrls, DatedSpecVersion } from '../../../types';
 import { createAuthServer } from './helpers/createAuthServer';
 import { createServer } from './helpers/createServer';
 import { ServerLifecycle } from './helpers/serverLifecycle';
@@ -22,7 +22,7 @@ export const CIMD_CLIENT_METADATA_URL =
  */
 export class AuthBasicCIMDScenario implements Scenario {
   name = 'auth/basic-cimd';
-  specVersions: SpecVersion[] = ['2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-11-25';
   description =
     'Tests OAuth flow with Client ID Metadata Documents (SEP-991/URL-based client IDs). Server advertises client_id_metadata_document_supported=true and client should use URL as client_id instead of DCR.';
   private authServer = new ServerLifecycle();

--- a/src/scenarios/client/auth/client-credentials.ts
+++ b/src/scenarios/client/auth/client-credentials.ts
@@ -4,8 +4,9 @@ import type {
   Scenario,
   ConformanceCheck,
   ScenarioUrls,
-  ScenarioSpecTag
+  SpecVersion
 } from '../../../types';
+import { LATEST_SPEC_VERSION } from '../../../types';
 import { createAuthServer } from './helpers/createAuthServer';
 import { createServer } from './helpers/createServer';
 import { ServerLifecycle } from './helpers/serverLifecycle';
@@ -37,7 +38,8 @@ async function generateTestKeypair(): Promise<{
  */
 export class ClientCredentialsJwtScenario implements Scenario {
   name = 'auth/client-credentials-jwt';
-  specVersions: ScenarioSpecTag[] = ['extension'];
+  extension = true;
+  introducedIn: SpecVersion = LATEST_SPEC_VERSION;
   description =
     'Tests OAuth client_credentials flow with private_key_jwt authentication (SEP-1046)';
 
@@ -256,7 +258,8 @@ export class ClientCredentialsJwtScenario implements Scenario {
  */
 export class ClientCredentialsBasicScenario implements Scenario {
   name = 'auth/client-credentials-basic';
-  specVersions: ScenarioSpecTag[] = ['extension'];
+  extension = true;
+  introducedIn: SpecVersion = LATEST_SPEC_VERSION;
   description =
     'Tests OAuth client_credentials flow with client_secret_basic authentication';
 

--- a/src/scenarios/client/auth/client-credentials.ts
+++ b/src/scenarios/client/auth/client-credentials.ts
@@ -32,7 +32,9 @@ async function generateTestKeypair(): Promise<{
  */
 export class ClientCredentialsJwtScenario implements Scenario {
   name = 'auth/client-credentials-jwt';
-  readonly source = { extensionId: 'client-credentials' } as const;
+  readonly source = {
+    extensionId: 'io.modelcontextprotocol/oauth-client-credentials'
+  } as const;
   description =
     'Tests OAuth client_credentials flow with private_key_jwt authentication (SEP-1046)';
 
@@ -251,7 +253,9 @@ export class ClientCredentialsJwtScenario implements Scenario {
  */
 export class ClientCredentialsBasicScenario implements Scenario {
   name = 'auth/client-credentials-basic';
-  readonly source = { extensionId: 'client-credentials' } as const;
+  readonly source = {
+    extensionId: 'io.modelcontextprotocol/oauth-client-credentials'
+  } as const;
   description =
     'Tests OAuth client_credentials flow with client_secret_basic authentication';
 

--- a/src/scenarios/client/auth/client-credentials.ts
+++ b/src/scenarios/client/auth/client-credentials.ts
@@ -1,12 +1,6 @@
 import * as jose from 'jose';
 import type { CryptoKey } from 'jose';
-import type {
-  Scenario,
-  ConformanceCheck,
-  ScenarioUrls,
-  SpecVersion
-} from '../../../types';
-import { LATEST_SPEC_VERSION } from '../../../types';
+import type { Scenario, ConformanceCheck, ScenarioUrls } from '../../../types';
 import { createAuthServer } from './helpers/createAuthServer';
 import { createServer } from './helpers/createServer';
 import { ServerLifecycle } from './helpers/serverLifecycle';
@@ -38,8 +32,7 @@ async function generateTestKeypair(): Promise<{
  */
 export class ClientCredentialsJwtScenario implements Scenario {
   name = 'auth/client-credentials-jwt';
-  extension = true;
-  introducedIn: SpecVersion = LATEST_SPEC_VERSION;
+  readonly source = { extensionId: 'client-credentials' } as const;
   description =
     'Tests OAuth client_credentials flow with private_key_jwt authentication (SEP-1046)';
 
@@ -258,8 +251,7 @@ export class ClientCredentialsJwtScenario implements Scenario {
  */
 export class ClientCredentialsBasicScenario implements Scenario {
   name = 'auth/client-credentials-basic';
-  extension = true;
-  introducedIn: SpecVersion = LATEST_SPEC_VERSION;
+  readonly source = { extensionId: 'client-credentials' } as const;
   description =
     'Tests OAuth client_credentials flow with client_secret_basic authentication';
 

--- a/src/scenarios/client/auth/cross-app-access.ts
+++ b/src/scenarios/client/auth/cross-app-access.ts
@@ -5,8 +5,9 @@ import type {
   Scenario,
   ConformanceCheck,
   ScenarioUrls,
-  ScenarioSpecTag
+  SpecVersion
 } from '../../../types';
+import { LATEST_SPEC_VERSION } from '../../../types';
 import { createAuthServer } from './helpers/createAuthServer';
 import { createServer } from './helpers/createServer';
 import { MockTokenVerifier } from './helpers/mockTokenVerifier';
@@ -60,7 +61,8 @@ async function createIdpIdToken(
  */
 export class CrossAppAccessCompleteFlowScenario implements Scenario {
   name = 'auth/cross-app-access-complete-flow';
-  specVersions: ScenarioSpecTag[] = ['extension'];
+  extension = true;
+  introducedIn: SpecVersion = LATEST_SPEC_VERSION;
   description =
     'Tests complete SEP-990 flow: token exchange + JWT bearer grant (Enterprise Managed OAuth)';
 

--- a/src/scenarios/client/auth/discovery-metadata.ts
+++ b/src/scenarios/client/auth/discovery-metadata.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Scenario, ConformanceCheck } from '../../../types';
-import { ScenarioUrls, DatedSpecVersion } from '../../../types';
+import { ScenarioUrls } from '../../../types';
 import { createAuthServer } from './helpers/createAuthServer';
 import { createServer } from './helpers/createServer';
 import { ServerLifecycle } from './helpers/serverLifecycle';
@@ -87,7 +87,7 @@ function createMetadataScenario(config: MetadataScenarioConfig): Scenario {
 
   return {
     name: `auth/${config.name}`,
-    introducedIn: '2025-11-25' as DatedSpecVersion,
+    source: { introducedIn: '2025-11-25' },
     description: `Tests Basic OAuth metadata discovery flow.
 
 **PRM:** ${config.prmLocation}${config.inWwwAuth ? '' : ' (not in WWW-Authenticate)'}

--- a/src/scenarios/client/auth/discovery-metadata.ts
+++ b/src/scenarios/client/auth/discovery-metadata.ts
@@ -7,7 +7,7 @@
  */
 
 import type { Scenario, ConformanceCheck } from '../../../types';
-import { ScenarioUrls } from '../../../types';
+import { ScenarioUrls, DatedSpecVersion } from '../../../types';
 import { createAuthServer } from './helpers/createAuthServer';
 import { createServer } from './helpers/createServer';
 import { ServerLifecycle } from './helpers/serverLifecycle';
@@ -87,7 +87,7 @@ function createMetadataScenario(config: MetadataScenarioConfig): Scenario {
 
   return {
     name: `auth/${config.name}`,
-    specVersions: ['2025-11-25'],
+    introducedIn: '2025-11-25' as DatedSpecVersion,
     description: `Tests Basic OAuth metadata discovery flow.
 
 **PRM:** ${config.prmLocation}${config.inWwwAuth ? '' : ' (not in WWW-Authenticate)'}

--- a/src/scenarios/client/auth/enterprise-managed-auth.ts
+++ b/src/scenarios/client/auth/enterprise-managed-auth.ts
@@ -1,13 +1,7 @@
 import * as jose from 'jose';
 import type { CryptoKey } from 'jose';
 import express, { type Request, type Response } from 'express';
-import type {
-  Scenario,
-  ConformanceCheck,
-  ScenarioUrls,
-  SpecVersion
-} from '../../../types';
-import { LATEST_SPEC_VERSION } from '../../../types';
+import type { Scenario, ConformanceCheck, ScenarioUrls } from '../../../types';
 import { createAuthServer } from './helpers/createAuthServer';
 import { createServer } from './helpers/createServer';
 import { MockTokenVerifier } from './helpers/mockTokenVerifier';
@@ -54,15 +48,14 @@ async function createIdpIdToken(
 }
 
 /**
- * Scenario: Complete Cross-App Access Flow
+ * Scenario: Enterprise Managed Auth (SEP-990)
  *
  * Tests the complete SEP-990 flow: IDP ID token -> authorization grant -> access token
  * This scenario combines both RFC 8693 token exchange and RFC 7523 JWT bearer grant.
  */
-export class CrossAppAccessCompleteFlowScenario implements Scenario {
-  name = 'auth/cross-app-access-complete-flow';
-  extension = true;
-  introducedIn: SpecVersion = LATEST_SPEC_VERSION;
+export class EnterpriseManagedAuthScenario implements Scenario {
+  name = 'auth/enterprise-managed-auth';
+  readonly source = { extensionId: 'enterprise-managed-auth' } as const;
   description =
     'Tests complete SEP-990 flow: token exchange + JWT bearer grant (Enterprise Managed OAuth)';
 

--- a/src/scenarios/client/auth/enterprise-managed-authorization.ts
+++ b/src/scenarios/client/auth/enterprise-managed-authorization.ts
@@ -48,16 +48,18 @@ async function createIdpIdToken(
 }
 
 /**
- * Scenario: Enterprise Managed Auth (SEP-990)
+ * Scenario: Enterprise-Managed Authorization (SEP-990)
  *
  * Tests the complete SEP-990 flow: IDP ID token -> authorization grant -> access token
  * This scenario combines both RFC 8693 token exchange and RFC 7523 JWT bearer grant.
  */
-export class EnterpriseManagedAuthScenario implements Scenario {
-  name = 'auth/enterprise-managed-auth';
-  readonly source = { extensionId: 'enterprise-managed-auth' } as const;
+export class EnterpriseManagedAuthorizationScenario implements Scenario {
+  name = 'auth/enterprise-managed-authorization';
+  readonly source = {
+    extensionId: 'io.modelcontextprotocol/enterprise-managed-authorization'
+  } as const;
   description =
-    'Tests complete SEP-990 flow: token exchange + JWT bearer grant (Enterprise Managed OAuth)';
+    'Tests complete SEP-990 flow: token exchange + JWT bearer grant (Enterprise-Managed Authorization)';
 
   private idpServer = new ServerLifecycle();
   private authServer = new ServerLifecycle();

--- a/src/scenarios/client/auth/index.ts
+++ b/src/scenarios/client/auth/index.ts
@@ -23,7 +23,7 @@ import {
 } from './client-credentials';
 import { ResourceMismatchScenario } from './resource-mismatch';
 import { PreRegistrationScenario } from './pre-registration';
-import { EnterpriseManagedAuthScenario } from './enterprise-managed-auth';
+import { EnterpriseManagedAuthorizationScenario } from './enterprise-managed-authorization';
 import {
   OfflineAccessScopeScenario,
   OfflineAccessNotSupportedScenario
@@ -54,7 +54,7 @@ export const backcompatScenariosList: Scenario[] = [
 export const extensionScenariosList: Scenario[] = [
   new ClientCredentialsJwtScenario(),
   new ClientCredentialsBasicScenario(),
-  new EnterpriseManagedAuthScenario()
+  new EnterpriseManagedAuthorizationScenario()
 ];
 
 // Draft scenarios (informational - not scored for tier assessment)

--- a/src/scenarios/client/auth/index.ts
+++ b/src/scenarios/client/auth/index.ts
@@ -23,7 +23,7 @@ import {
 } from './client-credentials';
 import { ResourceMismatchScenario } from './resource-mismatch';
 import { PreRegistrationScenario } from './pre-registration';
-import { CrossAppAccessCompleteFlowScenario } from './cross-app-access';
+import { EnterpriseManagedAuthScenario } from './enterprise-managed-auth';
 import {
   OfflineAccessScopeScenario,
   OfflineAccessNotSupportedScenario
@@ -54,7 +54,7 @@ export const backcompatScenariosList: Scenario[] = [
 export const extensionScenariosList: Scenario[] = [
   new ClientCredentialsJwtScenario(),
   new ClientCredentialsBasicScenario(),
-  new CrossAppAccessCompleteFlowScenario()
+  new EnterpriseManagedAuthScenario()
 ];
 
 // Draft scenarios (informational - not scored for tier assessment)

--- a/src/scenarios/client/auth/march-spec-backcompat.ts
+++ b/src/scenarios/client/auth/march-spec-backcompat.ts
@@ -1,5 +1,5 @@
 import type { Scenario, ConformanceCheck } from '../../../types';
-import { ScenarioUrls, DatedSpecVersion } from '../../../types';
+import { ScenarioUrls } from '../../../types';
 import { createAuthServer } from './helpers/createAuthServer';
 import { createServer } from './helpers/createServer';
 import { ServerLifecycle } from './helpers/serverLifecycle';
@@ -8,8 +8,10 @@ import { SpecReferences } from './spec-references';
 
 export class Auth20250326OAuthMetadataBackcompatScenario implements Scenario {
   name = 'auth/2025-03-26-oauth-metadata-backcompat';
-  introducedIn: DatedSpecVersion = '2025-03-26';
-  removedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = {
+    introducedIn: '2025-03-26',
+    removedIn: '2025-06-18'
+  } as const;
   description =
     'Tests 2025-03-26 spec OAuth flow: no PRM (Protected Resource Metadata), OAuth metadata at root location';
   private server = new ServerLifecycle();
@@ -70,8 +72,10 @@ export class Auth20250326OAuthMetadataBackcompatScenario implements Scenario {
 
 export class Auth20250326OEndpointFallbackScenario implements Scenario {
   name = 'auth/2025-03-26-oauth-endpoint-fallback';
-  introducedIn: DatedSpecVersion = '2025-03-26';
-  removedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = {
+    introducedIn: '2025-03-26',
+    removedIn: '2025-06-18'
+  } as const;
   description =
     'Tests OAuth flow with no metadata endpoints, relying on fallback to standard OAuth endpoints at server root (2025-03-26 spec behavior)';
   private server = new ServerLifecycle();

--- a/src/scenarios/client/auth/march-spec-backcompat.ts
+++ b/src/scenarios/client/auth/march-spec-backcompat.ts
@@ -1,5 +1,5 @@
 import type { Scenario, ConformanceCheck } from '../../../types';
-import { ScenarioUrls, SpecVersion } from '../../../types';
+import { ScenarioUrls, DatedSpecVersion } from '../../../types';
 import { createAuthServer } from './helpers/createAuthServer';
 import { createServer } from './helpers/createServer';
 import { ServerLifecycle } from './helpers/serverLifecycle';
@@ -8,7 +8,8 @@ import { SpecReferences } from './spec-references';
 
 export class Auth20250326OAuthMetadataBackcompatScenario implements Scenario {
   name = 'auth/2025-03-26-oauth-metadata-backcompat';
-  specVersions: SpecVersion[] = ['2025-03-26'];
+  introducedIn: DatedSpecVersion = '2025-03-26';
+  removedIn: DatedSpecVersion = '2025-06-18';
   description =
     'Tests 2025-03-26 spec OAuth flow: no PRM (Protected Resource Metadata), OAuth metadata at root location';
   private server = new ServerLifecycle();
@@ -69,7 +70,8 @@ export class Auth20250326OAuthMetadataBackcompatScenario implements Scenario {
 
 export class Auth20250326OEndpointFallbackScenario implements Scenario {
   name = 'auth/2025-03-26-oauth-endpoint-fallback';
-  specVersions: SpecVersion[] = ['2025-03-26'];
+  introducedIn: DatedSpecVersion = '2025-03-26';
+  removedIn: DatedSpecVersion = '2025-06-18';
   description =
     'Tests OAuth flow with no metadata endpoints, relying on fallback to standard OAuth endpoints at server root (2025-03-26 spec behavior)';
   private server = new ServerLifecycle();

--- a/src/scenarios/client/auth/offline-access.ts
+++ b/src/scenarios/client/auth/offline-access.ts
@@ -1,9 +1,5 @@
 import type { Scenario, ConformanceCheck } from '../../../types';
-import {
-  ScenarioUrls,
-  SpecVersion,
-  DRAFT_PROTOCOL_VERSION
-} from '../../../types';
+import { ScenarioUrls, DRAFT_PROTOCOL_VERSION } from '../../../types';
 import { createAuthServer } from './helpers/createAuthServer';
 import { createServer } from './helpers/createServer';
 import { ServerLifecycle } from './helpers/serverLifecycle';
@@ -27,7 +23,7 @@ import { MockTokenVerifier } from './helpers/mockTokenVerifier';
  */
 export class OfflineAccessScopeScenario implements Scenario {
   name = 'auth/offline-access-scope';
-  introducedIn: SpecVersion = DRAFT_PROTOCOL_VERSION;
+  readonly source = { introducedIn: DRAFT_PROTOCOL_VERSION } as const;
   description =
     'Tests that a client that wants a refresh token handles offline_access scope and refresh_token grant type when AS supports them (SEP-2207)';
 
@@ -231,7 +227,7 @@ export class OfflineAccessScopeScenario implements Scenario {
  */
 export class OfflineAccessNotSupportedScenario implements Scenario {
   name = 'auth/offline-access-not-supported';
-  introducedIn: SpecVersion = DRAFT_PROTOCOL_VERSION;
+  readonly source = { introducedIn: DRAFT_PROTOCOL_VERSION } as const;
   description =
     'Tests that client does not request offline_access when AS does not list it in scopes_supported (SEP-2207)';
 

--- a/src/scenarios/client/auth/offline-access.ts
+++ b/src/scenarios/client/auth/offline-access.ts
@@ -27,7 +27,7 @@ import { MockTokenVerifier } from './helpers/mockTokenVerifier';
  */
 export class OfflineAccessScopeScenario implements Scenario {
   name = 'auth/offline-access-scope';
-  specVersions: SpecVersion[] = [DRAFT_PROTOCOL_VERSION];
+  introducedIn: SpecVersion = DRAFT_PROTOCOL_VERSION;
   description =
     'Tests that a client that wants a refresh token handles offline_access scope and refresh_token grant type when AS supports them (SEP-2207)';
 
@@ -231,7 +231,7 @@ export class OfflineAccessScopeScenario implements Scenario {
  */
 export class OfflineAccessNotSupportedScenario implements Scenario {
   name = 'auth/offline-access-not-supported';
-  specVersions: SpecVersion[] = [DRAFT_PROTOCOL_VERSION];
+  introducedIn: SpecVersion = DRAFT_PROTOCOL_VERSION;
   description =
     'Tests that client does not request offline_access when AS does not list it in scopes_supported (SEP-2207)';
 

--- a/src/scenarios/client/auth/pre-registration.ts
+++ b/src/scenarios/client/auth/pre-registration.ts
@@ -2,7 +2,7 @@ import type {
   Scenario,
   ConformanceCheck,
   ScenarioUrls,
-  SpecVersion
+  DatedSpecVersion
 } from '../../../types';
 import { createAuthServer } from './helpers/createAuthServer';
 import { createServer } from './helpers/createServer';
@@ -24,7 +24,7 @@ const PRE_REGISTERED_CLIENT_SECRET = 'pre-registered-secret';
  */
 export class PreRegistrationScenario implements Scenario {
   name = 'auth/pre-registration';
-  specVersions: SpecVersion[] = ['2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-11-25';
   description =
     'Tests OAuth flow with pre-registered client credentials. Server does not support DCR.';
 

--- a/src/scenarios/client/auth/pre-registration.ts
+++ b/src/scenarios/client/auth/pre-registration.ts
@@ -1,9 +1,4 @@
-import type {
-  Scenario,
-  ConformanceCheck,
-  ScenarioUrls,
-  DatedSpecVersion
-} from '../../../types';
+import type { Scenario, ConformanceCheck, ScenarioUrls } from '../../../types';
 import { createAuthServer } from './helpers/createAuthServer';
 import { createServer } from './helpers/createServer';
 import { ServerLifecycle } from './helpers/serverLifecycle';
@@ -24,7 +19,7 @@ const PRE_REGISTERED_CLIENT_SECRET = 'pre-registered-secret';
  */
 export class PreRegistrationScenario implements Scenario {
   name = 'auth/pre-registration';
-  introducedIn: DatedSpecVersion = '2025-11-25';
+  readonly source = { introducedIn: '2025-11-25' } as const;
   description =
     'Tests OAuth flow with pre-registered client credentials. Server does not support DCR.';
 

--- a/src/scenarios/client/auth/resource-mismatch.ts
+++ b/src/scenarios/client/auth/resource-mismatch.ts
@@ -31,7 +31,7 @@ import { MockTokenVerifier } from './helpers/mockTokenVerifier.js';
  */
 export class ResourceMismatchScenario implements Scenario {
   name = 'auth/resource-mismatch';
-  specVersions: SpecVersion[] = [DRAFT_PROTOCOL_VERSION];
+  introducedIn: SpecVersion = DRAFT_PROTOCOL_VERSION;
   description =
     'Tests that client rejects when PRM resource does not match server URL';
   allowClientError = true;

--- a/src/scenarios/client/auth/resource-mismatch.ts
+++ b/src/scenarios/client/auth/resource-mismatch.ts
@@ -1,9 +1,5 @@
 import type { Scenario, ConformanceCheck } from '../../../types.js';
-import {
-  ScenarioUrls,
-  SpecVersion,
-  DRAFT_PROTOCOL_VERSION
-} from '../../../types.js';
+import { ScenarioUrls, DRAFT_PROTOCOL_VERSION } from '../../../types.js';
 import { createAuthServer } from './helpers/createAuthServer.js';
 import { createServer } from './helpers/createServer.js';
 import { ServerLifecycle } from './helpers/serverLifecycle.js';
@@ -31,7 +27,7 @@ import { MockTokenVerifier } from './helpers/mockTokenVerifier.js';
  */
 export class ResourceMismatchScenario implements Scenario {
   name = 'auth/resource-mismatch';
-  introducedIn: SpecVersion = DRAFT_PROTOCOL_VERSION;
+  readonly source = { introducedIn: DRAFT_PROTOCOL_VERSION } as const;
   description =
     'Tests that client rejects when PRM resource does not match server URL';
   allowClientError = true;

--- a/src/scenarios/client/auth/scope-handling.ts
+++ b/src/scenarios/client/auth/scope-handling.ts
@@ -1,5 +1,5 @@
 import type { Scenario, ConformanceCheck } from '../../../types';
-import { ScenarioUrls, SpecVersion } from '../../../types';
+import { ScenarioUrls, DatedSpecVersion } from '../../../types';
 import { createAuthServer } from './helpers/createAuthServer';
 import { createServer } from './helpers/createServer';
 import { ServerLifecycle } from './helpers/serverLifecycle';
@@ -15,7 +15,7 @@ import type { Request, Response, NextFunction } from 'express';
  */
 export class ScopeFromWwwAuthenticateScenario implements Scenario {
   name = 'auth/scope-from-www-authenticate';
-  specVersions: SpecVersion[] = ['2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-11-25';
   description =
     'Tests that client uses scope parameter from WWW-Authenticate header when provided';
   private authServer = new ServerLifecycle();
@@ -101,7 +101,7 @@ export class ScopeFromWwwAuthenticateScenario implements Scenario {
  */
 export class ScopeFromScopesSupportedScenario implements Scenario {
   name = 'auth/scope-from-scopes-supported';
-  specVersions: SpecVersion[] = ['2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-11-25';
   description =
     'Tests that client uses all scopes from scopes_supported when scope not in WWW-Authenticate header';
   private authServer = new ServerLifecycle();
@@ -197,7 +197,7 @@ export class ScopeFromScopesSupportedScenario implements Scenario {
  */
 export class ScopeOmittedWhenUndefinedScenario implements Scenario {
   name = 'auth/scope-omitted-when-undefined';
-  specVersions: SpecVersion[] = ['2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-11-25';
   description =
     'Tests that client omits scope parameter when scopes_supported is undefined';
   private authServer = new ServerLifecycle();
@@ -284,7 +284,7 @@ export class ScopeOmittedWhenUndefinedScenario implements Scenario {
  */
 export class ScopeStepUpAuthScenario implements Scenario {
   name = 'auth/scope-step-up';
-  specVersions: SpecVersion[] = ['2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-11-25';
   description =
     'Tests that client handles step-up authentication with different scope requirements per operation';
   private authServer = new ServerLifecycle();
@@ -481,7 +481,7 @@ export class ScopeStepUpAuthScenario implements Scenario {
  */
 export class ScopeRetryLimitScenario implements Scenario {
   name = 'auth/scope-retry-limit';
-  specVersions: SpecVersion[] = ['2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-11-25';
   description =
     'Tests that client implements retry limits to prevent infinite authorization loops on repeated 403 responses';
   allowClientError = true;

--- a/src/scenarios/client/auth/scope-handling.ts
+++ b/src/scenarios/client/auth/scope-handling.ts
@@ -1,5 +1,5 @@
 import type { Scenario, ConformanceCheck } from '../../../types';
-import { ScenarioUrls, DatedSpecVersion } from '../../../types';
+import { ScenarioUrls } from '../../../types';
 import { createAuthServer } from './helpers/createAuthServer';
 import { createServer } from './helpers/createServer';
 import { ServerLifecycle } from './helpers/serverLifecycle';
@@ -15,7 +15,7 @@ import type { Request, Response, NextFunction } from 'express';
  */
 export class ScopeFromWwwAuthenticateScenario implements Scenario {
   name = 'auth/scope-from-www-authenticate';
-  introducedIn: DatedSpecVersion = '2025-11-25';
+  readonly source = { introducedIn: '2025-11-25' } as const;
   description =
     'Tests that client uses scope parameter from WWW-Authenticate header when provided';
   private authServer = new ServerLifecycle();
@@ -101,7 +101,7 @@ export class ScopeFromWwwAuthenticateScenario implements Scenario {
  */
 export class ScopeFromScopesSupportedScenario implements Scenario {
   name = 'auth/scope-from-scopes-supported';
-  introducedIn: DatedSpecVersion = '2025-11-25';
+  readonly source = { introducedIn: '2025-11-25' } as const;
   description =
     'Tests that client uses all scopes from scopes_supported when scope not in WWW-Authenticate header';
   private authServer = new ServerLifecycle();
@@ -197,7 +197,7 @@ export class ScopeFromScopesSupportedScenario implements Scenario {
  */
 export class ScopeOmittedWhenUndefinedScenario implements Scenario {
   name = 'auth/scope-omitted-when-undefined';
-  introducedIn: DatedSpecVersion = '2025-11-25';
+  readonly source = { introducedIn: '2025-11-25' } as const;
   description =
     'Tests that client omits scope parameter when scopes_supported is undefined';
   private authServer = new ServerLifecycle();
@@ -284,7 +284,7 @@ export class ScopeOmittedWhenUndefinedScenario implements Scenario {
  */
 export class ScopeStepUpAuthScenario implements Scenario {
   name = 'auth/scope-step-up';
-  introducedIn: DatedSpecVersion = '2025-11-25';
+  readonly source = { introducedIn: '2025-11-25' } as const;
   description =
     'Tests that client handles step-up authentication with different scope requirements per operation';
   private authServer = new ServerLifecycle();
@@ -481,7 +481,7 @@ export class ScopeStepUpAuthScenario implements Scenario {
  */
 export class ScopeRetryLimitScenario implements Scenario {
   name = 'auth/scope-retry-limit';
-  introducedIn: DatedSpecVersion = '2025-11-25';
+  readonly source = { introducedIn: '2025-11-25' } as const;
   description =
     'Tests that client implements retry limits to prevent infinite authorization loops on repeated 403 responses';
   allowClientError = true;

--- a/src/scenarios/client/auth/token-endpoint-auth.ts
+++ b/src/scenarios/client/auth/token-endpoint-auth.ts
@@ -1,5 +1,5 @@
 import type { Scenario, ConformanceCheck } from '../../../types.js';
-import { ScenarioUrls, SpecVersion } from '../../../types.js';
+import { ScenarioUrls, DatedSpecVersion } from '../../../types.js';
 import { createAuthServer } from './helpers/createAuthServer.js';
 import { createServer } from './helpers/createServer.js';
 import { ServerLifecycle } from './helpers/serverLifecycle.js';
@@ -45,7 +45,7 @@ const AUTH_METHOD_NAMES: Record<AuthMethod, string> = {
 
 class TokenEndpointAuthScenario implements Scenario {
   name: string;
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description: string;
   private expectedAuthMethod: AuthMethod;
   private authServer = new ServerLifecycle();

--- a/src/scenarios/client/auth/token-endpoint-auth.ts
+++ b/src/scenarios/client/auth/token-endpoint-auth.ts
@@ -1,5 +1,5 @@
 import type { Scenario, ConformanceCheck } from '../../../types.js';
-import { ScenarioUrls, DatedSpecVersion } from '../../../types.js';
+import { ScenarioUrls } from '../../../types.js';
 import { createAuthServer } from './helpers/createAuthServer.js';
 import { createServer } from './helpers/createServer.js';
 import { ServerLifecycle } from './helpers/serverLifecycle.js';
@@ -45,7 +45,7 @@ const AUTH_METHOD_NAMES: Record<AuthMethod, string> = {
 
 class TokenEndpointAuthScenario implements Scenario {
   name: string;
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description: string;
   private expectedAuthMethod: AuthMethod;
   private authServer = new ServerLifecycle();

--- a/src/scenarios/client/elicitation-defaults.ts
+++ b/src/scenarios/client/elicitation-defaults.ts
@@ -11,7 +11,7 @@ import {
   ListToolsRequestSchema,
   ElicitResultSchema
 } from '@modelcontextprotocol/sdk/types.js';
-import type { Scenario, ConformanceCheck, SpecVersion } from '../../types';
+import type { Scenario, ConformanceCheck, DatedSpecVersion } from '../../types';
 import express, { Request, Response } from 'express';
 import { ScenarioUrls } from '../../types';
 import { createRequestLogger } from '../request-logger';
@@ -474,7 +474,7 @@ function createServer(checks: ConformanceCheck[]): {
 
 export class ElicitationClientDefaultsScenario implements Scenario {
   name = 'elicitation-sep1034-client-defaults';
-  specVersions: SpecVersion[] = ['2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-11-25';
   description =
     'Tests client applies default values for omitted elicitation fields (SEP-1034)';
   private app: express.Application | null = null;

--- a/src/scenarios/client/elicitation-defaults.ts
+++ b/src/scenarios/client/elicitation-defaults.ts
@@ -11,7 +11,7 @@ import {
   ListToolsRequestSchema,
   ElicitResultSchema
 } from '@modelcontextprotocol/sdk/types.js';
-import type { Scenario, ConformanceCheck, DatedSpecVersion } from '../../types';
+import type { Scenario, ConformanceCheck } from '../../types';
 import express, { Request, Response } from 'express';
 import { ScenarioUrls } from '../../types';
 import { createRequestLogger } from '../request-logger';
@@ -474,7 +474,7 @@ function createServer(checks: ConformanceCheck[]): {
 
 export class ElicitationClientDefaultsScenario implements Scenario {
   name = 'elicitation-sep1034-client-defaults';
-  introducedIn: DatedSpecVersion = '2025-11-25';
+  readonly source = { introducedIn: '2025-11-25' } as const;
   description =
     'Tests client applies default values for omitted elicitation fields (SEP-1034)';
   private app: express.Application | null = null;

--- a/src/scenarios/client/initialize.ts
+++ b/src/scenarios/client/initialize.ts
@@ -3,7 +3,7 @@ import {
   Scenario,
   ScenarioUrls,
   ConformanceCheck,
-  SpecVersion,
+  DatedSpecVersion,
   LATEST_SPEC_VERSION,
   NEGOTIABLE_PROTOCOL_VERSIONS
 } from '../../types';
@@ -11,7 +11,7 @@ import { clientChecks } from '../../checks/index';
 
 export class InitializeScenario implements Scenario {
   name = 'initialize';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = 'Tests MCP client initialization handshake';
 
   private server: http.Server | null = null;

--- a/src/scenarios/client/initialize.ts
+++ b/src/scenarios/client/initialize.ts
@@ -3,7 +3,6 @@ import {
   Scenario,
   ScenarioUrls,
   ConformanceCheck,
-  DatedSpecVersion,
   LATEST_SPEC_VERSION,
   NEGOTIABLE_PROTOCOL_VERSIONS
 } from '../../types';
@@ -11,7 +10,7 @@ import { clientChecks } from '../../checks/index';
 
 export class InitializeScenario implements Scenario {
   name = 'initialize';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = 'Tests MCP client initialization handshake';
 
   private server: http.Server | null = null;

--- a/src/scenarios/client/sse-retry.ts
+++ b/src/scenarios/client/sse-retry.ts
@@ -8,16 +8,11 @@
  */
 
 import http from 'http';
-import {
-  Scenario,
-  ScenarioUrls,
-  ConformanceCheck,
-  DatedSpecVersion
-} from '../../types.js';
+import { Scenario, ScenarioUrls, ConformanceCheck } from '../../types.js';
 
 export class SSERetryScenario implements Scenario {
   name = 'sse-retry';
-  introducedIn: DatedSpecVersion = '2025-11-25';
+  readonly source = { introducedIn: '2025-11-25' } as const;
   description =
     'Tests that client respects SSE retry field timing and reconnects properly (SEP-1699)';
 

--- a/src/scenarios/client/sse-retry.ts
+++ b/src/scenarios/client/sse-retry.ts
@@ -12,12 +12,12 @@ import {
   Scenario,
   ScenarioUrls,
   ConformanceCheck,
-  SpecVersion
+  DatedSpecVersion
 } from '../../types.js';
 
 export class SSERetryScenario implements Scenario {
   name = 'sse-retry';
-  specVersions: SpecVersion[] = ['2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-11-25';
   description =
     'Tests that client respects SSE retry field timing and reconnects properly (SEP-1699)';
 

--- a/src/scenarios/client/tools_call.ts
+++ b/src/scenarios/client/tools_call.ts
@@ -4,7 +4,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema
 } from '@modelcontextprotocol/sdk/types.js';
-import type { Scenario, ConformanceCheck, SpecVersion } from '../../types';
+import type { Scenario, ConformanceCheck, DatedSpecVersion } from '../../types';
 import express, { Request, Response } from 'express';
 import { ScenarioUrls } from '../../types';
 import { createRequestLogger } from '../request-logger';
@@ -115,7 +115,7 @@ function createServerApp(checks: ConformanceCheck[]): express.Application {
 
 export class ToolsCallScenario implements Scenario {
   name = 'tools_call';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = 'Tests calling tools with various parameter types';
   private app: express.Application | null = null;
   private httpServer: any = null;

--- a/src/scenarios/client/tools_call.ts
+++ b/src/scenarios/client/tools_call.ts
@@ -4,7 +4,7 @@ import {
   CallToolRequestSchema,
   ListToolsRequestSchema
 } from '@modelcontextprotocol/sdk/types.js';
-import type { Scenario, ConformanceCheck, DatedSpecVersion } from '../../types';
+import type { Scenario, ConformanceCheck } from '../../types';
 import express, { Request, Response } from 'express';
 import { ScenarioUrls } from '../../types';
 import { createRequestLogger } from '../request-logger';
@@ -115,7 +115,7 @@ function createServerApp(checks: ConformanceCheck[]): express.Application {
 
 export class ToolsCallScenario implements Scenario {
   name = 'tools_call';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = 'Tests calling tools with various parameter types';
   private app: express.Application | null = null;
   private httpServer: any = null;

--- a/src/scenarios/index.ts
+++ b/src/scenarios/index.ts
@@ -3,10 +3,10 @@ import {
   ClientScenario,
   ClientScenarioForAuthorizationServer,
   SpecVersion,
+  DatedSpecVersion,
   ScenarioSpecTag,
   DATED_SPEC_VERSIONS,
-  DRAFT_PROTOCOL_VERSION,
-  LATEST_SPEC_VERSION
+  DRAFT_PROTOCOL_VERSION
 } from '../types';
 import { InitializeScenario } from './client/initialize';
 import { ToolsCallScenario } from './client/tools_call';
@@ -279,20 +279,27 @@ export function resolveSpecVersion(value: string): SpecVersion {
   process.exit(1);
 }
 
-// The draft version selects everything in the latest dated release plus
-// scenarios tagged draft-only, so SEP authors can run the full suite against an
-// SDK tracking the in-progress spec without retagging core scenarios.
+function versionIndex(
+  v: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION
+): number {
+  return ALL_SPEC_VERSIONS.indexOf(v);
+}
+
+// Extension scenarios are never selected by --spec-version.
 function matchesSpecVersion(
-  scenario: { specVersions: ScenarioSpecTag[] },
+  scenario: {
+    introducedIn: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
+    removedIn?: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
+    extension?: boolean;
+  },
   version: SpecVersion
 ): boolean {
-  if (version === DRAFT_PROTOCOL_VERSION) {
-    return (
-      scenario.specVersions.includes(DRAFT_PROTOCOL_VERSION) ||
-      scenario.specVersions.includes(LATEST_SPEC_VERSION)
-    );
-  }
-  return scenario.specVersions.includes(version);
+  if (scenario.extension) return false;
+  return (
+    versionIndex(scenario.introducedIn) <= versionIndex(version) &&
+    (scenario.removedIn === undefined ||
+      versionIndex(version) < versionIndex(scenario.removedIn))
+  );
 }
 
 export function listScenariosForSpec(version: SpecVersion): string[] {
@@ -318,11 +325,17 @@ export function listClientScenariosForAuthorizationServerForSpec(
 export function getScenarioSpecVersions(
   name: string
 ): ScenarioSpecTag[] | undefined {
-  return (
-    scenarios.get(name)?.specVersions ??
-    clientScenarios.get(name)?.specVersions ??
-    clientScenariosForAuthorizationServer.get(name)?.specVersions
-  );
+  const s =
+    scenarios.get(name) ??
+    clientScenarios.get(name) ??
+    clientScenariosForAuthorizationServer.get(name);
+  if (!s) return undefined;
+  if (s.extension) return ['extension'];
+  const result: ScenarioSpecTag[] = [];
+  for (const v of ALL_SPEC_VERSIONS) {
+    if (matchesSpecVersion(s, v)) result.push(v);
+  }
+  return result;
 }
 
 export type { SpecVersion, ScenarioSpecTag };

--- a/src/scenarios/index.ts
+++ b/src/scenarios/index.ts
@@ -2,6 +2,7 @@ import {
   Scenario,
   ClientScenario,
   ClientScenarioForAuthorizationServer,
+  ScenarioSource,
   SpecVersion,
   DatedSpecVersion,
   ScenarioSpecTag,
@@ -285,32 +286,28 @@ function versionIndex(
   return ALL_SPEC_VERSIONS.indexOf(v);
 }
 
-// Extension scenarios are never selected by --spec-version.
+// Off-timeline sources (extensions etc.) are never selected by --spec-version.
 function matchesSpecVersion(
-  scenario: {
-    introducedIn: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
-    removedIn?: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
-    extension?: boolean;
-  },
+  source: ScenarioSource,
   version: SpecVersion
 ): boolean {
-  if (scenario.extension) return false;
+  if ('extensionId' in source) return false;
   return (
-    versionIndex(scenario.introducedIn) <= versionIndex(version) &&
-    (scenario.removedIn === undefined ||
-      versionIndex(version) < versionIndex(scenario.removedIn))
+    versionIndex(source.introducedIn) <= versionIndex(version) &&
+    (source.removedIn === undefined ||
+      versionIndex(version) < versionIndex(source.removedIn))
   );
 }
 
 export function listScenariosForSpec(version: SpecVersion): string[] {
   return scenariosList
-    .filter((s) => matchesSpecVersion(s, version))
+    .filter((s) => matchesSpecVersion(s.source, version))
     .map((s) => s.name);
 }
 
 export function listClientScenariosForSpec(version: SpecVersion): string[] {
   return allClientScenariosList
-    .filter((s) => matchesSpecVersion(s, version))
+    .filter((s) => matchesSpecVersion(s.source, version))
     .map((s) => s.name);
 }
 
@@ -318,7 +315,7 @@ export function listClientScenariosForAuthorizationServerForSpec(
   version: SpecVersion
 ): string[] {
   return allClientScenariosListForAuthorizationServer
-    .filter((s) => matchesSpecVersion(s, version))
+    .filter((s) => matchesSpecVersion(s.source, version))
     .map((s) => s.name);
 }
 
@@ -330,10 +327,10 @@ export function getScenarioSpecVersions(
     clientScenarios.get(name) ??
     clientScenariosForAuthorizationServer.get(name);
   if (!s) return undefined;
-  if (s.extension) return ['extension'];
+  if ('extensionId' in s.source) return ['extension'];
   const result: ScenarioSpecTag[] = [];
   for (const v of ALL_SPEC_VERSIONS) {
-    if (matchesSpecVersion(s, v)) result.push(v);
+    if (matchesSpecVersion(s.source, v)) result.push(v);
   }
   return result;
 }

--- a/src/scenarios/server/dns-rebinding.ts
+++ b/src/scenarios/server/dns-rebinding.ts
@@ -5,11 +5,7 @@
  * to prevent DNS rebinding attacks. See GHSA-w48q-cv73-mx4w for details.
  */
 
-import {
-  ClientScenario,
-  ConformanceCheck,
-  DatedSpecVersion
-} from '../../types';
+import { ClientScenario, ConformanceCheck } from '../../types';
 import { request } from 'undici';
 
 const SPEC_REFERENCES = [
@@ -89,7 +85,7 @@ async function sendRequestWithHostAndOrigin(
 
 export class DNSRebindingProtectionScenario implements ClientScenario {
   name = 'dns-rebinding-protection';
-  introducedIn: DatedSpecVersion = '2025-11-25';
+  readonly source = { introducedIn: '2025-11-25' } as const;
   description = `Test DNS rebinding protection for localhost servers.
 
 **Scope:** This test applies to localhost MCP servers running without HTTPS and without

--- a/src/scenarios/server/dns-rebinding.ts
+++ b/src/scenarios/server/dns-rebinding.ts
@@ -5,7 +5,11 @@
  * to prevent DNS rebinding attacks. See GHSA-w48q-cv73-mx4w for details.
  */
 
-import { ClientScenario, ConformanceCheck, SpecVersion } from '../../types';
+import {
+  ClientScenario,
+  ConformanceCheck,
+  DatedSpecVersion
+} from '../../types';
 import { request } from 'undici';
 
 const SPEC_REFERENCES = [
@@ -85,7 +89,7 @@ async function sendRequestWithHostAndOrigin(
 
 export class DNSRebindingProtectionScenario implements ClientScenario {
   name = 'dns-rebinding-protection';
-  specVersions: SpecVersion[] = ['2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-11-25';
   description = `Test DNS rebinding protection for localhost servers.
 
 **Scope:** This test applies to localhost MCP servers running without HTTPS and without

--- a/src/scenarios/server/elicitation-defaults.ts
+++ b/src/scenarios/server/elicitation-defaults.ts
@@ -2,17 +2,13 @@
  * SEP-1034: Elicitation default values test scenarios for MCP servers
  */
 
-import {
-  ClientScenario,
-  ConformanceCheck,
-  DatedSpecVersion
-} from '../../types';
+import { ClientScenario, ConformanceCheck } from '../../types';
 import { connectToServer } from './client-helper';
 import { ElicitRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 
 export class ElicitationDefaultsScenario implements ClientScenario {
   name = 'elicitation-sep1034-defaults';
-  introducedIn: DatedSpecVersion = '2025-11-25';
+  readonly source = { introducedIn: '2025-11-25' } as const;
   description = `Test elicitation with default values for all primitive types (SEP-1034).
 
 **Server Implementation Requirements:**

--- a/src/scenarios/server/elicitation-defaults.ts
+++ b/src/scenarios/server/elicitation-defaults.ts
@@ -2,13 +2,17 @@
  * SEP-1034: Elicitation default values test scenarios for MCP servers
  */
 
-import { ClientScenario, ConformanceCheck, SpecVersion } from '../../types';
+import {
+  ClientScenario,
+  ConformanceCheck,
+  DatedSpecVersion
+} from '../../types';
 import { connectToServer } from './client-helper';
 import { ElicitRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 
 export class ElicitationDefaultsScenario implements ClientScenario {
   name = 'elicitation-sep1034-defaults';
-  specVersions: SpecVersion[] = ['2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-11-25';
   description = `Test elicitation with default values for all primitive types (SEP-1034).
 
 **Server Implementation Requirements:**

--- a/src/scenarios/server/elicitation-enums.ts
+++ b/src/scenarios/server/elicitation-enums.ts
@@ -2,17 +2,13 @@
  * SEP-1330: Elicitation enum schema improvements test scenarios for MCP servers
  */
 
-import {
-  ClientScenario,
-  ConformanceCheck,
-  DatedSpecVersion
-} from '../../types';
+import { ClientScenario, ConformanceCheck } from '../../types';
 import { connectToServer } from './client-helper';
 import { ElicitRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 
 export class ElicitationEnumsScenario implements ClientScenario {
   name = 'elicitation-sep1330-enums';
-  introducedIn: DatedSpecVersion = '2025-11-25';
+  readonly source = { introducedIn: '2025-11-25' } as const;
   description = `Test elicitation with enum schema improvements (SEP-1330).
 
 **Server Implementation Requirements:**

--- a/src/scenarios/server/elicitation-enums.ts
+++ b/src/scenarios/server/elicitation-enums.ts
@@ -2,13 +2,17 @@
  * SEP-1330: Elicitation enum schema improvements test scenarios for MCP servers
  */
 
-import { ClientScenario, ConformanceCheck, SpecVersion } from '../../types';
+import {
+  ClientScenario,
+  ConformanceCheck,
+  DatedSpecVersion
+} from '../../types';
 import { connectToServer } from './client-helper';
 import { ElicitRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 
 export class ElicitationEnumsScenario implements ClientScenario {
   name = 'elicitation-sep1330-enums';
-  specVersions: SpecVersion[] = ['2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-11-25';
   description = `Test elicitation with enum schema improvements (SEP-1330).
 
 **Server Implementation Requirements:**

--- a/src/scenarios/server/json-schema-2020-12.ts
+++ b/src/scenarios/server/json-schema-2020-12.ts
@@ -6,11 +6,7 @@
  * or additionalProperties fields.
  */
 
-import {
-  ClientScenario,
-  ConformanceCheck,
-  DatedSpecVersion
-} from '../../types.js';
+import { ClientScenario, ConformanceCheck } from '../../types.js';
 import { connectToServer } from './client-helper.js';
 
 const EXPECTED_TOOL_NAME = 'json_schema_2020_12_tool';
@@ -18,7 +14,7 @@ const EXPECTED_SCHEMA_DIALECT = 'https://json-schema.org/draft/2020-12/schema';
 
 export class JsonSchema2020_12Scenario implements ClientScenario {
   name = 'json-schema-2020-12';
-  introducedIn: DatedSpecVersion = '2025-11-25';
+  readonly source = { introducedIn: '2025-11-25' } as const;
   description = `Validates JSON Schema 2020-12 keyword preservation (SEP-1613).
 
 **Server Implementation Requirements:**

--- a/src/scenarios/server/json-schema-2020-12.ts
+++ b/src/scenarios/server/json-schema-2020-12.ts
@@ -6,7 +6,11 @@
  * or additionalProperties fields.
  */
 
-import { ClientScenario, ConformanceCheck, SpecVersion } from '../../types.js';
+import {
+  ClientScenario,
+  ConformanceCheck,
+  DatedSpecVersion
+} from '../../types.js';
 import { connectToServer } from './client-helper.js';
 
 const EXPECTED_TOOL_NAME = 'json_schema_2020_12_tool';
@@ -14,7 +18,7 @@ const EXPECTED_SCHEMA_DIALECT = 'https://json-schema.org/draft/2020-12/schema';
 
 export class JsonSchema2020_12Scenario implements ClientScenario {
   name = 'json-schema-2020-12';
-  specVersions: SpecVersion[] = ['2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-11-25';
   description = `Validates JSON Schema 2020-12 keyword preservation (SEP-1613).
 
 **Server Implementation Requirements:**

--- a/src/scenarios/server/lifecycle.ts
+++ b/src/scenarios/server/lifecycle.ts
@@ -2,11 +2,7 @@
  * Lifecycle test scenarios for MCP servers
  */
 
-import {
-  ClientScenario,
-  ConformanceCheck,
-  DatedSpecVersion
-} from '../../types';
+import { ClientScenario, ConformanceCheck } from '../../types';
 import { connectToServer } from './client-helper';
 
 const VISIBLE_ASCII_REGEX = /^[\x21-\x7E]+$/;
@@ -20,7 +16,7 @@ const SESSION_SPEC_REFERENCES = [
 
 export class ServerInitializeScenario implements ClientScenario {
   name = 'server-initialize';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test basic server initialization handshake.
 
 **Server Implementation Requirements:**

--- a/src/scenarios/server/lifecycle.ts
+++ b/src/scenarios/server/lifecycle.ts
@@ -2,7 +2,11 @@
  * Lifecycle test scenarios for MCP servers
  */
 
-import { ClientScenario, ConformanceCheck, SpecVersion } from '../../types';
+import {
+  ClientScenario,
+  ConformanceCheck,
+  DatedSpecVersion
+} from '../../types';
 import { connectToServer } from './client-helper';
 
 const VISIBLE_ASCII_REGEX = /^[\x21-\x7E]+$/;
@@ -16,7 +20,7 @@ const SESSION_SPEC_REFERENCES = [
 
 export class ServerInitializeScenario implements ClientScenario {
   name = 'server-initialize';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test basic server initialization handshake.
 
 **Server Implementation Requirements:**

--- a/src/scenarios/server/prompts.ts
+++ b/src/scenarios/server/prompts.ts
@@ -2,12 +2,16 @@
  * Prompts test scenarios for MCP servers
  */
 
-import { ClientScenario, ConformanceCheck, SpecVersion } from '../../types';
+import {
+  ClientScenario,
+  ConformanceCheck,
+  DatedSpecVersion
+} from '../../types';
 import { connectToServer } from './client-helper';
 
 export class PromptsListScenario implements ClientScenario {
   name = 'prompts-list';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test listing available prompts.
 
 **Server Implementation Requirements:**
@@ -88,7 +92,7 @@ export class PromptsListScenario implements ClientScenario {
 
 export class PromptsGetSimpleScenario implements ClientScenario {
   name = 'prompts-get-simple';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test getting a simple prompt without arguments.
 
 **Server Implementation Requirements:**
@@ -173,7 +177,7 @@ Implement a prompt named \`test_simple_prompt\` with no arguments that returns:
 
 export class PromptsGetWithArgsScenario implements ClientScenario {
   name = 'prompts-get-with-args';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test parameterized prompt.
 
 **Server Implementation Requirements:**
@@ -269,7 +273,7 @@ Returns (with args \`{arg1: "hello", arg2: "world"}\`):
 
 export class PromptsGetEmbeddedResourceScenario implements ClientScenario {
   name = 'prompts-get-embedded-resource';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test prompt with embedded resource content.
 
 **Server Implementation Requirements:**
@@ -375,7 +379,7 @@ Returns:
 
 export class PromptsGetWithImageScenario implements ClientScenario {
   name = 'prompts-get-with-image';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test prompt with image content.
 
 **Server Implementation Requirements:**

--- a/src/scenarios/server/prompts.ts
+++ b/src/scenarios/server/prompts.ts
@@ -2,16 +2,12 @@
  * Prompts test scenarios for MCP servers
  */
 
-import {
-  ClientScenario,
-  ConformanceCheck,
-  DatedSpecVersion
-} from '../../types';
+import { ClientScenario, ConformanceCheck } from '../../types';
 import { connectToServer } from './client-helper';
 
 export class PromptsListScenario implements ClientScenario {
   name = 'prompts-list';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test listing available prompts.
 
 **Server Implementation Requirements:**
@@ -92,7 +88,7 @@ export class PromptsListScenario implements ClientScenario {
 
 export class PromptsGetSimpleScenario implements ClientScenario {
   name = 'prompts-get-simple';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test getting a simple prompt without arguments.
 
 **Server Implementation Requirements:**
@@ -177,7 +173,7 @@ Implement a prompt named \`test_simple_prompt\` with no arguments that returns:
 
 export class PromptsGetWithArgsScenario implements ClientScenario {
   name = 'prompts-get-with-args';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test parameterized prompt.
 
 **Server Implementation Requirements:**
@@ -273,7 +269,7 @@ Returns (with args \`{arg1: "hello", arg2: "world"}\`):
 
 export class PromptsGetEmbeddedResourceScenario implements ClientScenario {
   name = 'prompts-get-embedded-resource';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test prompt with embedded resource content.
 
 **Server Implementation Requirements:**
@@ -379,7 +375,7 @@ Returns:
 
 export class PromptsGetWithImageScenario implements ClientScenario {
   name = 'prompts-get-with-image';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test prompt with image content.
 
 **Server Implementation Requirements:**

--- a/src/scenarios/server/resources.ts
+++ b/src/scenarios/server/resources.ts
@@ -5,8 +5,6 @@
 import {
   ClientScenario,
   ConformanceCheck,
-  DatedSpecVersion,
-  SpecVersion,
   DRAFT_PROTOCOL_VERSION
 } from '../../types';
 import { connectToServer } from './client-helper';
@@ -18,7 +16,7 @@ import {
 
 export class ResourcesListScenario implements ClientScenario {
   name = 'resources-list';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test listing available resources.
 
 **Server Implementation Requirements:**
@@ -99,7 +97,7 @@ export class ResourcesListScenario implements ClientScenario {
 
 export class ResourcesReadTextScenario implements ClientScenario {
   name = 'resources-read-text';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test reading text resource.
 
 **Server Implementation Requirements:**
@@ -186,7 +184,7 @@ Implement resource \`test://static-text\` that returns:
 
 export class ResourcesReadBinaryScenario implements ClientScenario {
   name = 'resources-read-binary';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test reading binary resource.
 
 **Server Implementation Requirements:**
@@ -271,7 +269,7 @@ Implement resource \`test://static-binary\` that returns:
 
 export class ResourcesTemplateReadScenario implements ClientScenario {
   name = 'resources-templates-read';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test reading resource from template.
 
 **Server Implementation Requirements:**
@@ -373,7 +371,7 @@ Returns (for \`uri: "test://template/123/data"\`):
 
 export class ResourcesSubscribeScenario implements ClientScenario {
   name = 'resources-subscribe';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test subscribing to resource updates.
 
 **Server Implementation Requirements:**
@@ -444,7 +442,7 @@ Example request:
 
 export class ResourcesNotFoundErrorScenario implements ClientScenario {
   name = 'sep-2164-resource-not-found';
-  introducedIn: SpecVersion = DRAFT_PROTOCOL_VERSION;
+  readonly source = { introducedIn: DRAFT_PROTOCOL_VERSION } as const;
   description = `Test error handling for non-existent resources (SEP-2164).
 
 **Server Implementation Requirements:**
@@ -603,7 +601,7 @@ This scenario does not require the server to register any specific resource — 
 
 export class ResourcesUnsubscribeScenario implements ClientScenario {
   name = 'resources-unsubscribe';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test unsubscribing from resource.
 
 **Server Implementation Requirements:**

--- a/src/scenarios/server/resources.ts
+++ b/src/scenarios/server/resources.ts
@@ -5,6 +5,7 @@
 import {
   ClientScenario,
   ConformanceCheck,
+  DatedSpecVersion,
   SpecVersion,
   DRAFT_PROTOCOL_VERSION
 } from '../../types';
@@ -17,7 +18,7 @@ import {
 
 export class ResourcesListScenario implements ClientScenario {
   name = 'resources-list';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test listing available resources.
 
 **Server Implementation Requirements:**
@@ -98,7 +99,7 @@ export class ResourcesListScenario implements ClientScenario {
 
 export class ResourcesReadTextScenario implements ClientScenario {
   name = 'resources-read-text';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test reading text resource.
 
 **Server Implementation Requirements:**
@@ -185,7 +186,7 @@ Implement resource \`test://static-text\` that returns:
 
 export class ResourcesReadBinaryScenario implements ClientScenario {
   name = 'resources-read-binary';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test reading binary resource.
 
 **Server Implementation Requirements:**
@@ -270,7 +271,7 @@ Implement resource \`test://static-binary\` that returns:
 
 export class ResourcesTemplateReadScenario implements ClientScenario {
   name = 'resources-templates-read';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test reading resource from template.
 
 **Server Implementation Requirements:**
@@ -372,7 +373,7 @@ Returns (for \`uri: "test://template/123/data"\`):
 
 export class ResourcesSubscribeScenario implements ClientScenario {
   name = 'resources-subscribe';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test subscribing to resource updates.
 
 **Server Implementation Requirements:**
@@ -443,7 +444,7 @@ Example request:
 
 export class ResourcesNotFoundErrorScenario implements ClientScenario {
   name = 'sep-2164-resource-not-found';
-  specVersions: SpecVersion[] = [DRAFT_PROTOCOL_VERSION];
+  introducedIn: SpecVersion = DRAFT_PROTOCOL_VERSION;
   description = `Test error handling for non-existent resources (SEP-2164).
 
 **Server Implementation Requirements:**
@@ -602,7 +603,7 @@ This scenario does not require the server to register any specific resource — 
 
 export class ResourcesUnsubscribeScenario implements ClientScenario {
   name = 'resources-unsubscribe';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test unsubscribing from resource.
 
 **Server Implementation Requirements:**

--- a/src/scenarios/server/sse-multiple-streams.ts
+++ b/src/scenarios/server/sse-multiple-streams.ts
@@ -9,18 +9,14 @@
  * Multiple concurrent streams are achieved via POST requests, each getting their own stream.
  */
 
-import {
-  ClientScenario,
-  ConformanceCheck,
-  DatedSpecVersion
-} from '../../types.js';
+import { ClientScenario, ConformanceCheck } from '../../types.js';
 import { EventSourceParserStream } from 'eventsource-parser/stream';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
 export class ServerSSEMultipleStreamsScenario implements ClientScenario {
   name = 'server-sse-multiple-streams';
-  introducedIn: DatedSpecVersion = '2025-11-25';
+  readonly source = { introducedIn: '2025-11-25' } as const;
   description =
     'Test server supports multiple concurrent POST SSE streams (SEP-1699)';
 

--- a/src/scenarios/server/sse-multiple-streams.ts
+++ b/src/scenarios/server/sse-multiple-streams.ts
@@ -9,14 +9,18 @@
  * Multiple concurrent streams are achieved via POST requests, each getting their own stream.
  */
 
-import { ClientScenario, ConformanceCheck, SpecVersion } from '../../types.js';
+import {
+  ClientScenario,
+  ConformanceCheck,
+  DatedSpecVersion
+} from '../../types.js';
 import { EventSourceParserStream } from 'eventsource-parser/stream';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 
 export class ServerSSEMultipleStreamsScenario implements ClientScenario {
   name = 'server-sse-multiple-streams';
-  specVersions: SpecVersion[] = ['2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-11-25';
   description =
     'Test server supports multiple concurrent POST SSE streams (SEP-1699)';
 

--- a/src/scenarios/server/sse-polling.ts
+++ b/src/scenarios/server/sse-polling.ts
@@ -8,11 +8,7 @@
  * - Replaying events when client reconnects with Last-Event-ID
  */
 
-import {
-  ClientScenario,
-  ConformanceCheck,
-  DatedSpecVersion
-} from '../../types.js';
+import { ClientScenario, ConformanceCheck } from '../../types.js';
 import { EventSourceParserStream } from 'eventsource-parser/stream';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
@@ -71,7 +67,7 @@ function createLoggingFetch(checks: ConformanceCheck[]) {
 
 export class ServerSSEPollingScenario implements ClientScenario {
   name = 'server-sse-polling';
-  introducedIn: DatedSpecVersion = '2025-11-25';
+  readonly source = { introducedIn: '2025-11-25' } as const;
   description =
     'Test server SSE polling via test_reconnection tool that closes stream mid-call (SEP-1699)';
 

--- a/src/scenarios/server/sse-polling.ts
+++ b/src/scenarios/server/sse-polling.ts
@@ -8,7 +8,11 @@
  * - Replaying events when client reconnects with Last-Event-ID
  */
 
-import { ClientScenario, ConformanceCheck, SpecVersion } from '../../types.js';
+import {
+  ClientScenario,
+  ConformanceCheck,
+  DatedSpecVersion
+} from '../../types.js';
 import { EventSourceParserStream } from 'eventsource-parser/stream';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
@@ -67,7 +71,7 @@ function createLoggingFetch(checks: ConformanceCheck[]) {
 
 export class ServerSSEPollingScenario implements ClientScenario {
   name = 'server-sse-polling';
-  specVersions: SpecVersion[] = ['2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-11-25';
   description =
     'Test server SSE polling via test_reconnection tool that closes stream mid-call (SEP-1699)';
 

--- a/src/scenarios/server/tools.ts
+++ b/src/scenarios/server/tools.ts
@@ -2,7 +2,11 @@
  * Tools test scenarios for MCP servers
  */
 
-import { ClientScenario, ConformanceCheck, SpecVersion } from '../../types';
+import {
+  ClientScenario,
+  ConformanceCheck,
+  DatedSpecVersion
+} from '../../types';
 import { connectToServer, NotificationCollector } from './client-helper';
 import {
   CallToolResultSchema,
@@ -90,7 +94,7 @@ export function buildToolsNameFormatCheck(
 
 export class ToolsListScenario implements ClientScenario {
   name = 'tools-list';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test listing available tools.
 
 **Server Implementation Requirements:**
@@ -177,7 +181,7 @@ export class ToolsListScenario implements ClientScenario {
 
 export class ToolsCallSimpleTextScenario implements ClientScenario {
   name = 'tools-call-simple-text';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test calling a tool that returns simple text.
 
 **Server Implementation Requirements:**
@@ -262,7 +266,7 @@ Implement tool \`test_simple_text\` with no arguments that returns:
 
 export class ToolsCallImageScenario implements ClientScenario {
   name = 'tools-call-image';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test calling a tool that returns image content.
 
 **Server Implementation Requirements:**
@@ -350,7 +354,7 @@ Implement tool \`test_image_content\` with no arguments that returns:
 
 export class ToolsCallMultipleContentTypesScenario implements ClientScenario {
   name = 'tools-call-mixed-content';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test tool returning multiple content types.
 
 **Server Implementation Requirements:**
@@ -451,7 +455,7 @@ Implement tool \`test_multiple_content_types\` with no arguments that returns:
 
 export class ToolsCallWithLoggingScenario implements ClientScenario {
   name = 'tools-call-with-logging';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test tool that sends log messages during execution.
 
 **Server Implementation Requirements:**
@@ -540,7 +544,7 @@ Implement tool \`test_tool_with_logging\` with no arguments.
 
 export class ToolsCallErrorScenario implements ClientScenario {
   name = 'tools-call-error';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test tool error reporting.
 
 **Server Implementation Requirements:**
@@ -625,7 +629,7 @@ Implement tool \`test_error_handling\` with no arguments.
 
 export class ToolsCallWithProgressScenario implements ClientScenario {
   name = 'tools-call-with-progress';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test tool that reports progress notifications.
 
 **Server Implementation Requirements:**
@@ -745,7 +749,7 @@ If no progress token provided, just execute with delays.
 
 export class ToolsCallSamplingScenario implements ClientScenario {
   name = 'tools-call-sampling';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test tool that requests LLM sampling from client.
 
 **Server Implementation Requirements:**
@@ -873,7 +877,7 @@ Implement tool \`test_sampling\` with argument:
 
 export class ToolsCallElicitationScenario implements ClientScenario {
   name = 'tools-call-elicitation';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test tool that requests user input (elicitation) from client.
 
 **Server Implementation Requirements:**
@@ -1004,7 +1008,7 @@ Implement tool \`test_elicitation\` with argument:
 
 export class ToolsCallAudioScenario implements ClientScenario {
   name = 'tools-call-audio';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test calling a tool that returns audio content.
 
 **Server Implementation Requirements:**
@@ -1099,7 +1103,7 @@ Implement tool \`test_audio_content\` with no arguments that returns:
 
 export class ToolsCallEmbeddedResourceScenario implements ClientScenario {
   name = 'tools-call-embedded-resource';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test calling a tool that returns embedded resource content.
 
 **Server Implementation Requirements:**

--- a/src/scenarios/server/tools.ts
+++ b/src/scenarios/server/tools.ts
@@ -2,11 +2,7 @@
  * Tools test scenarios for MCP servers
  */
 
-import {
-  ClientScenario,
-  ConformanceCheck,
-  DatedSpecVersion
-} from '../../types';
+import { ClientScenario, ConformanceCheck } from '../../types';
 import { connectToServer, NotificationCollector } from './client-helper';
 import {
   CallToolResultSchema,
@@ -94,7 +90,7 @@ export function buildToolsNameFormatCheck(
 
 export class ToolsListScenario implements ClientScenario {
   name = 'tools-list';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test listing available tools.
 
 **Server Implementation Requirements:**
@@ -181,7 +177,7 @@ export class ToolsListScenario implements ClientScenario {
 
 export class ToolsCallSimpleTextScenario implements ClientScenario {
   name = 'tools-call-simple-text';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test calling a tool that returns simple text.
 
 **Server Implementation Requirements:**
@@ -266,7 +262,7 @@ Implement tool \`test_simple_text\` with no arguments that returns:
 
 export class ToolsCallImageScenario implements ClientScenario {
   name = 'tools-call-image';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test calling a tool that returns image content.
 
 **Server Implementation Requirements:**
@@ -354,7 +350,7 @@ Implement tool \`test_image_content\` with no arguments that returns:
 
 export class ToolsCallMultipleContentTypesScenario implements ClientScenario {
   name = 'tools-call-mixed-content';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test tool returning multiple content types.
 
 **Server Implementation Requirements:**
@@ -455,7 +451,7 @@ Implement tool \`test_multiple_content_types\` with no arguments that returns:
 
 export class ToolsCallWithLoggingScenario implements ClientScenario {
   name = 'tools-call-with-logging';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test tool that sends log messages during execution.
 
 **Server Implementation Requirements:**
@@ -544,7 +540,7 @@ Implement tool \`test_tool_with_logging\` with no arguments.
 
 export class ToolsCallErrorScenario implements ClientScenario {
   name = 'tools-call-error';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test tool error reporting.
 
 **Server Implementation Requirements:**
@@ -629,7 +625,7 @@ Implement tool \`test_error_handling\` with no arguments.
 
 export class ToolsCallWithProgressScenario implements ClientScenario {
   name = 'tools-call-with-progress';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test tool that reports progress notifications.
 
 **Server Implementation Requirements:**
@@ -749,7 +745,7 @@ If no progress token provided, just execute with delays.
 
 export class ToolsCallSamplingScenario implements ClientScenario {
   name = 'tools-call-sampling';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test tool that requests LLM sampling from client.
 
 **Server Implementation Requirements:**
@@ -877,7 +873,7 @@ Implement tool \`test_sampling\` with argument:
 
 export class ToolsCallElicitationScenario implements ClientScenario {
   name = 'tools-call-elicitation';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test tool that requests user input (elicitation) from client.
 
 **Server Implementation Requirements:**
@@ -1008,7 +1004,7 @@ Implement tool \`test_elicitation\` with argument:
 
 export class ToolsCallAudioScenario implements ClientScenario {
   name = 'tools-call-audio';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test calling a tool that returns audio content.
 
 **Server Implementation Requirements:**
@@ -1103,7 +1099,7 @@ Implement tool \`test_audio_content\` with no arguments that returns:
 
 export class ToolsCallEmbeddedResourceScenario implements ClientScenario {
   name = 'tools-call-embedded-resource';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test calling a tool that returns embedded resource content.
 
 **Server Implementation Requirements:**

--- a/src/scenarios/server/utils.ts
+++ b/src/scenarios/server/utils.ts
@@ -2,12 +2,16 @@
  * Utilities test scenarios for MCP servers
  */
 
-import { ClientScenario, ConformanceCheck, SpecVersion } from '../../types';
+import {
+  ClientScenario,
+  ConformanceCheck,
+  DatedSpecVersion
+} from '../../types';
 import { connectToServer } from './client-helper';
 
 export class LoggingSetLevelScenario implements ClientScenario {
   name = 'logging-set-level';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test setting logging level.
 
 **Server Implementation Requirements:**
@@ -86,7 +90,7 @@ export class LoggingSetLevelScenario implements ClientScenario {
 
 export class PingScenario implements ClientScenario {
   name = 'ping';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test ping utility for connection health check.
 
 **Server Implementation Requirements:**
@@ -176,7 +180,7 @@ export class PingScenario implements ClientScenario {
 
 export class CompletionCompleteScenario implements ClientScenario {
   name = 'completion-complete';
-  specVersions: SpecVersion[] = ['2025-06-18', '2025-11-25'];
+  introducedIn: DatedSpecVersion = '2025-06-18';
   description = `Test completion endpoint.
 
 **Server Implementation Requirements:**

--- a/src/scenarios/server/utils.ts
+++ b/src/scenarios/server/utils.ts
@@ -2,16 +2,12 @@
  * Utilities test scenarios for MCP servers
  */
 
-import {
-  ClientScenario,
-  ConformanceCheck,
-  DatedSpecVersion
-} from '../../types';
+import { ClientScenario, ConformanceCheck } from '../../types';
 import { connectToServer } from './client-helper';
 
 export class LoggingSetLevelScenario implements ClientScenario {
   name = 'logging-set-level';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test setting logging level.
 
 **Server Implementation Requirements:**
@@ -90,7 +86,7 @@ export class LoggingSetLevelScenario implements ClientScenario {
 
 export class PingScenario implements ClientScenario {
   name = 'ping';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test ping utility for connection health check.
 
 **Server Implementation Requirements:**
@@ -180,7 +176,7 @@ export class PingScenario implements ClientScenario {
 
 export class CompletionCompleteScenario implements ClientScenario {
   name = 'completion-complete';
-  introducedIn: DatedSpecVersion = '2025-06-18';
+  readonly source = { introducedIn: '2025-06-18' } as const;
   description = `Test completion endpoint.
 
 **Server Implementation Requirements:**

--- a/src/scenarios/spec-version.test.ts
+++ b/src/scenarios/spec-version.test.ts
@@ -1,60 +1,23 @@
 import { describe, it, expect } from 'vitest';
 import {
   listScenarios,
-  listClientScenarios,
   listScenariosForSpec,
   listDraftScenarios,
   listExtensionScenarios,
   getScenarioSpecVersions,
   resolveSpecVersion,
   ALL_SPEC_VERSIONS,
-  scenarios,
-  clientScenarios
+  scenarios
 } from './index';
 import {
   DATED_SPEC_VERSIONS,
   DRAFT_PROTOCOL_VERSION,
-  LATEST_SPEC_VERSION,
-  ScenarioSpecTag
+  LATEST_SPEC_VERSION
 } from '../types';
 
-const ALL_SCENARIO_SPEC_TAGS: ScenarioSpecTag[] = [
-  ...ALL_SPEC_VERSIONS,
-  'extension'
-];
-
 describe('specVersions helpers', () => {
-  it('every Scenario has introducedIn', () => {
-    for (const name of listScenarios()) {
-      const s = scenarios.get(name);
-      expect(s, `scenario "${name}" missing from map`).toBeDefined();
-      if (s!.extension) continue;
-      expect(
-        s!.introducedIn,
-        `scenario "${name}" is missing introducedIn`
-      ).toBeDefined();
-      expect(ALL_SCENARIO_SPEC_TAGS).toContain(s!.introducedIn);
-      if (s!.removedIn !== undefined) {
-        expect(ALL_SCENARIO_SPEC_TAGS).toContain(s!.removedIn);
-      }
-    }
-  });
-
-  it('every ClientScenario has introducedIn', () => {
-    for (const name of listClientScenarios()) {
-      const s = clientScenarios.get(name);
-      expect(s, `client scenario "${name}" missing from map`).toBeDefined();
-      if (s!.extension) continue;
-      expect(
-        s!.introducedIn,
-        `client scenario "${name}" is missing introducedIn`
-      ).toBeDefined();
-      expect(ALL_SCENARIO_SPEC_TAGS).toContain(s!.introducedIn);
-      if (s!.removedIn !== undefined) {
-        expect(ALL_SCENARIO_SPEC_TAGS).toContain(s!.removedIn);
-      }
-    }
-  });
+  // The ScenarioSource union (introducedIn XOR extensionId) is enforced by the
+  // type system; no runtime invariant test is needed.
 
   it('listScenariosForSpec returns scenarios whose range covers that version', () => {
     const selected = listScenariosForSpec('2025-06-18');
@@ -70,12 +33,12 @@ describe('specVersions helpers', () => {
       const selected = new Set(listScenariosForSpec(v));
       const vIdx = ALL_SPEC_VERSIONS.indexOf(v);
       for (const name of listScenarios()) {
-        const s = scenarios.get(name)!;
-        if (s.extension || s.removedIn === undefined) continue;
-        if (vIdx >= ALL_SPEC_VERSIONS.indexOf(s.removedIn)) {
+        const src = scenarios.get(name)!.source;
+        if ('extensionId' in src || src.removedIn === undefined) continue;
+        if (vIdx >= ALL_SPEC_VERSIONS.indexOf(src.removedIn)) {
           expect(
             selected.has(name),
-            `scenario "${name}" (removedIn ${s.removedIn}) should not appear in --spec-version ${v}`
+            `scenario "${name}" (removedIn ${src.removedIn}) should not appear in --spec-version ${v}`
           ).toBe(false);
         }
       }

--- a/src/scenarios/spec-version.test.ts
+++ b/src/scenarios/spec-version.test.ts
@@ -7,7 +7,9 @@ import {
   listExtensionScenarios,
   getScenarioSpecVersions,
   resolveSpecVersion,
-  ALL_SPEC_VERSIONS
+  ALL_SPEC_VERSIONS,
+  scenarios,
+  clientScenarios
 } from './index';
 import {
   DATED_SPEC_VERSIONS,
@@ -22,65 +24,71 @@ const ALL_SCENARIO_SPEC_TAGS: ScenarioSpecTag[] = [
 ];
 
 describe('specVersions helpers', () => {
-  it('every Scenario has specVersions', () => {
+  it('every Scenario has introducedIn', () => {
     for (const name of listScenarios()) {
-      const versions = getScenarioSpecVersions(name);
+      const s = scenarios.get(name);
+      expect(s, `scenario "${name}" missing from map`).toBeDefined();
+      if (s!.extension) continue;
       expect(
-        versions,
-        `scenario "${name}" is missing specVersions`
+        s!.introducedIn,
+        `scenario "${name}" is missing introducedIn`
       ).toBeDefined();
-      expect(versions!.length).toBeGreaterThan(0);
-      for (const v of versions!) {
-        expect(ALL_SCENARIO_SPEC_TAGS).toContain(v);
+      expect(ALL_SCENARIO_SPEC_TAGS).toContain(s!.introducedIn);
+      if (s!.removedIn !== undefined) {
+        expect(ALL_SCENARIO_SPEC_TAGS).toContain(s!.removedIn);
       }
     }
   });
 
-  it('every ClientScenario has specVersions', () => {
+  it('every ClientScenario has introducedIn', () => {
     for (const name of listClientScenarios()) {
-      const versions = getScenarioSpecVersions(name);
+      const s = clientScenarios.get(name);
+      expect(s, `client scenario "${name}" missing from map`).toBeDefined();
+      if (s!.extension) continue;
       expect(
-        versions,
-        `client scenario "${name}" is missing specVersions`
+        s!.introducedIn,
+        `client scenario "${name}" is missing introducedIn`
       ).toBeDefined();
-      expect(versions!.length).toBeGreaterThan(0);
-      for (const v of versions!) {
-        expect(ALL_SCENARIO_SPEC_TAGS).toContain(v);
+      expect(ALL_SCENARIO_SPEC_TAGS).toContain(s!.introducedIn);
+      if (s!.removedIn !== undefined) {
+        expect(ALL_SCENARIO_SPEC_TAGS).toContain(s!.removedIn);
       }
     }
   });
 
-  it('listScenariosForSpec returns scenarios that include that version', () => {
-    const scenarios = listScenariosForSpec('2025-06-18');
-    expect(scenarios.length).toBeGreaterThan(0);
-    for (const name of scenarios) {
-      expect(getScenarioSpecVersions(name)).toContain('2025-06-18');
+  it('listScenariosForSpec returns scenarios whose range covers that version', () => {
+    const selected = listScenariosForSpec('2025-06-18');
+    expect(selected.length).toBeGreaterThan(0);
+    for (const name of selected) {
+      const tags = getScenarioSpecVersions(name);
+      expect(tags).toContain('2025-06-18');
+    }
+  });
+
+  it('scenarios with removedIn do not appear in versions at or after the cutoff', () => {
+    for (const v of ALL_SPEC_VERSIONS) {
+      const selected = new Set(listScenariosForSpec(v));
+      const vIdx = ALL_SPEC_VERSIONS.indexOf(v);
+      for (const name of listScenarios()) {
+        const s = scenarios.get(name)!;
+        if (s.extension || s.removedIn === undefined) continue;
+        if (vIdx >= ALL_SPEC_VERSIONS.indexOf(s.removedIn)) {
+          expect(
+            selected.has(name),
+            `scenario "${name}" (removedIn ${s.removedIn}) should not appear in --spec-version ${v}`
+          ).toBe(false);
+        }
+      }
     }
   });
 
   it('2025-11-25 includes scenarios carried forward from 2025-06-18', () => {
     const base = listScenariosForSpec('2025-06-18');
     const current = listScenariosForSpec('2025-11-25');
-    // scenarios tagged with both versions should appear in both lists
     const currentSet = new Set(current);
-    // at least some overlap (carried-forward scenarios)
     const overlap = base.filter((s) => currentSet.has(s));
     expect(overlap.length).toBeGreaterThan(0);
-    // current should have more total (new 2025-11-25-only scenarios)
     expect(current.length).toBeGreaterThan(overlap.length);
-  });
-
-  it('2025-11-25 does not include 2025-03-26-only scenarios', () => {
-    const backcompat = listScenariosForSpec('2025-03-26');
-    const current = listScenariosForSpec('2025-11-25');
-    const currentSet = new Set(current);
-    // backcompat-only scenarios should not appear in 2025-11-25
-    for (const name of backcompat) {
-      const versions = getScenarioSpecVersions(name)!;
-      if (!versions.includes('2025-11-25')) {
-        expect(currentSet.has(name)).toBe(false);
-      }
-    }
   });
 
   it('the draft spec version is a superset of the latest dated release', () => {
@@ -94,14 +102,14 @@ describe('specVersions helpers', () => {
     }
   });
 
-  it('draft-tagged scenarios are not also tagged with a dated version', () => {
+  it('draft-introduced scenarios are not matched by any dated spec version', () => {
     for (const name of listDraftScenarios()) {
-      const versions = getScenarioSpecVersions(name)!;
       for (const dated of DATED_SPEC_VERSIONS) {
+        const selected = new Set(listScenariosForSpec(dated));
         expect(
-          versions,
-          `scenario "${name}" is tagged with both DRAFT_PROTOCOL_VERSION and '${dated}'`
-        ).not.toContain(dated);
+          selected.has(name),
+          `draft scenario "${name}" should not appear in --spec-version ${dated}`
+        ).toBe(false);
       }
     }
   });

--- a/src/schemas/context.ts
+++ b/src/schemas/context.ts
@@ -24,7 +24,7 @@ export const ClientConformanceContextSchema = z.discriminatedUnion('name', [
     client_secret: z.string()
   }),
   z.object({
-    name: z.literal('auth/cross-app-access-complete-flow'),
+    name: z.literal('auth/enterprise-managed-auth'),
     client_id: z.string(),
     client_secret: z.string(),
     idp_client_id: z.string(),

--- a/src/schemas/context.ts
+++ b/src/schemas/context.ts
@@ -24,7 +24,7 @@ export const ClientConformanceContextSchema = z.discriminatedUnion('name', [
     client_secret: z.string()
   }),
   z.object({
-    name: z.literal('auth/enterprise-managed-auth'),
+    name: z.literal('auth/enterprise-managed-authorization'),
     client_id: z.string(),
     client_secret: z.string(),
     idp_client_id: z.string(),

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,10 +58,14 @@ export type SpecVersion = DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
 // (selectable via --suite extensions, never via --spec-version). See #256.
 export type ScenarioSpecTag = SpecVersion | 'extension';
 
-/** Known protocol extensions that this suite has scenarios for. */
+/**
+ * Known protocol extensions that this suite has scenarios for.
+ * Values are SEP-2133 extension identifiers (the keys used in
+ * `capabilities.extensions`).
+ */
 export const EXTENSION_IDS = [
-  'client-credentials',
-  'enterprise-managed-auth'
+  'io.modelcontextprotocol/oauth-client-credentials',
+  'io.modelcontextprotocol/enterprise-managed-authorization'
 ] as const;
 export type ExtensionId = (typeof EXTENSION_IDS)[number];
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -71,7 +71,9 @@ export interface ScenarioUrls {
 export interface Scenario {
   name: string;
   description: string;
-  specVersions: ScenarioSpecTag[];
+  introducedIn: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
+  removedIn?: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
+  extension?: boolean;
   /**
    * If true, a non-zero client exit code is expected and will not cause the test to fail.
    * Use this for scenarios where the client is expected to error (e.g., rejecting invalid auth).
@@ -85,13 +87,17 @@ export interface Scenario {
 export interface ClientScenario {
   name: string;
   description: string;
-  specVersions: ScenarioSpecTag[];
+  introducedIn: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
+  removedIn?: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
+  extension?: boolean;
   run(serverUrl: string): Promise<ConformanceCheck[]>;
 }
 
 export interface ClientScenarioForAuthorizationServer {
   name: string;
   description: string;
-  specVersions: ScenarioSpecTag[];
+  introducedIn: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
+  removedIn?: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
+  extension?: boolean;
   run(serverUrl: string): Promise<ConformanceCheck[]>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,25 @@ export type SpecVersion = DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
 // (selectable via --suite extensions, never via --spec-version). See #256.
 export type ScenarioSpecTag = SpecVersion | 'extension';
 
+/** Known protocol extensions that this suite has scenarios for. */
+export const EXTENSION_IDS = [
+  'client-credentials',
+  'enterprise-managed-auth'
+] as const;
+export type ExtensionId = (typeof EXTENSION_IDS)[number];
+
+/**
+ * Where a scenario's requirement comes from. Either the dated spec timeline
+ * (`introducedIn`/`removedIn`) or a named protocol extension that lives
+ * outside the spec release cycle. Extensions never match `--spec-version`.
+ */
+export type ScenarioSource =
+  | {
+      introducedIn: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
+      removedIn?: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
+    }
+  | { extensionId: ExtensionId };
+
 export interface ScenarioUrls {
   serverUrl: string;
   authUrl?: string;
@@ -71,9 +90,7 @@ export interface ScenarioUrls {
 export interface Scenario {
   name: string;
   description: string;
-  introducedIn: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
-  removedIn?: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
-  extension?: boolean;
+  source: ScenarioSource;
   /**
    * If true, a non-zero client exit code is expected and will not cause the test to fail.
    * Use this for scenarios where the client is expected to error (e.g., rejecting invalid auth).
@@ -87,17 +104,13 @@ export interface Scenario {
 export interface ClientScenario {
   name: string;
   description: string;
-  introducedIn: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
-  removedIn?: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
-  extension?: boolean;
+  source: ScenarioSource;
   run(serverUrl: string): Promise<ConformanceCheck[]>;
 }
 
 export interface ClientScenarioForAuthorizationServer {
   name: string;
   description: string;
-  introducedIn: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
-  removedIn?: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
-  extension?: boolean;
+  source: ScenarioSource;
   run(serverUrl: string): Promise<ConformanceCheck[]>;
 }


### PR DESCRIPTION
Closes #256. Follows up on #255.

## Problem

Scenarios were tagged with an explicit list of every spec version they apply to:

```ts
specVersions = ['2025-06-18', '2025-11-25']
```

Every new spec release means touching every carried-forward scenario, and there's no way to express removal — a SEP that tightens or removes a requirement can't mark an old scenario as "no longer valid in draft". Extension scenarios were tagged `['extension']`, which doesn't fit a version list at all.

## Design

Replace the flat `specVersions` list with a nested `source` union:

```ts
export const EXTENSION_IDS = [
  'io.modelcontextprotocol/oauth-client-credentials',
  'io.modelcontextprotocol/enterprise-managed-authorization'
] as const;
export type ExtensionId = (typeof EXTENSION_IDS)[number];

export type ScenarioSource =
  | { introducedIn: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
      removedIn?: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION }
  | { extensionId: ExtensionId };

export interface Scenario {
  ...
  source: ScenarioSource;
}
```

A scenario either sits on the spec timeline (`introducedIn` / optional `removedIn`) **or** names a protocol extension by its SEP-2133 identifier. The compiler enforces the XOR; no runtime invariant test needed. The union lives inside a property so `Scenario` stays a plain interface and `class implements Scenario` keeps working — TypeScript won't let a class `implements` a union directly.

`matchesSpecVersion` becomes a range check gated on the union:

```ts
if ('extensionId' in source) return false;
return versionIndex(source.introducedIn) <= versionIndex(version)
    && (source.removedIn === undefined || versionIndex(version) < versionIndex(source.removedIn));
```

`getScenarioSpecVersions()` reconstructs the legacy `ScenarioSpecTag[]` for tier-check; `ALL_SPEC_VERSIONS`, `resolveSpecVersion`, and all `--spec-version` CLI semantics are unchanged.

## Migration

| Old `specVersions` | New `source` |
|---|---|
| `['2025-03-26', '2025-06-18', '2025-11-25']` | `{ introducedIn: '2025-03-26' }` |
| `['2025-06-18', '2025-11-25']` | `{ introducedIn: '2025-06-18' }` |
| `['2025-11-25']` | `{ introducedIn: '2025-11-25' }` |
| `['2025-03-26']` | `{ introducedIn: '2025-03-26', removedIn: '2025-06-18' }` |
| `[DRAFT_PROTOCOL_VERSION]` | `{ introducedIn: DRAFT_PROTOCOL_VERSION }` |
| `['extension']` | `{ extensionId: 'io.modelcontextprotocol/...' }` |

## `cross-app-access` → `enterprise-managed-authorization` rename

Aligns with the canonical extension name from `docs/extensions/client-matrix.mdx`. Renamed: file, class `EnterpriseManagedAuthorizationScenario`, slug `auth/enterprise-managed-authorization`, `context.ts` schema literal, and the `everything-client.ts` runner.

## Testing

```
$ npx vitest run
Test Files  9 passed (9)
     Tests  116 passed (116)
```

(118 → 116: the two "every Scenario has introducedIn" runtime tests are now compiler-enforced and removed.) Build, type-check, and lint clean. `node dist/index.js list` shows `auth/enterprise-managed-authorization [extension]`.