### PR TITLE
ci(traceability): tolerate SDK conformance failures in the refresh run

### DIFF
--- a/.github/workflows/traceability.yml
+++ b/.github/workflows/traceability.yml
@@ -52,9 +52,12 @@ jobs:
       - name: Run conformance suites against the reference SDK
         # `sdk` requires --mode client|server; run both into the same results dir
         # (the second reuses the cached checkout + build via --skip-build).
+        # `|| true`: the manifest only needs the emitted check IDs (written
+        # regardless of pass/fail), so SDK conformance failures must not fail
+        # this step. The "no results produced" guard below is the real safety net.
         run: |
-          node dist/index.js sdk "$SDK_REF" --mode client --suite all -o results
-          node dist/index.js sdk "$SDK_REF" --mode server --suite all --skip-build -o results
+          node dist/index.js sdk "$SDK_REF" --mode client --suite all -o results || true
+          node dist/index.js sdk "$SDK_REF" --mode server --suite all --skip-build -o results || true
 
       - name: Fail if no results were produced
         run: |


### PR DESCRIPTION
Second issue surfaced by dispatching the workflow: the corepack fix (#289) let the SDK build, and the suites ran (323 passed, 7 failed) — but `sdk` exits non-zero on conformance failures not in the SDK's baseline, which failed the run step.

The traceability manifest only needs the **emitted check IDs** (written per-scenario regardless of pass/fail), so SDK conformance failures must not fail the refresh. Add `|| true` to both invocations; the existing 'no results produced' guard remains the real safety net.

Run that surfaced it: https://github.com/modelcontextprotocol/conformance/actions/runs/26128036288