### PR TITLE
chore: add SEP-2207 requirement-traceability YAML (OIDC refresh tokens)

### DIFF
--- a/src/seps/sep-2207.yaml
+++ b/src/seps/sep-2207.yaml
@@ -1,0 +1,12 @@
+sep: 2207
+spec_url: https://modelcontextprotocol.io/specification/draft/basic/authorization#refresh-tokens
+requirements:
+  - check: sep-2207-client-metadata-grant-types
+    text: 'MCP Clients that desire refresh tokens SHOULD include `refresh_token` in their `grant_types` client metadata'
+  - check: sep-2207-server-no-offline-access
+    text: 'MCP Servers (Protected Resources) SHOULD NOT include `offline_access` in `WWW-Authenticate` scope or Protected Resource Metadata `scopes_supported`, as refresh tokens are not a resource requirement'
+
+  - text: 'MCP Clients that desire refresh tokens MUST keep refresh tokens confidential in transit and storage as specified in OAuth 2.1 Section 4.3'
+    excluded: 'Confidentiality of refresh tokens in storage is client-internal state, and in-transit (TLS) confidentiality is not exercised by the harness over localhost HTTP; not protocol-observable'
+  - text: 'MCP Clients that desire refresh tokens MUST NOT assume refresh tokens will be issued; the AS retains discretion'
+    excluded: 'A client "assuming" refresh tokens will be issued is mental-state; only manifests as general authorization-flow completion, which other checks already cover; not directly protocol-observable'


### PR DESCRIPTION
Adds the SEP-2484 requirement-traceability file for [SEP-2207: OIDC-flavored refresh token guidance](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2207), mapping each normative sentence from the new `## Refresh Tokens` section of `authorization.mdx` to a check ID or an exclusion reason.

## Requirements

**`check:` rows (2)**
- `sep-2207-client-metadata-grant-types` — Clients SHOULD include `refresh_token` in `grant_types` client metadata. Already implemented in `src/scenarios/client/auth/offline-access.ts` (from #166); the YAML check ID matches.
- `sep-2207-server-no-offline-access` — Servers SHOULD NOT include `offline_access` in `WWW-Authenticate` scope or PRM `scopes_supported`. **Not yet implemented** — the server suite has no PRM/WWW-Authenticate scenario, so this needs a new server-side scenario (follow-up).

**`excluded:` rows (2)**
- Clients MUST keep refresh tokens confidential in transit/storage — storage is client-internal state; in-transit (TLS) confidentiality isn't exercised by the harness over localhost HTTP. Not protocol-observable.
- Clients MUST NOT assume refresh tokens will be issued — mental-state phrasing; only manifests as general flow completion, already covered elsewhere. Not directly observable.

**Skipped:** the "Clients MAY add `offline_access` to scope" sentence is MAY-level, so it gets no traceability row (the scenario's INFO-level `offline-access-requested` check stays as-is).

Severity classification follows the spec text per `AGENTS.md`.