### PR TITLE
fix: unsupported header takes precedence over header mismatch

### DIFF
--- a/src/scenarios/server/stateless.ts
+++ b/src/scenarios/server/stateless.ts
@@ -403,7 +403,7 @@ export class ServerStatelessScenario implements ClientScenario {
     const responseAbsent = await sendRpc(
       'server/discover',
       { _meta: headerMismatchMeta },
-      { 'MCP-Protocol-Version': 'mismatch.version' },
+      { 'MCP-Protocol-Version': DRAFT_PROTOCOL_VERSION },
       302
     ).catch(() => null);
     const resAbsent: any = responseAbsent?.res ?? null;


### PR DESCRIPTION
The `sep-2575-http-server-header-mismatch-400` should check with a supported header and mismatch protocol version in `_meta`.

According to the SEP, 
```
* Requirement: This header is MANDATORY. Servers should reject requests with a missing or unsupported version.
* This header MUST match the value provided in the Request as specified below.
```
hence, unsupported header takes precedence over header mismatch. In order to run this check, we must provide a supported header version with a mismatch `_meta.protocolVersion` value.