### PR TITLE
SEP-837: application_type check in DCR registration

### DIFF
--- a/examples/clients/typescript/auth-test-no-application-type.ts
+++ b/examples/clients/typescript/auth-test-no-application-type.ts
@@ -1,0 +1,44 @@
+/**
+ * Negative client for SEP-837: registers via DCR WITHOUT application_type.
+ * Expected to trigger sep-837-application-type-present = FAILURE.
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {
+  withOAuthRetryWithProvider,
+  handle401
+} from './helpers/withOAuthRetry';
+import { ConformanceOAuthProvider } from './helpers/ConformanceOAuthProvider';
+import { runAsCli } from './helpers/cliRunner';
+
+export async function runClient(serverUrl: string): Promise<void> {
+  const provider = new ConformanceOAuthProvider(
+    'http://localhost:3000/callback',
+    {
+      client_name: 'auth-test-no-application-type',
+      redirect_uris: ['http://localhost:3000/callback']
+      // application_type intentionally omitted
+    }
+  );
+  const oauthFetch = withOAuthRetryWithProvider(
+    provider,
+    new URL(serverUrl),
+    handle401
+  )(fetch);
+  const client = new Client(
+    { name: 'auth-test-no-application-type', version: '1.0.0' },
+    { capabilities: {} }
+  );
+  const transport = new StreamableHTTPClientTransport(new URL(serverUrl), {
+    fetch: oauthFetch
+  });
+  await client.connect(transport);
+  await client.listTools();
+  await transport.close();
+}
+
+runAsCli(
+  runClient,
+  import.meta.url,
+  'auth-test-no-application-type <server-url>'
+);

--- a/examples/clients/typescript/everything-client.ts
+++ b/examples/clients/typescript/everything-client.ts
@@ -284,7 +284,8 @@ async function runAuthMigrationClient(serverUrl: string): Promise<void> {
     'http://localhost:3000/callback',
     {
       client_name: 'auth-migration-client',
-      redirect_uris: ['http://localhost:3000/callback']
+      redirect_uris: ['http://localhost:3000/callback'],
+      application_type: 'native'
     }
   );
 

--- a/examples/clients/typescript/helpers/ConformanceOAuthProvider.ts
+++ b/examples/clients/typescript/helpers/ConformanceOAuthProvider.ts
@@ -6,6 +6,16 @@ import {
   OAuthTokens
 } from '@modelcontextprotocol/sdk/shared/auth.js';
 
+/**
+ * SEP-837 adds `application_type` to DCR; the SDK's OAuthClientMetadataSchema
+ * doesn't include it yet. The SDK spreads clientMetadata verbatim into the
+ * /register POST body, so widening the type here is sufficient to get the
+ * field on the wire. Drop this once the SDK schema is updated.
+ */
+type ConformanceClientMetadata = OAuthClientMetadata & {
+  application_type?: 'native' | 'web';
+};
+
 export class ConformanceOAuthProvider implements OAuthClientProvider {
   private _clientInformation?: OAuthClientInformationFull;
   private _tokens?: OAuthTokens;
@@ -17,7 +27,7 @@ export class ConformanceOAuthProvider implements OAuthClientProvider {
 
   constructor(
     private readonly _redirectUrl: string | URL,
-    private readonly _clientMetadata: OAuthClientMetadata,
+    private readonly _clientMetadata: ConformanceClientMetadata,
     private readonly _clientMetadataUrl?: string | URL
   ) {}
 
@@ -25,7 +35,7 @@ export class ConformanceOAuthProvider implements OAuthClientProvider {
     return this._redirectUrl;
   }
 
-  get clientMetadata(): OAuthClientMetadata {
+  get clientMetadata(): ConformanceClientMetadata {
     return this._clientMetadata;
   }
 

--- a/examples/clients/typescript/helpers/withOAuthRetry.ts
+++ b/examples/clients/typescript/helpers/withOAuthRetry.ts
@@ -70,7 +70,10 @@ export const withOAuthRetry = (
     'http://localhost:3000/callback',
     {
       client_name: clientName,
-      redirect_uris: ['http://localhost:3000/callback']
+      redirect_uris: ['http://localhost:3000/callback'],
+      // SEP-837: the conformance example clients are CLI tools, i.e. native
+      // applications under the OIDC client-type taxonomy.
+      application_type: 'native'
     },
     clientMetadataUrl
   );

--- a/src/scenarios/client/auth/helpers/createAuthServer.ts
+++ b/src/scenarios/client/auth/helpers/createAuthServer.ts
@@ -386,6 +386,25 @@ export function createAuthServer(
       }
     });
 
+    // SEP-837: clients MUST specify an appropriate application_type during DCR.
+    // The harness can't know the client's real class (native vs web), so this
+    // checks presence + that the value is one of the two OIDC-defined values.
+    const appType = req.body.application_type;
+    const validAppType = appType === 'native' || appType === 'web';
+    checks.push({
+      id: 'sep-837-application-type-present',
+      name: 'DCR application_type specified',
+      description: validAppType
+        ? `Client specified application_type "${appType}" during Dynamic Client Registration`
+        : appType === undefined
+          ? 'Client MUST specify an appropriate application_type during Dynamic Client Registration (SEP-837); field was omitted'
+          : `Client MUST specify an appropriate application_type during Dynamic Client Registration (SEP-837); got "${appType}", expected "native" or "web"`,
+      status: validAppType ? 'SUCCESS' : 'FAILURE',
+      timestamp: new Date().toISOString(),
+      specReferences: [SpecReferences.MCP_DCR],
+      details: { application_type: appType ?? '(omitted)' }
+    });
+
     res.status(201).json({
       client_id: clientId,
       ...(clientSecret && { client_secret: clientSecret }),

--- a/src/scenarios/client/auth/index.test.ts
+++ b/src/scenarios/client/auth/index.test.ts
@@ -15,6 +15,7 @@ import { runClient as ignore403Client } from '../../../../examples/clients/types
 import { runClient as noRetryLimitClient } from '../../../../examples/clients/typescript/auth-test-no-retry-limit';
 import { runClient as noPkceClient } from '../../../../examples/clients/typescript/auth-test-no-pkce';
 import { runClient as reuseCredsClient } from '../../../../examples/clients/typescript/auth-test-reuse-credentials';
+import { runClient as noAppTypeClient } from '../../../../examples/clients/typescript/auth-test-no-application-type';
 import { getHandler } from '../../../../examples/clients/typescript/everything-client';
 import { setLogLevel } from '../../../../examples/clients/typescript/helpers/logger';
 
@@ -153,6 +154,13 @@ describe('Negative tests', () => {
         ]
       }
     );
+  });
+
+  test('client omits application_type during DCR (SEP-837)', async () => {
+    const runner = new InlineClientRunner(noAppTypeClient);
+    await runClientAgainstScenario(runner, 'auth/metadata-default', {
+      expectedFailureSlugs: ['sep-837-application-type-present']
+    });
   });
 
   test('client does not use PKCE', async () => {

--- a/src/seps/sep-837.yaml
+++ b/src/seps/sep-837.yaml
@@ -1,0 +1,14 @@
+sep: 837
+spec_url: https://modelcontextprotocol.io/specification/draft/basic/authorization#application-type-and-redirect-uri-constraints
+requirements:
+  - check: sep-837-application-type-present
+    text: 'MCP clients MUST specify an appropriate application_type during Dynamic Client Registration.'
+
+  - text: 'Native applications (desktop applications, mobile apps, CLI tools, and locally-hosted web applications accessed via localhost) SHOULD use application_type: "native".'
+    excluded: 'harness cannot determine the client-under-test application class (native vs web) out-of-band; only presence and value validity are wire-observable'
+  - text: 'Web applications (remote browser-based applications served from a non-local host) SHOULD use application_type: "web".'
+    excluded: 'harness cannot determine the client-under-test application class (native vs web) out-of-band; only presence and value validity are wire-observable'
+  - text: 'MCP clients MUST be prepared to handle registration failures due to redirect URI constraints when authorization servers implement OIDC.'
+    excluded: 'robustness requirement with no defined wire-level success criterion'
+  - text: 'When a registration request is rejected, clients SHOULD surface a meaningful error to the user or developer.'
+    excluded: 'UI/DX behavior, not protocol-observable'


### PR DESCRIPTION
Closes #283.

Adds `sep-837-application-type-present` per [SEP-837](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/837): clients **MUST** specify an appropriate `application_type` during Dynamic Client Registration. The harness can't know the client's real class (native vs web) so the check asserts presence + that the value is one of the two OIDC-defined values.

**What changed**
- `src/seps/sep-837.yaml`: 1 `check:`, 4 `excluded:` (class-specific SHOULDs unobservable; UI/robustness)
- Check added in the shared `createAuthServer` `/register` handler so it fires in every DCR-using auth scenario — no new scenario per the fewer-scenarios rule
- Passing example: `withOAuthRetry` now sets `application_type: 'native'` (the conformance example clients are CLI tools)
- Negative: `auth-test-no-application-type.ts` (omits the field) + vitest case

**Output** — `node dist/index.js client --scenario auth/metadata-default`

| client | result |
|---|---|
| `everything-client` | 16/16, 0 failed — `sep-837-application-type-present` SUCCESS ("native") |
| `auth-test-no-application-type` | 14/15, **1 failed** — `sep-837-application-type-present` FAILURE |

`npm test`: auth suite 28/28; lefthook pre-push 127/127.