### PR TITLE
ci(traceability): enable corepack for the SDK build

### DIFF
--- a/.github/workflows/traceability.yml
+++ b/.github/workflows/traceability.yml
@@ -42,6 +42,10 @@ jobs:
           node-version: 24
           cache: npm
 
+      # The SDK's own build (e.g. typescript-sdk uses `pnpm install && pnpm run
+      # build:all`) needs pnpm on PATH; corepack provides it.
+      - run: corepack enable
+
       - run: npm ci
       - run: npm run build
 


### PR DESCRIPTION
The traceability refresh workflow failed on first dispatch with `pnpm: not found` — the reference SDK's build (`pnpm install && pnpm run build:all` for typescript-sdk) needs pnpm on PATH. Add `corepack enable` to the `run` job.

Run that surfaced it: https://github.com/modelcontextprotocol/conformance/actions/runs/26126324504