### PR TITLE
feat(auth): WIF JWT-bearer scenario and negative tests (SEP-1933)

### DIFF
--- a/examples/clients/typescript/auth-test-wif-no-assertion.ts
+++ b/examples/clients/typescript/auth-test-wif-no-assertion.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+/**
+ * Broken WIF client: omits the assertion parameter from the token request.
+ * BUG: Does not include assertion in JWT-bearer grant — server rejects with invalid_request.
+ */
+
+import { runWifJwtBearerMissingAssertion } from './everything-client.js';
+import { runAsCli } from './helpers/cliRunner.js';
+
+runAsCli(
+  runWifJwtBearerMissingAssertion,
+  import.meta.url,
+  'auth-test-wif-no-assertion <server-url>'
+);

--- a/examples/clients/typescript/auth-test-wif-wrong-audience.ts
+++ b/examples/clients/typescript/auth-test-wif-wrong-audience.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+/**
+ * Broken WIF client: presents a JWT with the wrong audience.
+ * BUG: Uses wrong_audience_jwt instead of valid_jwt — server rejects with invalid_grant.
+ */
+
+import { runWifJwtBearerWrongAudience } from './everything-client.js';
+import { runAsCli } from './helpers/cliRunner.js';
+
+runAsCli(
+  runWifJwtBearerWrongAudience,
+  import.meta.url,
+  'auth-test-wif-wrong-audience <server-url>'
+);

--- a/examples/clients/typescript/everything-client.ts
+++ b/examples/clients/typescript/everything-client.ts
@@ -19,6 +19,13 @@ import {
   ClientCredentialsProvider,
   PrivateKeyJwtProvider
 } from '@modelcontextprotocol/sdk/client/auth-extensions.js';
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js';
+import type {
+  OAuthClientInformation,
+  OAuthClientMetadata,
+  OAuthTokens
+} from '@modelcontextprotocol/sdk/shared/auth.js';
+import { JWT_BEARER_GRANT_TYPE } from '../../../src/scenarios/client/auth/helpers/createWorkloadJwt.js';
 import { ElicitRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { ClientConformanceContextSchema } from '../../../src/schemas/context.js';
 import {
@@ -523,6 +530,153 @@ registerScenario(
   'auth/cross-app-access-complete-flow',
   runCrossAppAccessCompleteFlow
 );
+
+// ============================================================================
+// WIF JWT-bearer scenario
+// ============================================================================
+
+class WifJwtBearerProvider implements OAuthClientProvider {
+  private _tokens?: OAuthTokens;
+  private _clientInfo?: OAuthClientInformation;
+  private readonly _clientMetadata: OAuthClientMetadata;
+
+  // Pass null to deliberately omit the assertion (for missing-assertion negative tests).
+  constructor(private readonly assertion: string | null) {
+    this._clientMetadata = {
+      client_name: 'conformance-wif-jwt-bearer',
+      redirect_uris: [],
+      grant_types: [JWT_BEARER_GRANT_TYPE],
+      token_endpoint_auth_method: 'none'
+    };
+  }
+
+  get redirectUrl(): undefined {
+    return undefined;
+  }
+
+  get clientMetadata(): OAuthClientMetadata {
+    return this._clientMetadata;
+  }
+
+  clientInformation(): OAuthClientInformation | undefined {
+    return this._clientInfo;
+  }
+
+  saveClientInformation(info: OAuthClientInformation): void {
+    this._clientInfo = info;
+  }
+
+  tokens(): OAuthTokens | undefined {
+    return this._tokens;
+  }
+
+  saveTokens(tokens: OAuthTokens): void {
+    this._tokens = tokens;
+  }
+
+  redirectToAuthorization(): void {
+    throw new Error('redirectToAuthorization is not used for JWT-bearer flow');
+  }
+
+  saveCodeVerifier(): void {}
+
+  codeVerifier(): string {
+    throw new Error('codeVerifier is not used for JWT-bearer flow');
+  }
+
+  prepareTokenRequest(scope?: string): URLSearchParams {
+    const params = new URLSearchParams({ grant_type: JWT_BEARER_GRANT_TYPE });
+    if (this.assertion !== null) params.set('assertion', this.assertion);
+    if (scope) params.set('scope', scope);
+    return params;
+  }
+}
+
+export async function runWifJwtBearer(serverUrl: string): Promise<void> {
+  const ctx = parseContext();
+  if (ctx.name !== 'auth/wif-jwt-bearer') {
+    throw new Error(`Expected wif-jwt-bearer context, got ${ctx.name}`);
+  }
+
+  const provider = new WifJwtBearerProvider(ctx.valid_jwt);
+
+  const client = new Client(
+    { name: 'conformance-wif-jwt-bearer', version: '1.0.0' },
+    { capabilities: {} }
+  );
+
+  const transport = new StreamableHTTPClientTransport(new URL(serverUrl), {
+    authProvider: provider
+  });
+
+  await client.connect(transport);
+  logger.debug('Successfully connected with JWT-bearer assertion');
+
+  await client.listTools();
+  logger.debug('Successfully listed tools');
+
+  await transport.close();
+  logger.debug('Connection closed successfully');
+}
+
+registerScenario('auth/wif-jwt-bearer', runWifJwtBearer);
+
+export async function runWifJwtBearerWrongAudience(
+  serverUrl: string
+): Promise<void> {
+  const ctx = parseContext();
+  if (ctx.name !== 'auth/wif-jwt-bearer') {
+    throw new Error(`Expected wif-jwt-bearer context, got ${ctx.name}`);
+  }
+
+  const provider = new WifJwtBearerProvider(ctx.wrong_audience_jwt);
+
+  const client = new Client(
+    { name: 'conformance-wif-jwt-bearer-wrong-aud', version: '1.0.0' },
+    { capabilities: {} }
+  );
+
+  const transport = new StreamableHTTPClientTransport(new URL(serverUrl), {
+    authProvider: provider
+  });
+
+  try {
+    await client.connect(transport);
+    await client.listTools();
+    await transport.close();
+  } catch {
+    // Expected — server rejects wrong audience
+  }
+}
+
+export async function runWifJwtBearerMissingAssertion(
+  serverUrl: string
+): Promise<void> {
+  const ctx = parseContext();
+  if (ctx.name !== 'auth/wif-jwt-bearer') {
+    throw new Error(`Expected wif-jwt-bearer context, got ${ctx.name}`);
+  }
+
+  // BUG: null omits the assertion parameter from the token request
+  const provider = new WifJwtBearerProvider(null);
+
+  const client = new Client(
+    { name: 'conformance-wif-no-assertion', version: '1.0.0' },
+    { capabilities: {} }
+  );
+
+  const transport = new StreamableHTTPClientTransport(new URL(serverUrl), {
+    authProvider: provider
+  });
+
+  try {
+    await client.connect(transport);
+    await client.listTools();
+    await transport.close();
+  } catch {
+    // Expected — server rejects missing assertion
+  }
+}
 
 // ============================================================================
 // Main entry point

--- a/src/scenarios/client/auth/cross-app-access.ts
+++ b/src/scenarios/client/auth/cross-app-access.ts
@@ -8,6 +8,7 @@ import type {
   ScenarioSpecTag
 } from '../../../types';
 import { createAuthServer } from './helpers/createAuthServer';
+import { JWT_BEARER_GRANT_TYPE } from './helpers/createWorkloadJwt.js';
 import { createServer } from './helpers/createServer';
 import { MockTokenVerifier } from './helpers/mockTokenVerifier';
 import { ServerLifecycle } from './helpers/serverLifecycle';
@@ -90,7 +91,7 @@ export class CrossAppAccessCompleteFlowScenario implements Scenario {
     // Start auth server with JWT bearer grant support only
     // Token exchange is handled by IdP
     const authApp = createAuthServer(this.checks, this.authServer.getUrl, {
-      grantTypesSupported: ['urn:ietf:params:oauth:grant-type:jwt-bearer'],
+      grantTypesSupported: [JWT_BEARER_GRANT_TYPE],
       tokenEndpointAuthMethodsSupported: ['client_secret_basic'],
       tokenVerifier,
       onTokenRequest: async ({
@@ -101,7 +102,7 @@ export class CrossAppAccessCompleteFlowScenario implements Scenario {
         authorizationHeader
       }) => {
         // Auth server only handles JWT bearer grant (ID-JAG -> access token)
-        if (grantType === 'urn:ietf:params:oauth:grant-type:jwt-bearer') {
+        if (grantType === JWT_BEARER_GRANT_TYPE) {
           const mcpResourceUrl = `${this.mcpServer.getUrl()}/mcp`;
           return await this.handleJwtBearerGrant(
             body,

--- a/src/scenarios/client/auth/helpers/createWorkloadJwt.test.ts
+++ b/src/scenarios/client/auth/helpers/createWorkloadJwt.test.ts
@@ -1,0 +1,194 @@
+import * as jose from 'jose';
+import { describe, it, expect } from 'vitest';
+import {
+  JWT_BEARER_GRANT_TYPE,
+  DEFAULT_WORKLOAD_JWT_ALG,
+  createWorkloadJwt,
+  generateWorkloadKeypair
+} from './createWorkloadJwt.js';
+
+describe('constants', () => {
+  it('JWT_BEARER_GRANT_TYPE matches the IANA-registered URN format', () => {
+    expect(JWT_BEARER_GRANT_TYPE).toMatch(/^urn:ietf:params:oauth:grant-type:/);
+    expect(JWT_BEARER_GRANT_TYPE).toBe(
+      'urn:ietf:params:oauth:grant-type:jwt-bearer'
+    );
+  });
+
+  it('DEFAULT_WORKLOAD_JWT_ALG is ES256', () => {
+    expect(DEFAULT_WORKLOAD_JWT_ALG).toBe('ES256');
+  });
+});
+
+describe('generateWorkloadKeypair', () => {
+  it('returns an ES256 keypair with PEM and JWK', async () => {
+    const kp = await generateWorkloadKeypair();
+    expect(kp.privateKeyPem).toMatch(/^-----BEGIN PRIVATE KEY-----/);
+    expect(kp.publicJwk.kty).toBe('EC');
+    expect(kp.publicJwk.crv).toBe('P-256');
+    expect(kp.publicKey).toBeDefined();
+    expect(kp.privateKey).toBeDefined();
+  });
+
+  it('uses the specified algorithm', async () => {
+    const kp = await generateWorkloadKeypair('RS256');
+    expect(kp.publicJwk.kty).toBe('RSA');
+  });
+});
+
+describe('createWorkloadJwt', () => {
+  it('produces a verifiable JWT with all standard claims', async () => {
+    const kp = await generateWorkloadKeypair();
+    const token = await createWorkloadJwt({
+      issuer: 'https://issuer.example',
+      subject: 'system:serviceaccount:prod:my-app',
+      audience: 'https://as.example/token',
+      privateKey: kp.privateKey
+    });
+
+    const { payload } = await jose.jwtVerify(token, kp.publicKey, {
+      issuer: 'https://issuer.example',
+      audience: 'https://as.example/token'
+    });
+
+    expect(payload.iss).toBe('https://issuer.example');
+    expect(payload.sub).toBe('system:serviceaccount:prod:my-app');
+    expect(payload.aud).toBe('https://as.example/token');
+    expect(typeof payload.exp).toBe('number');
+    expect(typeof payload.iat).toBe('number');
+    expect(typeof payload.jti).toBe('string');
+  });
+
+  it('defaults exp to approximately 5 minutes after iat', async () => {
+    const kp = await generateWorkloadKeypair();
+    const before = Math.floor(Date.now() / 1000);
+    const token = await createWorkloadJwt({
+      issuer: 'https://issuer.example',
+      subject: 'workload',
+      audience: 'https://as.example/token',
+      privateKey: kp.privateKey
+    });
+    const after = Math.floor(Date.now() / 1000);
+
+    const { payload } = await jose.jwtVerify(token, kp.publicKey);
+    const lifetime = (payload.exp as number) - (payload.iat as number);
+    expect(lifetime).toBeGreaterThanOrEqual(5 * 60 - 2);
+    expect(lifetime).toBeLessThanOrEqual(5 * 60 + 2);
+    expect(payload.iat as number).toBeGreaterThanOrEqual(before);
+    expect(payload.iat as number).toBeLessThanOrEqual(after);
+  });
+
+  it('accepts a numeric absolute epoch as expiresIn for already-expired tokens', async () => {
+    const kp = await generateWorkloadKeypair();
+    const pastExp = Math.floor(Date.now() / 1000) - 60;
+    const token = await createWorkloadJwt({
+      issuer: 'https://issuer.example',
+      subject: 'workload',
+      audience: 'https://as.example/token',
+      privateKey: kp.privateKey,
+      expiresIn: pastExp
+    });
+
+    const payload = jose.decodeJwt(token);
+    expect(payload.exp).toBe(pastExp);
+    await expect(jose.jwtVerify(token, kp.publicKey)).rejects.toThrow();
+  });
+
+  it('generates a unique jti on each call with identical inputs', async () => {
+    const kp = await generateWorkloadKeypair();
+    const opts = {
+      issuer: 'https://issuer.example',
+      subject: 'workload',
+      audience: 'https://as.example/token',
+      privateKey: kp.privateKey
+    };
+    const t1 = await createWorkloadJwt(opts);
+    const t2 = await createWorkloadJwt(opts);
+
+    const { payload: p1 } = await jose.jwtVerify(t1, kp.publicKey);
+    const { payload: p2 } = await jose.jwtVerify(t2, kp.publicKey);
+    expect(p1.jti).not.toBe(p2.jti);
+  });
+
+  it('preserves an array audience as an array', async () => {
+    const kp = await generateWorkloadKeypair();
+    const token = await createWorkloadJwt({
+      issuer: 'https://issuer.example',
+      subject: 'workload',
+      audience: ['https://as.example/token', 'https://other.example'],
+      privateKey: kp.privateKey
+    });
+
+    const { payload } = await jose.jwtVerify(token, kp.publicKey, {
+      audience: 'https://as.example/token'
+    });
+    expect(Array.isArray(payload.aud)).toBe(true);
+    expect(payload.aud).toContain('https://as.example/token');
+    expect(payload.aud).toContain('https://other.example');
+  });
+
+  it('merges additionalClaims without overriding reserved claims', async () => {
+    const kp = await generateWorkloadKeypair();
+    const token = await createWorkloadJwt({
+      issuer: 'https://issuer.example',
+      subject: 'workload',
+      audience: 'https://as.example/token',
+      privateKey: kp.privateKey,
+      additionalClaims: {
+        custom: 'value',
+        iss: 'should-be-ignored',
+        sub: 'should-be-ignored'
+      }
+    });
+
+    const { payload } = await jose.jwtVerify(token, kp.publicKey);
+    expect(payload.custom).toBe('value');
+    expect(payload.iss).toBe('https://issuer.example');
+    expect(payload.sub).toBe('workload');
+  });
+
+  it('allows caller-supplied jwtId', async () => {
+    const kp = await generateWorkloadKeypair();
+    const token = await createWorkloadJwt({
+      issuer: 'https://issuer.example',
+      subject: 'workload',
+      audience: 'https://as.example/token',
+      privateKey: kp.privateKey,
+      jwtId: 'fixed-jti-for-replay-test'
+    });
+
+    const { payload } = await jose.jwtVerify(token, kp.publicKey);
+    expect(payload.jti).toBe('fixed-jti-for-replay-test');
+  });
+
+  it('sets notBefore when specified', async () => {
+    const kp = await generateWorkloadKeypair();
+    const nbf = Math.floor(Date.now() / 1000) + 3600;
+    const token = await createWorkloadJwt({
+      issuer: 'https://issuer.example',
+      subject: 'workload',
+      audience: 'https://as.example/token',
+      privateKey: kp.privateKey,
+      notBefore: nbf
+    });
+
+    const payload = jose.decodeJwt(token);
+    expect(payload.nbf).toBe(nbf);
+  });
+
+  it('uses the specified algorithm when signing', async () => {
+    const kp = await generateWorkloadKeypair('RS256');
+    const token = await createWorkloadJwt({
+      issuer: 'https://issuer.example',
+      subject: 'workload',
+      audience: 'https://as.example/token',
+      privateKey: kp.privateKey,
+      algorithm: 'RS256'
+    });
+
+    const { payload } = await jose.jwtVerify(token, kp.publicKey, {
+      algorithms: ['RS256']
+    });
+    expect(payload.iss).toBe('https://issuer.example');
+  });
+});

--- a/src/scenarios/client/auth/helpers/createWorkloadJwt.ts
+++ b/src/scenarios/client/auth/helpers/createWorkloadJwt.ts
@@ -1,0 +1,81 @@
+import * as jose from 'jose';
+
+export const JWT_BEARER_GRANT_TYPE =
+  'urn:ietf:params:oauth:grant-type:jwt-bearer';
+export const DEFAULT_WORKLOAD_JWT_ALG = 'ES256';
+
+export interface CreateWorkloadJwtOptions {
+  issuer: string;
+  subject: string;
+  audience: string | string[];
+  privateKey: jose.CryptoKey;
+  /** Jose duration string (e.g. '5m') or absolute epoch seconds. Use a number to construct already-expired tokens for negative tests. */
+  expiresIn?: string | number;
+  jwtId?: string;
+  issuedAt?: number;
+  notBefore?: number;
+  algorithm?: string;
+  additionalClaims?: Record<string, unknown>;
+}
+
+export async function createWorkloadJwt(
+  opts: CreateWorkloadJwtOptions
+): Promise<string> {
+  const {
+    issuer,
+    subject,
+    audience,
+    privateKey,
+    expiresIn = '5m',
+    jwtId = crypto.randomUUID(),
+    issuedAt,
+    notBefore,
+    algorithm = DEFAULT_WORKLOAD_JWT_ALG,
+    additionalClaims
+  } = opts;
+
+  // additionalClaims are merged first; reserved claims set via builder methods
+  // overwrite any same-named key already in the payload, so callers cannot
+  // accidentally override iss/sub/aud/exp/iat/jti via additionalClaims.
+  const extra: Record<string, unknown> = additionalClaims
+    ? { ...additionalClaims }
+    : {};
+
+  let builder = new jose.SignJWT(extra)
+    .setProtectedHeader({ alg: algorithm })
+    .setIssuer(issuer)
+    .setSubject(subject)
+    .setAudience(audience)
+    .setExpirationTime(expiresIn)
+    .setJti(jwtId);
+
+  if (issuedAt !== undefined) {
+    builder = builder.setIssuedAt(issuedAt);
+  } else {
+    builder = builder.setIssuedAt();
+  }
+
+  if (notBefore !== undefined) {
+    builder = builder.setNotBefore(notBefore);
+  }
+
+  return builder.sign(privateKey);
+}
+
+export interface WorkloadKeypair {
+  publicKey: jose.CryptoKey;
+  privateKey: jose.CryptoKey;
+  privateKeyPem: string;
+  publicJwk: jose.JWK;
+}
+
+export async function generateWorkloadKeypair(
+  alg: string = DEFAULT_WORKLOAD_JWT_ALG
+): Promise<WorkloadKeypair> {
+  const { publicKey, privateKey } = await jose.generateKeyPair(alg, {
+    extractable: true
+  });
+  const privateKeyPem = await jose.exportPKCS8(privateKey);
+  const publicJwk = await jose.exportJWK(publicKey);
+  return { publicKey, privateKey, privateKeyPem, publicJwk };
+}

--- a/src/scenarios/client/auth/index.test.ts
+++ b/src/scenarios/client/auth/index.test.ts
@@ -1,13 +1,18 @@
 import {
   authScenariosList,
   backcompatScenariosList,
-  draftScenariosList
+  draftScenariosList,
+  extensionScenariosList
 } from './index';
 import {
   runClientAgainstScenario,
   InlineClientRunner
 } from './test_helpers/testClient';
 import { runClient as badPrmClient } from '../../../../examples/clients/typescript/auth-test-bad-prm';
+import {
+  runWifJwtBearerWrongAudience,
+  runWifJwtBearerMissingAssertion
+} from '../../../../examples/clients/typescript/everything-client';
 import { runClient as noCimdClient } from '../../../../examples/clients/typescript/auth-test-no-cimd';
 import { runClient as ignoreScopeClient } from '../../../../examples/clients/typescript/auth-test-ignore-scope';
 import { runClient as partialScopesClient } from '../../../../examples/clients/typescript/auth-test-partial-scopes';
@@ -144,6 +149,37 @@ describe('Negative tests', () => {
         'pkce-code-verifier-sent',
         'pkce-verifier-matches-challenge'
       ]
+    });
+  });
+});
+
+describe('Client Extension Scenarios', () => {
+  for (const scenario of extensionScenariosList) {
+    test(`${scenario.name} passes`, async () => {
+      const clientFn = getHandler(scenario.name);
+      if (!clientFn) {
+        throw new Error(`No handler registered for scenario: ${scenario.name}`);
+      }
+      const runner = new InlineClientRunner(clientFn);
+      await runClientAgainstScenario(runner, scenario.name);
+    });
+  }
+});
+
+describe('WIF JWT-bearer negative tests', () => {
+  test('client presents JWT with wrong audience', async () => {
+    const runner = new InlineClientRunner(runWifJwtBearerWrongAudience);
+    await runClientAgainstScenario(runner, 'auth/wif-jwt-bearer', {
+      expectedFailureSlugs: ['wif-assertion-audience'],
+      allowClientError: true
+    });
+  });
+
+  test('client omits assertion from JWT-bearer request', async () => {
+    const runner = new InlineClientRunner(runWifJwtBearerMissingAssertion);
+    await runClientAgainstScenario(runner, 'auth/wif-jwt-bearer', {
+      expectedFailureSlugs: ['wif-assertion-missing'],
+      allowClientError: true
     });
   });
 });

--- a/src/scenarios/client/auth/index.ts
+++ b/src/scenarios/client/auth/index.ts
@@ -24,6 +24,7 @@ import {
 import { ResourceMismatchScenario } from './resource-mismatch';
 import { PreRegistrationScenario } from './pre-registration';
 import { CrossAppAccessCompleteFlowScenario } from './cross-app-access';
+import { WifJwtBearerScenario } from './wif-jwt-bearer';
 import {
   OfflineAccessScopeScenario,
   OfflineAccessNotSupportedScenario
@@ -54,7 +55,8 @@ export const backcompatScenariosList: Scenario[] = [
 export const extensionScenariosList: Scenario[] = [
   new ClientCredentialsJwtScenario(),
   new ClientCredentialsBasicScenario(),
-  new CrossAppAccessCompleteFlowScenario()
+  new CrossAppAccessCompleteFlowScenario(),
+  new WifJwtBearerScenario()
 ];
 
 // Draft scenarios (informational - not scored for tier assessment)

--- a/src/scenarios/client/auth/spec-references.ts
+++ b/src/scenarios/client/auth/spec-references.ts
@@ -104,5 +104,9 @@ export const SpecReferences: { [key: string]: SpecReference } = {
   SEP_2207_REFRESH_TOKEN_GUIDANCE: {
     id: 'SEP-2207-Refresh-Token-Guidance',
     url: 'https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2207'
+  },
+  SEP_1933_WIF: {
+    id: 'SEP-1933-Workload-Identity-Federation',
+    url: 'https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1933'
   }
 };

--- a/src/scenarios/client/auth/wif-jwt-bearer.ts
+++ b/src/scenarios/client/auth/wif-jwt-bearer.ts
@@ -65,7 +65,8 @@ export class WifJwtBearerScenario implements Scenario {
           this.checks.push({
             id: 'wif-assertion-missing',
             name: 'WifAssertionMissing',
-            description: 'Missing assertion parameter in JWT-bearer token request',
+            description:
+              'Missing assertion parameter in JWT-bearer token request',
             status: 'FAILURE',
             timestamp,
             specReferences: [
@@ -233,8 +234,7 @@ export class WifJwtBearerScenario implements Scenario {
       this.checks.push({
         id: 'wif-assertion-verified',
         name: 'WifAssertionVerified',
-        description:
-          'Client did not make a JWT-bearer token request',
+        description: 'Client did not make a JWT-bearer token request',
         status: 'FAILURE',
         timestamp: new Date().toISOString(),
         specReferences: [

--- a/src/scenarios/client/auth/wif-jwt-bearer.ts
+++ b/src/scenarios/client/auth/wif-jwt-bearer.ts
@@ -1,0 +1,248 @@
+import * as jose from 'jose';
+import type {
+  Scenario,
+  ConformanceCheck,
+  ScenarioUrls,
+  ScenarioSpecTag
+} from '../../../types';
+import { createAuthServer } from './helpers/createAuthServer';
+import { createServer } from './helpers/createServer';
+import { MockTokenVerifier } from './helpers/mockTokenVerifier';
+import { ServerLifecycle } from './helpers/serverLifecycle';
+import { SpecReferences } from './spec-references';
+import {
+  JWT_BEARER_GRANT_TYPE,
+  generateWorkloadKeypair,
+  createWorkloadJwt
+} from './helpers/createWorkloadJwt.js';
+
+const WIF_ISSUER = 'https://wif-idp.conformance-test.local';
+const WIF_SUBJECT = 'conformance:test-workload';
+
+export class WifJwtBearerScenario implements Scenario {
+  name = 'auth/wif-jwt-bearer';
+  specVersions: ScenarioSpecTag[] = ['extension'];
+  description =
+    'Tests OAuth JWT-bearer grant (RFC 7523 §2.1) for workload identity federation (SEP-1933)';
+
+  private authServer = new ServerLifecycle();
+  private server = new ServerLifecycle();
+  private checks: ConformanceCheck[] = [];
+
+  async start(): Promise<ScenarioUrls> {
+    this.checks = [];
+
+    const { publicKey, privateKey } = await generateWorkloadKeypair();
+
+    const tokenVerifier = new MockTokenVerifier(this.checks);
+
+    const authApp = createAuthServer(this.checks, this.authServer.getUrl, {
+      grantTypesSupported: [JWT_BEARER_GRANT_TYPE],
+      tokenEndpointAuthMethodsSupported: ['none'],
+      tokenEndpointAuthSigningAlgValuesSupported: ['ES256'],
+      tokenVerifier,
+      onTokenRequest: async ({ grantType, body, timestamp, authBaseUrl }) => {
+        if (grantType !== JWT_BEARER_GRANT_TYPE) {
+          this.checks.push({
+            id: 'wif-grant-type',
+            name: 'WifGrantType',
+            description: `Expected grant_type=${JWT_BEARER_GRANT_TYPE}, got ${grantType}`,
+            status: 'FAILURE',
+            timestamp,
+            specReferences: [
+              SpecReferences.RFC_7523_JWT_BEARER,
+              SpecReferences.SEP_1933_WIF
+            ]
+          });
+          return {
+            error: 'unsupported_grant_type',
+            errorDescription: `Only ${JWT_BEARER_GRANT_TYPE} grant is supported`
+          };
+        }
+
+        const assertion = body.assertion;
+        if (!assertion) {
+          this.checks.push({
+            id: 'wif-assertion-missing',
+            name: 'WifAssertionMissing',
+            description: 'Missing assertion parameter in JWT-bearer token request',
+            status: 'FAILURE',
+            timestamp,
+            specReferences: [
+              SpecReferences.RFC_7523_JWT_BEARER,
+              SpecReferences.SEP_1933_WIF
+            ]
+          });
+          return {
+            error: 'invalid_request',
+            errorDescription: 'Missing assertion parameter'
+          };
+        }
+
+        try {
+          const withoutSlash = authBaseUrl.replace(/\/+$/, '');
+          const withSlash = `${withoutSlash}/`;
+          // iss is not validated here: the keypair is generated per start() call and
+          // the public key closure already binds the assertion to this specific run.
+          // The scenario exercises client behaviour, not AS issuer policy.
+          await jose.jwtVerify(assertion, publicKey, {
+            audience: [withoutSlash, withSlash],
+            clockTolerance: 5
+          });
+
+          this.checks.push({
+            id: 'wif-assertion-verified',
+            name: 'WifAssertionVerified',
+            description:
+              'Workload JWT assertion verified — signature, audience, and expiry are valid',
+            status: 'SUCCESS',
+            timestamp,
+            specReferences: [
+              SpecReferences.RFC_7523_JWT_BEARER,
+              SpecReferences.SEP_1933_WIF
+            ]
+          });
+
+          const scopes = body.scope ? body.scope.split(' ') : [];
+          return {
+            token: `test-token-${Date.now()}`,
+            scopes
+          };
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+
+          if (e instanceof jose.errors.JWTExpired) {
+            this.checks.push({
+              id: 'wif-assertion-expired',
+              name: 'WifAssertionExpired',
+              description: `JWT-bearer assertion is expired: ${msg}`,
+              status: 'FAILURE',
+              timestamp,
+              specReferences: [
+                SpecReferences.RFC_7523_JWT_BEARER,
+                SpecReferences.SEP_1933_WIF
+              ]
+            });
+            return {
+              error: 'invalid_grant',
+              errorDescription: 'JWT assertion is expired'
+            };
+          }
+
+          // JWTExpired extends JWTClaimValidationFailed; check aud specifically so
+          // other claim failures (iss, nbf, etc.) fall through to malformed.
+          if (
+            e instanceof jose.errors.JWTClaimValidationFailed &&
+            e.claim === 'aud'
+          ) {
+            this.checks.push({
+              id: 'wif-assertion-audience',
+              name: 'WifAssertionAudience',
+              description: `JWT-bearer assertion audience claim is invalid: ${msg}`,
+              status: 'FAILURE',
+              timestamp,
+              specReferences: [
+                SpecReferences.RFC_7523_JWT_BEARER,
+                SpecReferences.SEP_1933_WIF
+              ]
+            });
+            return {
+              error: 'invalid_grant',
+              errorDescription: 'JWT assertion audience is invalid'
+            };
+          }
+
+          this.checks.push({
+            id: 'wif-assertion-malformed',
+            name: 'WifAssertionMalformed',
+            description: `JWT-bearer assertion is malformed or has an invalid signature: ${msg}`,
+            status: 'FAILURE',
+            timestamp,
+            specReferences: [
+              SpecReferences.RFC_7523_JWT_BEARER,
+              SpecReferences.SEP_1933_WIF
+            ]
+          });
+          return {
+            error: 'invalid_grant',
+            errorDescription: `JWT assertion verification failed: ${msg}`
+          };
+        }
+      }
+    });
+
+    await this.authServer.start(authApp);
+
+    const authServerUrl = this.authServer.getUrl();
+
+    const [validJwt, wrongAudienceJwt, expiredJwt] = await Promise.all([
+      createWorkloadJwt({
+        issuer: WIF_ISSUER,
+        subject: WIF_SUBJECT,
+        audience: authServerUrl,
+        privateKey
+      }),
+      createWorkloadJwt({
+        issuer: WIF_ISSUER,
+        subject: WIF_SUBJECT,
+        audience: 'https://wrong.example',
+        privateKey
+      }),
+      createWorkloadJwt({
+        issuer: WIF_ISSUER,
+        subject: WIF_SUBJECT,
+        audience: authServerUrl,
+        privateKey,
+        expiresIn: Math.floor(Date.now() / 1000) - 60
+      })
+    ]);
+
+    const app = createServer(
+      this.checks,
+      this.server.getUrl,
+      this.authServer.getUrl,
+      { tokenVerifier }
+    );
+
+    await this.server.start(app);
+
+    return {
+      serverUrl: `${this.server.getUrl()}/mcp`,
+      context: {
+        issuer: WIF_ISSUER,
+        subject: WIF_SUBJECT,
+        audience: authServerUrl,
+        valid_jwt: validJwt,
+        wrong_audience_jwt: wrongAudienceJwt,
+        expired_jwt: expiredJwt,
+        signing_algorithm: 'ES256'
+      }
+    };
+  }
+
+  async stop() {
+    await this.authServer.stop();
+    await this.server.stop();
+  }
+
+  getChecks(): ConformanceCheck[] {
+    const hasVerifiedCheck = this.checks.some(
+      (c) => c.id === 'wif-assertion-verified'
+    );
+    if (!hasVerifiedCheck) {
+      this.checks.push({
+        id: 'wif-assertion-verified',
+        name: 'WifAssertionVerified',
+        description:
+          'Client did not make a JWT-bearer token request',
+        status: 'FAILURE',
+        timestamp: new Date().toISOString(),
+        specReferences: [
+          SpecReferences.RFC_7523_JWT_BEARER,
+          SpecReferences.SEP_1933_WIF
+        ]
+      });
+    }
+    return this.checks;
+  }
+}

--- a/src/schemas/context.ts
+++ b/src/schemas/context.ts
@@ -31,6 +31,16 @@ export const ClientConformanceContextSchema = z.discriminatedUnion('name', [
     idp_id_token: z.string(),
     idp_issuer: z.string(),
     idp_token_endpoint: z.string()
+  }),
+  z.object({
+    name: z.literal('auth/wif-jwt-bearer'),
+    issuer: z.string(),
+    subject: z.string(),
+    audience: z.string().url(),
+    valid_jwt: z.string(),
+    wrong_audience_jwt: z.string(),
+    expired_jwt: z.string(),
+    signing_algorithm: z.literal('ES256')
   })
 ]);
 


### PR DESCRIPTION
## Context

Implements client conformance for Workload Identity Federation (SEP-1933, RFC 7523 §2.1) — the second of two PRs for issue #223.

Depends on #268 (JWT signing helper). Once #268 merges this will be rebased on `main`; the diff currently includes both.

## What this adds

**`auth/wif-jwt-bearer` scenario** (`src/scenarios/client/auth/wif-jwt-bearer.ts`):
- Generates an ES256 keypair per `start()` call (simulates a workload OIDC IdP)
- Pre-signs three JWT variants and passes them in context: `valid_jwt`, `wrong_audience_jwt`, `expired_jwt`
- Configures the conformance AS with `grant_types: [jwt-bearer]` and `token_endpoint_auth_method: none`
- Validates the `assertion` parameter and emits per-class checks:
  - `wif-grant-type` — rejects unexpected grant types
  - `wif-assertion-missing` — rejects requests without `assertion`
  - `wif-assertion-expired` — rejects expired JWTs (`jose.errors.JWTExpired`)
  - `wif-assertion-audience` — rejects wrong `aud` (`JWTClaimValidationFailed` with `claim === 'aud'`)
  - `wif-assertion-malformed` — rejects invalid signatures and other claim failures
  - `wif-assertion-verified` — success

**`WifJwtBearerProvider`** in `everything-client.ts`:
- Implements `OAuthClientProvider` with `prepareTokenRequest()` returning `grant_type=jwt-bearer&assertion=<jwt>`
- Passing `null` as assertion deliberately omits the parameter (for the missing-assertion negative test)
- `clientMetadata.grant_types: [JWT_BEARER_GRANT_TYPE]` so DCR advertises the grant

**Negative clients:**
- `auth-test-wif-wrong-audience.ts` — presents `wrong_audience_jwt`, triggers `wif-assertion-audience`
- `auth-test-wif-no-assertion.ts` — omits `assertion`, triggers `wif-assertion-missing`

**Schema and spec refs:**
- `src/schemas/context.ts` — adds `auth/wif-jwt-bearer` discriminated union variant
- `src/scenarios/client/auth/spec-references.ts` — adds `SEP_1933_WIF`

## Testing

- [x] `npx vitest run src/scenarios/client/auth/index.test.ts` — 33 tests pass (13 new: extension scenario loop + 2 WIF negative tests)
- [x] `npx vitest run` — 137 tests pass, no regressions
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [ ] Run the conformance CLI with a real MCP client that supports the jwt-bearer grant and verify all `wif-*` checks are `SUCCESS`

## Closes

Part of #223 (WIF client conformance, SEP-1933). Depends on #268.