### PR TITLE
SEP-2106: traceability YAML + JSON Schema 2020-12 conformance checks

### DIFF
--- a/examples/clients/typescript/everything-client.ts
+++ b/examples/clients/typescript/everything-client.ts
@@ -93,6 +93,12 @@ async function runBasicClient(serverUrl: string): Promise<void> {
 
 registerScenarios(['initialize', 'tools-call'], runBasicClient);
 
+// SEP-2106: json-schema-ref-no-deref advertises a tool whose inputSchema
+// contains a network-URI $ref. A conformant client lists tools normally and
+// simply never fetches that URI, so the basic connect+listTools flow is the
+// correct behavior here.
+registerScenario('json-schema-ref-no-deref', runBasicClient);
+
 // ============================================================================
 // request-metadata scenario (SEP-2575)
 // ============================================================================

--- a/examples/servers/typescript/everything-server.ts
+++ b/examples/servers/typescript/everything-server.ts
@@ -123,6 +123,8 @@ const JSON_SCHEMA_2020_12_INPUT_SCHEMA = {
   type: 'object' as const,
   $defs: {
     address: {
+      // SEP-2106: reference keyword ($anchor) must be preserved
+      $anchor: 'addressDef',
       type: 'object',
       properties: {
         street: { type: 'string' },
@@ -132,8 +134,25 @@ const JSON_SCHEMA_2020_12_INPUT_SCHEMA = {
   },
   properties: {
     name: { type: 'string' },
-    address: { $ref: '#/$defs/address' }
+    address: { $ref: '#/$defs/address' },
+    contactMethod: { type: 'string', enum: ['phone', 'email'] },
+    phone: { type: 'string' },
+    email: { type: 'string' }
   },
+  // SEP-2106: the full JSON Schema 2020-12 vocabulary is permitted in
+  // inputSchema (alongside the required root `type: "object"`). These keywords
+  // exercise that SDKs preserve them through tools/list rather than stripping
+  // them down to properties/required.
+  //
+  // Composition keywords (allOf / anyOf):
+  allOf: [{ anyOf: [{ required: ['phone'] }, { required: ['email'] }] }],
+  // Conditional keywords (if / then / else):
+  if: {
+    properties: { contactMethod: { const: 'phone' } },
+    required: ['contactMethod']
+  },
+  then: { required: ['phone'] },
+  else: { required: ['email'] },
   additionalProperties: false
 };
 

--- a/examples/servers/typescript/sep-2106-stripped-schema.ts
+++ b/examples/servers/typescript/sep-2106-stripped-schema.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+/**
+ * SEP-2106 Negative Test Server
+ *
+ * Advertises `json_schema_2020_12_tool` but strips its inputSchema down to a
+ * bare `type: "object"` with simple properties — dropping the JSON Schema
+ * 2020-12 vocabulary (no $schema, $defs, additionalProperties, composition
+ * (allOf/anyOf), conditional (if/then/else), or $anchor keywords).
+ *
+ * The json-schema-2020-12 scenario should emit FAILURE for the SEP-2106
+ * composition / conditional / $anchor preservation checks (as well as the
+ * SEP-1613 $schema / $defs / additionalProperties checks) against this server.
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import express from 'express';
+
+function createServer() {
+  const server = new Server(
+    { name: 'sep-2106-stripped-schema', version: '1.0.0' },
+    { capabilities: { tools: {} } }
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      {
+        name: 'json_schema_2020_12_tool',
+        description:
+          'Tool whose JSON Schema 2020-12 keywords have been stripped',
+        // Stripped: only type + plain properties survive.
+        inputSchema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            address: {
+              type: 'object',
+              properties: {
+                street: { type: 'string' },
+                city: { type: 'string' }
+              }
+            }
+          }
+        }
+      }
+    ]
+  }));
+
+  return server;
+}
+
+const app = express();
+app.use(express.json());
+
+app.post('/mcp', async (req, res) => {
+  try {
+    const server = createServer();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined
+    });
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } catch (error) {
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32603,
+          message: `Internal error: ${error instanceof Error ? error.message : String(error)}`
+        },
+        id: null
+      });
+    }
+  }
+});
+
+const PORT = parseInt(process.env.PORT || '3006', 10);
+app.listen(PORT, '127.0.0.1', () => {
+  console.log(
+    `SEP-2106 negative test server running on http://localhost:${PORT}/mcp`
+  );
+});

--- a/examples/servers/typescript/sep-2106-stripped-schema.ts
+++ b/examples/servers/typescript/sep-2106-stripped-schema.ts
@@ -76,7 +76,7 @@ app.post('/mcp', async (req, res) => {
   }
 });
 
-const PORT = parseInt(process.env.PORT || '3006', 10);
+const PORT = parseInt(process.env.PORT || '3007', 10);
 app.listen(PORT, '127.0.0.1', () => {
   console.log(
     `SEP-2106 negative test server running on http://localhost:${PORT}/mcp`

--- a/src/scenarios/client/json-schema-ref-deref.test.ts
+++ b/src/scenarios/client/json-schema-ref-deref.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {
+  runClientAgainstScenario,
+  InlineClientRunner
+} from './auth/test_helpers/testClient';
+import { JsonSchemaRefDerefScenario } from './json-schema-ref-deref';
+import { getScenario } from '../index';
+
+/**
+ * SEP-2106: implementations MUST NOT automatically dereference $ref values
+ * that resolve to a network URI.
+ *
+ * Positive: a compliant client lists tools and never touches the canary URL.
+ * Negative: a client that walks tool schemas and fetches network $refs must
+ * produce a FAILURE for sep-2106-no-network-ref-deref.
+ */
+
+/** Recursively collect string `$ref` values that look like network URIs. */
+function collectNetworkRefs(node: unknown, out: string[] = []): string[] {
+  if (Array.isArray(node)) {
+    for (const item of node) collectNetworkRefs(item, out);
+    return out;
+  }
+  if (node && typeof node === 'object') {
+    for (const [key, value] of Object.entries(node)) {
+      if (
+        key === '$ref' &&
+        typeof value === 'string' &&
+        /^https?:/.test(value)
+      ) {
+        out.push(value);
+      } else {
+        collectNetworkRefs(value, out);
+      }
+    }
+  }
+  return out;
+}
+
+async function compliantClient(serverUrl: string): Promise<void> {
+  const client = new Client(
+    { name: 'test-client', version: '1.0.0' },
+    { capabilities: {} }
+  );
+  const transport = new StreamableHTTPClientTransport(new URL(serverUrl));
+  await client.connect(transport);
+  await client.listTools();
+  await transport.close();
+}
+
+async function dereferencingClient(serverUrl: string): Promise<void> {
+  const client = new Client(
+    { name: 'deref-client', version: '1.0.0' },
+    { capabilities: {} }
+  );
+  const transport = new StreamableHTTPClientTransport(new URL(serverUrl));
+  await client.connect(transport);
+  const result = await client.listTools();
+
+  // Naive schema processing: resolve every $ref, including network URIs.
+  // This is exactly the behavior SEP-2106 forbids.
+  for (const tool of result.tools ?? []) {
+    for (const ref of collectNetworkRefs(tool.inputSchema)) {
+      await fetch(ref);
+    }
+  }
+
+  await transport.close();
+}
+
+describe('json-schema-ref-no-deref (SEP-2106)', () => {
+  test('scenario is registered', () => {
+    expect(getScenario('json-schema-ref-no-deref')).toBeDefined();
+  });
+
+  test('compliant client passes: network $ref is not fetched', async () => {
+    await runClientAgainstScenario(
+      new InlineClientRunner(compliantClient),
+      'json-schema-ref-no-deref'
+    );
+  });
+
+  test('dereferencing client fails: canary fetch is detected', async () => {
+    await runClientAgainstScenario(
+      new InlineClientRunner(dereferencingClient),
+      'json-schema-ref-no-deref',
+      { expectedFailureSlugs: ['sep-2106-no-network-ref-deref'] }
+    );
+  });
+
+  test('client that never lists tools fails: requirement cannot be evaluated', async () => {
+    const scenario = new JsonSchemaRefDerefScenario();
+    await scenario.start();
+    try {
+      const checks = scenario.getChecks();
+      const check = checks.find(
+        (c) => c.id === 'sep-2106-no-network-ref-deref'
+      );
+      expect(check?.status).toBe('FAILURE');
+    } finally {
+      await scenario.stop();
+    }
+  });
+});

--- a/src/scenarios/client/json-schema-ref-deref.ts
+++ b/src/scenarios/client/json-schema-ref-deref.ts
@@ -1,0 +1,187 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import type { Scenario, ConformanceCheck } from '../../types';
+import express, { Request, Response } from 'express';
+import { ScenarioUrls, DRAFT_PROTOCOL_VERSION } from '../../types';
+
+/**
+ * Scenario: JSON Schema network $ref dereferencing (SEP-2106)
+ *
+ * SEP-2106 permits the full JSON Schema 2020-12 vocabulary in tool schemas,
+ * including `$ref`. A `$ref` that resolves to a network URI is an SSRF /
+ * fetch-DoS vector: a malicious tool definition could point at internal
+ * infrastructure and have the *client* fetch it during schema processing.
+ *
+ * Per SEP-2106, implementations MUST NOT automatically dereference `$ref`
+ * values that resolve to a network URI (anything that is not a same-document
+ * JSON Pointer such as `#/$defs/Foo` or an internal `$anchor`).
+ *
+ * This scenario advertises a tool whose inputSchema contains both a
+ * same-document `$ref` and a `$ref` to a canary URL hosted by the scenario
+ * itself. If the client fetches the canary URL at any point before the
+ * scenario stops, the check fails.
+ */
+
+const TOOL_NAME = 'lookup_user';
+const CANARY_PATH = '/canary/profile-schema.json';
+const CHECK_ID = 'sep-2106-no-network-ref-deref';
+
+const SPEC_REFERENCES = [
+  {
+    id: 'SEP-2106',
+    url: 'https://modelcontextprotocol.io/seps/2106-json-schema-2020-12#security-implications'
+  }
+];
+
+function createMcpServer(canaryUrl: string, onToolsListed: () => void): Server {
+  const server = new Server(
+    { name: 'json-schema-ref-deref-server', version: '1.0.0' },
+    { capabilities: { tools: {} } }
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    onToolsListed();
+    return {
+      tools: [
+        {
+          name: TOOL_NAME,
+          description: 'Look up a user profile by id',
+          inputSchema: {
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            type: 'object',
+            $defs: {
+              userId: { type: 'string', pattern: '^[a-z0-9-]+$' }
+            },
+            properties: {
+              // Same-document $ref: safe, expected to be resolvable locally.
+              id: { $ref: '#/$defs/userId' },
+              // Network $ref: the canary. Implementations MUST NOT fetch this
+              // automatically while processing the schema.
+              profile: { $ref: canaryUrl }
+            },
+            required: ['id']
+          }
+        }
+      ]
+    };
+  });
+
+  return server;
+}
+
+export class JsonSchemaRefDerefScenario implements Scenario {
+  name = 'json-schema-ref-no-deref';
+  readonly source = { introducedIn: DRAFT_PROTOCOL_VERSION } as const;
+  description = `Tests that a client does not automatically dereference a network-URI \`$ref\` in a tool's inputSchema (SEP-2106).
+
+The scenario advertises a tool whose inputSchema contains a \`$ref\` pointing at a canary URL. The client should list tools (and may otherwise process the schema), but must not fetch the canary URL. Same-document refs (\`#/$defs/...\`) remain safe to resolve.`;
+
+  private app: express.Application | null = null;
+  private httpServer: ReturnType<express.Application['listen']> | null = null;
+  private checks: ConformanceCheck[] = [];
+  private canaryRequests: Array<{ method: string; userAgent?: string }> = [];
+  private toolsListed = false;
+
+  async start(): Promise<ScenarioUrls> {
+    this.checks = [];
+    this.canaryRequests = [];
+    this.toolsListed = false;
+
+    const app = express();
+    app.use(express.json());
+
+    // Canary endpoint: any request here means the client dereferenced the
+    // network $ref. Return a valid schema so a dereferencing client gets a
+    // realistic response rather than an error it might silently swallow.
+    app.all(CANARY_PATH, (req: Request, res: Response) => {
+      this.canaryRequests.push({
+        method: req.method,
+        userAgent: req.headers['user-agent']
+      });
+      res.json({
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        type: 'object',
+        properties: { displayName: { type: 'string' } }
+      });
+    });
+
+    app.post('/mcp', async (req: Request, res: Response) => {
+      // Stateless: fresh server and transport per request
+      const server = createMcpServer(this.canaryUrl(), () => {
+        this.toolsListed = true;
+      });
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined
+      });
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+    });
+
+    this.app = app;
+    this.httpServer = app.listen(0);
+    return { serverUrl: `${this.baseUrl()}/mcp` };
+  }
+
+  private baseUrl(): string {
+    const address = this.httpServer?.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('Scenario server is not listening');
+    }
+    return `http://localhost:${address.port}`;
+  }
+
+  private canaryUrl(): string {
+    return `${this.baseUrl()}${CANARY_PATH}`;
+  }
+
+  async stop() {
+    if (this.httpServer) {
+      await new Promise((resolve) => this.httpServer!.close(resolve));
+      this.httpServer = null;
+    }
+    this.app = null;
+  }
+
+  getChecks(): ConformanceCheck[] {
+    const timestamp = new Date().toISOString();
+    const fetched = this.canaryRequests.length > 0;
+
+    if (!this.toolsListed) {
+      this.checks.push({
+        id: CHECK_ID,
+        name: 'NoNetworkRefDereference',
+        description:
+          'Client never requested tools/list, so $ref handling could not be evaluated',
+        status: 'FAILURE',
+        timestamp,
+        errorMessage:
+          'Client did not call tools/list against a server advertising a tool with a network $ref',
+        specReferences: SPEC_REFERENCES,
+        details: { toolsListed: false }
+      });
+      return this.checks;
+    }
+
+    this.checks.push({
+      id: CHECK_ID,
+      name: 'NoNetworkRefDereference',
+      description: fetched
+        ? 'Client automatically dereferenced a network-URI $ref in a tool inputSchema. Implementations MUST NOT automatically dereference $ref values that resolve to a network URI (SEP-2106).'
+        : 'Client did not dereference the network-URI $ref in the tool inputSchema',
+      status: fetched ? 'FAILURE' : 'SUCCESS',
+      timestamp,
+      errorMessage: fetched
+        ? `Canary URL ${CANARY_PATH} was fetched ${this.canaryRequests.length} time(s)`
+        : undefined,
+      specReferences: SPEC_REFERENCES,
+      details: {
+        toolsListed: true,
+        canaryRequestCount: this.canaryRequests.length,
+        canaryRequests: this.canaryRequests
+      }
+    });
+
+    return this.checks;
+  }
+}

--- a/src/scenarios/client/json-schema-ref-deref.ts
+++ b/src/scenarios/client/json-schema-ref-deref.ts
@@ -79,12 +79,10 @@ The scenario advertises a tool whose inputSchema contains a \`$ref\` pointing at
 
   private app: express.Application | null = null;
   private httpServer: ReturnType<express.Application['listen']> | null = null;
-  private checks: ConformanceCheck[] = [];
   private canaryRequests: Array<{ method: string; userAgent?: string }> = [];
   private toolsListed = false;
 
   async start(): Promise<ScenarioUrls> {
-    this.checks = [];
     this.canaryRequests = [];
     this.toolsListed = false;
 
@@ -107,15 +105,28 @@ The scenario advertises a tool whose inputSchema contains a \`$ref\` pointing at
     });
 
     app.post('/mcp', async (req: Request, res: Response) => {
-      // Stateless: fresh server and transport per request
-      const server = createMcpServer(this.canaryUrl(), () => {
-        this.toolsListed = true;
-      });
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: undefined
-      });
-      await server.connect(transport);
-      await transport.handleRequest(req, res, req.body);
+      try {
+        // Stateless: fresh server and transport per request
+        const server = createMcpServer(this.canaryUrl(), () => {
+          this.toolsListed = true;
+        });
+        const transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: undefined
+        });
+        await server.connect(transport);
+        await transport.handleRequest(req, res, req.body);
+      } catch (error) {
+        if (!res.headersSent) {
+          res.status(500).json({
+            jsonrpc: '2.0',
+            error: {
+              code: -32603,
+              message: `Internal error: ${error instanceof Error ? error.message : String(error)}`
+            },
+            id: null
+          });
+        }
+      }
     });
 
     this.app = app;
@@ -144,44 +155,47 @@ The scenario advertises a tool whose inputSchema contains a \`$ref\` pointing at
   }
 
   getChecks(): ConformanceCheck[] {
+    // Built fresh on every call so getChecks() is idempotent — the runner may
+    // call it more than once and we must not accumulate duplicates.
     const timestamp = new Date().toISOString();
     const fetched = this.canaryRequests.length > 0;
 
     if (!this.toolsListed) {
-      this.checks.push({
-        id: CHECK_ID,
-        name: 'NoNetworkRefDereference',
-        description:
-          'Client never requested tools/list, so $ref handling could not be evaluated',
-        status: 'FAILURE',
-        timestamp,
-        errorMessage:
-          'Client did not call tools/list against a server advertising a tool with a network $ref',
-        specReferences: SPEC_REFERENCES,
-        details: { toolsListed: false }
-      });
-      return this.checks;
+      return [
+        {
+          id: CHECK_ID,
+          name: 'NoNetworkRefDereference',
+          description:
+            'Client never requested tools/list, so $ref handling could not be evaluated',
+          status: 'FAILURE',
+          timestamp,
+          errorMessage:
+            'Client did not call tools/list against a server advertising a tool with a network $ref',
+          specReferences: SPEC_REFERENCES,
+          details: { toolsListed: false }
+        }
+      ];
     }
 
-    this.checks.push({
-      id: CHECK_ID,
-      name: 'NoNetworkRefDereference',
-      description: fetched
-        ? 'Client automatically dereferenced a network-URI $ref in a tool inputSchema. Implementations MUST NOT automatically dereference $ref values that resolve to a network URI (SEP-2106).'
-        : 'Client did not dereference the network-URI $ref in the tool inputSchema',
-      status: fetched ? 'FAILURE' : 'SUCCESS',
-      timestamp,
-      errorMessage: fetched
-        ? `Canary URL ${CANARY_PATH} was fetched ${this.canaryRequests.length} time(s)`
-        : undefined,
-      specReferences: SPEC_REFERENCES,
-      details: {
-        toolsListed: true,
-        canaryRequestCount: this.canaryRequests.length,
-        canaryRequests: this.canaryRequests
+    return [
+      {
+        id: CHECK_ID,
+        name: 'NoNetworkRefDereference',
+        description: fetched
+          ? 'Client automatically dereferenced a network-URI $ref in a tool inputSchema. Implementations MUST NOT automatically dereference $ref values that resolve to a network URI (SEP-2106).'
+          : 'Client did not dereference the network-URI $ref in the tool inputSchema',
+        status: fetched ? 'FAILURE' : 'SUCCESS',
+        timestamp,
+        errorMessage: fetched
+          ? `Canary URL ${CANARY_PATH} was fetched ${this.canaryRequests.length} time(s)`
+          : undefined,
+        specReferences: SPEC_REFERENCES,
+        details: {
+          toolsListed: true,
+          canaryRequestCount: this.canaryRequests.length,
+          canaryRequests: this.canaryRequests
+        }
       }
-    });
-
-    return this.checks;
+    ];
   }
 }

--- a/src/scenarios/index.ts
+++ b/src/scenarios/index.ts
@@ -105,6 +105,7 @@ import {
   HttpCustomHeadersScenario,
   HttpInvalidToolHeadersScenario
 } from './client/http-custom-headers';
+import { JsonSchemaRefDerefScenario } from './client/json-schema-ref-deref';
 
 // Pending client scenarios (not yet fully tested/implemented)
 const pendingClientScenariosList: ClientScenario[] = [
@@ -254,7 +255,10 @@ const scenariosList: Scenario[] = [
   // HTTP Standardization scenarios (SEP-2243)
   new HttpStandardHeadersScenario(),
   new HttpCustomHeadersScenario(),
-  new HttpInvalidToolHeadersScenario()
+  new HttpInvalidToolHeadersScenario(),
+
+  // JSON Schema network $ref dereferencing (SEP-2106)
+  new JsonSchemaRefDerefScenario()
 ];
 
 // Core scenarios (tier 1 requirements)

--- a/src/scenarios/server/json-schema-2020-12.ts
+++ b/src/scenarios/server/json-schema-2020-12.ts
@@ -20,11 +20,11 @@ const EXPECTED_SCHEMA_DIALECT = 'https://json-schema.org/draft/2020-12/schema';
 export class JsonSchema2020_12Scenario implements ClientScenario {
   name = 'json-schema-2020-12';
   readonly source = { introducedIn: '2025-11-25' } as const;
-  description = `Validates JSON Schema 2020-12 keyword preservation (SEP-1613).
+  description = `Validates JSON Schema 2020-12 keyword preservation (SEP-1613, SEP-2106).
 
 **Server Implementation Requirements:**
 
-Implement tool \`${EXPECTED_TOOL_NAME}\` with inputSchema containing JSON Schema 2020-12 features:
+Implement tool \`${EXPECTED_TOOL_NAME}\` with inputSchema containing JSON Schema 2020-12 features, including the broader vocabulary permitted by SEP-2106 (an \`$anchor\` inside \`$defs\`, composition keywords \`allOf\`/\`anyOf\`, and conditional keywords \`if\`/\`then\`/\`else\`):
 
 \`\`\`json
 {
@@ -35,6 +35,7 @@ Implement tool \`${EXPECTED_TOOL_NAME}\` with inputSchema containing JSON Schema
     "type": "object",
     "$defs": {
       "address": {
+        "$anchor": "addressDef",
         "type": "object",
         "properties": {
           "street": { "type": "string" },
@@ -44,20 +45,26 @@ Implement tool \`${EXPECTED_TOOL_NAME}\` with inputSchema containing JSON Schema
     },
     "properties": {
       "name": { "type": "string" },
-      "address": { "$ref": "#/$defs/address" }
+      "address": { "$ref": "#/$defs/address" },
+      "contactMethod": { "type": "string", "enum": ["phone", "email"] },
+      "phone": { "type": "string" },
+      "email": { "type": "string" }
     },
+    "allOf": [
+      { "anyOf": [{ "required": ["phone"] }, { "required": ["email"] }] }
+    ],
+    "if": {
+      "properties": { "contactMethod": { "const": "phone" } },
+      "required": ["contactMethod"]
+    },
+    "then": { "required": ["phone"] },
+    "else": { "required": ["email"] },
     "additionalProperties": false
   }
 }
 \`\`\`
 
-The \`inputSchema\` should also exercise the broader JSON Schema 2020-12 vocabulary permitted by SEP-2106:
-
-- a \`$defs\` subschema with an \`$anchor\`
-- composition keywords (\`allOf\` containing \`anyOf\`)
-- conditional keywords (\`if\`/\`then\`/\`else\`)
-
-**Verification**: The test verifies that \`$schema\`, \`$defs\`, and \`additionalProperties\` are preserved (SEP-1613), and that the composition, conditional, and \`$anchor\` keywords are preserved (SEP-2106), in the tool listing response.`;
+**Verification**: The test verifies that \`$schema\`, \`$defs\`, and \`additionalProperties\` are preserved (SEP-1613), and that the composition (\`allOf\`/\`anyOf\`), conditional (\`if\`/\`then\`/\`else\`), and \`$anchor\` keywords are preserved (SEP-2106), in the tool listing response.`;
 
   async run(serverUrl: string): Promise<ConformanceCheck[]> {
     const checks: ConformanceCheck[] = [];

--- a/src/scenarios/server/json-schema-2020-12.ts
+++ b/src/scenarios/server/json-schema-2020-12.ts
@@ -1,9 +1,14 @@
 /**
- * JSON Schema 2020-12 conformance test scenario (SEP-1613)
+ * JSON Schema 2020-12 conformance test scenario (SEP-1613, SEP-2106)
  *
  * Validates that MCP servers correctly preserve JSON Schema 2020-12 keywords
  * in tool definitions, ensuring implementations don't strip $schema, $defs,
- * or additionalProperties fields.
+ * or additionalProperties fields (SEP-1613).
+ *
+ * SEP-2106 broadened inputSchema to permit the full JSON Schema 2020-12
+ * vocabulary alongside the required root `type: "object"`. This scenario also
+ * verifies that composition (allOf/anyOf), conditional (if/then/else), and
+ * reference ($anchor) keywords survive tools/list rather than being stripped.
  */
 
 import { ClientScenario, ConformanceCheck } from '../../types.js';
@@ -46,7 +51,13 @@ Implement tool \`${EXPECTED_TOOL_NAME}\` with inputSchema containing JSON Schema
 }
 \`\`\`
 
-**Verification**: The test verifies that \`$schema\`, \`$defs\`, and \`additionalProperties\` are preserved in the tool listing response.`;
+The \`inputSchema\` should also exercise the broader JSON Schema 2020-12 vocabulary permitted by SEP-2106:
+
+- a \`$defs\` subschema with an \`$anchor\`
+- composition keywords (\`allOf\` containing \`anyOf\`)
+- conditional keywords (\`if\`/\`then\`/\`else\`)
+
+**Verification**: The test verifies that \`$schema\`, \`$defs\`, and \`additionalProperties\` are preserved (SEP-1613), and that the composition, conditional, and \`$anchor\` keywords are preserved (SEP-2106), in the tool listing response.`;
 
   async run(serverUrl: string): Promise<ConformanceCheck[]> {
     const checks: ConformanceCheck[] = [];
@@ -54,6 +65,12 @@ Implement tool \`${EXPECTED_TOOL_NAME}\` with inputSchema containing JSON Schema
       {
         id: 'SEP-1613',
         url: 'https://github.com/modelcontextprotocol/specification/pull/655'
+      }
+    ];
+    const sep2106References = [
+      {
+        id: 'SEP-2106',
+        url: 'https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2106'
       }
     ];
 
@@ -161,6 +178,88 @@ Implement tool \`${EXPECTED_TOOL_NAME}\` with inputSchema containing JSON Schema
           hasAdditionalProps,
           additionalPropsValue,
           expected: false
+        }
+      });
+
+      // SEP-2106: the full JSON Schema 2020-12 vocabulary is permitted in
+      // inputSchema and must survive tools/list rather than being stripped to
+      // properties/required.
+
+      // Check 5: composition keywords (allOf / anyOf) preserved
+      const allOf = inputSchema['allOf'];
+      const hasAllOf = Array.isArray(allOf) && allOf.length > 0;
+      const hasNestedAnyOf =
+        Array.isArray(allOf) &&
+        allOf.some(
+          (sub) =>
+            typeof sub === 'object' &&
+            sub !== null &&
+            Array.isArray((sub as Record<string, unknown>)['anyOf'])
+        );
+
+      checks.push({
+        id: 'sep-2106-composition-keywords-preserved',
+        name: 'JsonSchema2020_12CompositionKeywords',
+        description:
+          'inputSchema composition keywords (allOf/anyOf) preserved (SEP-2106)',
+        status: hasAllOf && hasNestedAnyOf ? 'SUCCESS' : 'FAILURE',
+        timestamp: new Date().toISOString(),
+        errorMessage: !hasAllOf
+          ? 'allOf keyword missing from inputSchema - composition keyword was likely stripped'
+          : !hasNestedAnyOf
+            ? 'nested anyOf missing from allOf - composition keyword was likely stripped'
+            : undefined,
+        specReferences: sep2106References,
+        details: {
+          hasAllOf,
+          hasNestedAnyOf
+        }
+      });
+
+      // Check 6: conditional keywords (if / then / else) preserved
+      const hasIf = 'if' in inputSchema;
+      const hasThen = 'then' in inputSchema;
+      const hasElse = 'else' in inputSchema;
+
+      checks.push({
+        id: 'sep-2106-conditional-keywords-preserved',
+        name: 'JsonSchema2020_12ConditionalKeywords',
+        description:
+          'inputSchema conditional keywords (if/then/else) preserved (SEP-2106)',
+        status: hasIf && hasThen && hasElse ? 'SUCCESS' : 'FAILURE',
+        timestamp: new Date().toISOString(),
+        errorMessage:
+          !hasIf || !hasThen || !hasElse
+            ? `Conditional keywords missing (if=${hasIf}, then=${hasThen}, else=${hasElse}) - likely stripped`
+            : undefined,
+        specReferences: sep2106References,
+        details: {
+          hasIf,
+          hasThen,
+          hasElse
+        }
+      });
+
+      // Check 7: reference keyword ($anchor) preserved within $defs.address
+      const addressDef = defsValue?.['address'] as
+        | Record<string, unknown>
+        | undefined;
+      const hasAnchor = !!addressDef && '$anchor' in addressDef;
+
+      checks.push({
+        id: 'sep-2106-anchor-keyword-preserved',
+        name: 'JsonSchema2020_12AnchorKeyword',
+        description:
+          'inputSchema reference keyword ($anchor) preserved in $defs (SEP-2106)',
+        status: hasAnchor ? 'SUCCESS' : 'FAILURE',
+        timestamp: new Date().toISOString(),
+        errorMessage: hasAnchor
+          ? undefined
+          : '$anchor missing from $defs.address - reference keyword was likely stripped',
+        specReferences: sep2106References,
+        details: {
+          hasAnchor,
+          anchorValue: addressDef?.['$anchor']
         }
       });
 

--- a/src/scenarios/server/json-schema-2020-12.ts
+++ b/src/scenarios/server/json-schema-2020-12.ts
@@ -11,11 +11,38 @@
  * reference ($anchor) keywords survive tools/list rather than being stripped.
  */
 
-import { ClientScenario, ConformanceCheck } from '../../types.js';
+import {
+  CheckStatus,
+  ClientScenario,
+  ConformanceCheck,
+  DRAFT_PROTOCOL_VERSION
+} from '../../types.js';
 import { connectToServer } from './client-helper.js';
 
 const EXPECTED_TOOL_NAME = 'json_schema_2020_12_tool';
 const EXPECTED_SCHEMA_DIALECT = 'https://json-schema.org/draft/2020-12/schema';
+
+/**
+ * Soft version gate for the SEP-2106 keyword-preservation checks.
+ *
+ * Preserving the broader JSON Schema 2020-12 vocabulary is good behavior at
+ * any protocol version, so a server that preserves the keywords gets SUCCESS
+ * regardless of what it negotiated. Stripping them is only a conformance
+ * FAILURE once the server claims a protocol version that includes SEP-2106
+ * (the draft); a server that only negotiated an earlier dated version is not
+ * yet subject to the requirement, so the check is SKIPPED rather than failed.
+ */
+export function sep2106KeywordCheckStatus(
+  preserved: boolean,
+  negotiatedProtocolVersion: string | undefined
+): CheckStatus {
+  if (preserved) {
+    return 'SUCCESS';
+  }
+  return negotiatedProtocolVersion === DRAFT_PROTOCOL_VERSION
+    ? 'FAILURE'
+    : 'SKIPPED';
+}
 
 export class JsonSchema2020_12Scenario implements ClientScenario {
   name = 'json-schema-2020-12';
@@ -83,6 +110,11 @@ Implement tool \`${EXPECTED_TOOL_NAME}\` with inputSchema containing JSON Schema
 
     try {
       const connection = await connectToServer(serverUrl);
+      // Negotiated wire protocolVersion from the initialize handshake; used to
+      // soft-gate the SEP-2106 checks below.
+      const negotiatedVersion = (
+        connection.client.transport as { protocolVersion?: string } | undefined
+      )?.protocolVersion;
       const result = await connection.client.listTools();
 
       // Find the test tool
@@ -190,7 +222,11 @@ Implement tool \`${EXPECTED_TOOL_NAME}\` with inputSchema containing JSON Schema
 
       // SEP-2106: the full JSON Schema 2020-12 vocabulary is permitted in
       // inputSchema and must survive tools/list rather than being stripped to
-      // properties/required.
+      // properties/required. These checks are soft-gated on the negotiated
+      // protocol version (see sep2106KeywordCheckStatus): stripping the
+      // keywords is only a FAILURE for servers that negotiated the draft
+      // protocol version, and SKIPPED otherwise.
+      const skippedSuffix = ` (server negotiated protocol version ${negotiatedVersion ?? 'unknown'}; SEP-2106 applies from ${DRAFT_PROTOCOL_VERSION})`;
 
       // Check 5: composition keywords (allOf / anyOf) preserved
       const allOf = inputSchema['allOf'];
@@ -203,23 +239,30 @@ Implement tool \`${EXPECTED_TOOL_NAME}\` with inputSchema containing JSON Schema
             sub !== null &&
             Array.isArray((sub as Record<string, unknown>)['anyOf'])
         );
+      const compositionPreserved = hasAllOf && hasNestedAnyOf;
+      const compositionStatus = sep2106KeywordCheckStatus(
+        compositionPreserved,
+        negotiatedVersion
+      );
 
       checks.push({
         id: 'sep-2106-composition-keywords-preserved',
         name: 'JsonSchema2020_12CompositionKeywords',
         description:
           'inputSchema composition keywords (allOf/anyOf) preserved (SEP-2106)',
-        status: hasAllOf && hasNestedAnyOf ? 'SUCCESS' : 'FAILURE',
+        status: compositionStatus,
         timestamp: new Date().toISOString(),
-        errorMessage: !hasAllOf
-          ? 'allOf keyword missing from inputSchema - composition keyword was likely stripped'
-          : !hasNestedAnyOf
-            ? 'nested anyOf missing from allOf - composition keyword was likely stripped'
-            : undefined,
+        errorMessage: compositionPreserved
+          ? undefined
+          : (!hasAllOf
+              ? 'allOf keyword missing from inputSchema - composition keyword was likely stripped'
+              : 'nested anyOf missing from allOf - composition keyword was likely stripped') +
+            (compositionStatus === 'SKIPPED' ? skippedSuffix : ''),
         specReferences: sep2106References,
         details: {
           hasAllOf,
-          hasNestedAnyOf
+          hasNestedAnyOf,
+          negotiatedProtocolVersion: negotiatedVersion
         }
       });
 
@@ -227,23 +270,29 @@ Implement tool \`${EXPECTED_TOOL_NAME}\` with inputSchema containing JSON Schema
       const hasIf = 'if' in inputSchema;
       const hasThen = 'then' in inputSchema;
       const hasElse = 'else' in inputSchema;
+      const conditionalPreserved = hasIf && hasThen && hasElse;
+      const conditionalStatus = sep2106KeywordCheckStatus(
+        conditionalPreserved,
+        negotiatedVersion
+      );
 
       checks.push({
         id: 'sep-2106-conditional-keywords-preserved',
         name: 'JsonSchema2020_12ConditionalKeywords',
         description:
           'inputSchema conditional keywords (if/then/else) preserved (SEP-2106)',
-        status: hasIf && hasThen && hasElse ? 'SUCCESS' : 'FAILURE',
+        status: conditionalStatus,
         timestamp: new Date().toISOString(),
-        errorMessage:
-          !hasIf || !hasThen || !hasElse
-            ? `Conditional keywords missing (if=${hasIf}, then=${hasThen}, else=${hasElse}) - likely stripped`
-            : undefined,
+        errorMessage: conditionalPreserved
+          ? undefined
+          : `Conditional keywords missing (if=${hasIf}, then=${hasThen}, else=${hasElse}) - likely stripped` +
+            (conditionalStatus === 'SKIPPED' ? skippedSuffix : ''),
         specReferences: sep2106References,
         details: {
           hasIf,
           hasThen,
-          hasElse
+          hasElse,
+          negotiatedProtocolVersion: negotiatedVersion
         }
       });
 
@@ -252,17 +301,22 @@ Implement tool \`${EXPECTED_TOOL_NAME}\` with inputSchema containing JSON Schema
         | Record<string, unknown>
         | undefined;
       const hasAnchor = !!addressDef && '$anchor' in addressDef;
+      const anchorStatus = sep2106KeywordCheckStatus(
+        hasAnchor,
+        negotiatedVersion
+      );
 
       checks.push({
         id: 'sep-2106-anchor-keyword-preserved',
         name: 'JsonSchema2020_12AnchorKeyword',
         description:
           'inputSchema reference keyword ($anchor) preserved in $defs (SEP-2106)',
-        status: hasAnchor ? 'SUCCESS' : 'FAILURE',
+        status: anchorStatus,
         timestamp: new Date().toISOString(),
         errorMessage: hasAnchor
           ? undefined
-          : '$anchor missing from $defs.address - reference keyword was likely stripped',
+          : '$anchor missing from $defs.address - reference keyword was likely stripped' +
+            (anchorStatus === 'SKIPPED' ? skippedSuffix : ''),
         specReferences: sep2106References,
         details: {
           hasAnchor,

--- a/src/scenarios/server/negative.test.ts
+++ b/src/scenarios/server/negative.test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { DNSRebindingProtectionScenario } from './dns-rebinding';
 import { ResourcesNotFoundErrorScenario } from './resources';
 import { CachingScenario } from './caching';
+import { JsonSchema2020_12Scenario } from './json-schema-2020-12';
 
 function startServer(scriptPath: string, port: number): Promise<ChildProcess> {
   return new Promise((resolve, reject) => {
@@ -147,5 +148,51 @@ describe('Server scenario negative tests', () => {
         expect(check?.status).toBe('FAILURE');
       }
     }, 15000);
+  });
+
+  describe('json-schema-2020-12 (SEP-2106)', () => {
+    let serverProcess: ChildProcess | null = null;
+    const PORT = 3007;
+
+    beforeAll(async () => {
+      serverProcess = await startServer(
+        path.join(
+          process.cwd(),
+          'examples/servers/typescript/sep-2106-stripped-schema.ts'
+        ),
+        PORT
+      );
+    }, 35000);
+
+    afterAll(async () => {
+      await stopServer(serverProcess);
+    });
+
+    it('emits FAILURE for SEP-2106 keyword-preservation checks against a server that strips the 2020-12 vocabulary', async () => {
+      const scenario = new JsonSchema2020_12Scenario();
+      const checks = await scenario.run(`http://localhost:${PORT}/mcp`);
+
+      // The tool is still advertised, so it must be found...
+      const found = checks.find(
+        (c) => c.id === 'json-schema-2020-12-tool-found'
+      );
+      expect(found?.status).toBe('SUCCESS');
+
+      // ...but the stripped 2020-12 keywords must be reported as FAILURE.
+      const composition = checks.find(
+        (c) => c.id === 'sep-2106-composition-keywords-preserved'
+      );
+      expect(composition?.status).toBe('FAILURE');
+
+      const conditional = checks.find(
+        (c) => c.id === 'sep-2106-conditional-keywords-preserved'
+      );
+      expect(conditional?.status).toBe('FAILURE');
+
+      const anchor = checks.find(
+        (c) => c.id === 'sep-2106-anchor-keyword-preserved'
+      );
+      expect(anchor?.status).toBe('FAILURE');
+    }, 10000);
   });
 });

--- a/src/scenarios/server/negative.test.ts
+++ b/src/scenarios/server/negative.test.ts
@@ -3,7 +3,11 @@ import path from 'path';
 import { DNSRebindingProtectionScenario } from './dns-rebinding';
 import { ResourcesNotFoundErrorScenario } from './resources';
 import { CachingScenario } from './caching';
-import { JsonSchema2020_12Scenario } from './json-schema-2020-12';
+import {
+  JsonSchema2020_12Scenario,
+  sep2106KeywordCheckStatus
+} from './json-schema-2020-12';
+import { DRAFT_PROTOCOL_VERSION, LATEST_SPEC_VERSION } from '../../types';
 
 function startServer(scriptPath: string, port: number): Promise<ChildProcess> {
   return new Promise((resolve, reject) => {
@@ -168,7 +172,7 @@ describe('Server scenario negative tests', () => {
       await stopServer(serverProcess);
     });
 
-    it('emits FAILURE for SEP-2106 keyword-preservation checks against a server that strips the 2020-12 vocabulary', async () => {
+    it('flags SEP-2106 keyword-preservation checks against a server that strips the 2020-12 vocabulary', async () => {
       const scenario = new JsonSchema2020_12Scenario();
       const checks = await scenario.run(`http://localhost:${PORT}/mcp`);
 
@@ -178,21 +182,46 @@ describe('Server scenario negative tests', () => {
       );
       expect(found?.status).toBe('SUCCESS');
 
-      // ...but the stripped 2020-12 keywords must be reported as FAILURE.
+      // ...but the stripped 2020-12 keywords must be flagged. The stripped
+      // server negotiates 2025-11-25 (the published SDK does not advertise the
+      // draft protocol version), so the soft version gate reports SKIPPED
+      // rather than FAILURE — see sep2106KeywordCheckStatus.
       const composition = checks.find(
         (c) => c.id === 'sep-2106-composition-keywords-preserved'
       );
-      expect(composition?.status).toBe('FAILURE');
+      expect(composition?.status).toBe('SKIPPED');
 
       const conditional = checks.find(
         (c) => c.id === 'sep-2106-conditional-keywords-preserved'
       );
-      expect(conditional?.status).toBe('FAILURE');
+      expect(conditional?.status).toBe('SKIPPED');
 
       const anchor = checks.find(
         (c) => c.id === 'sep-2106-anchor-keyword-preserved'
       );
-      expect(anchor?.status).toBe('FAILURE');
+      expect(anchor?.status).toBe('SKIPPED');
     }, 10000);
+  });
+
+  describe('sep2106KeywordCheckStatus (soft version gate)', () => {
+    it('passes preserved keywords at any negotiated version', () => {
+      expect(sep2106KeywordCheckStatus(true, DRAFT_PROTOCOL_VERSION)).toBe(
+        'SUCCESS'
+      );
+      expect(sep2106KeywordCheckStatus(true, LATEST_SPEC_VERSION)).toBe(
+        'SUCCESS'
+      );
+      expect(sep2106KeywordCheckStatus(true, undefined)).toBe('SUCCESS');
+    });
+
+    it('fails stripped keywords only when the server negotiated the draft version', () => {
+      expect(sep2106KeywordCheckStatus(false, DRAFT_PROTOCOL_VERSION)).toBe(
+        'FAILURE'
+      );
+      expect(sep2106KeywordCheckStatus(false, LATEST_SPEC_VERSION)).toBe(
+        'SKIPPED'
+      );
+      expect(sep2106KeywordCheckStatus(false, undefined)).toBe('SKIPPED');
+    });
   });
 });

--- a/src/seps/sep-2106.yaml
+++ b/src/seps/sep-2106.yaml
@@ -1,21 +1,15 @@
 sep: 2106
-spec_url: https://modelcontextprotocol.io/specification/draft/server/tools#structured-content
+spec_url: https://modelcontextprotocol.io/seps/2106-json-schema-2020-12#security-implications
 requirements:
-  - check: sep-2106-non-object-structured-content-fallback
-    text: 'For backwards compatibility, a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block'
   - check: sep-2106-no-network-ref-deref
     text: 'Implementations MUST NOT automatically dereference `$ref` values that resolve to a network URI (i.e. anything that is not a same-document JSON Pointer such as `#/$defs/Foo` or an internal `$anchor`); an opt-in mode that fetches non-local `$ref`s MUST be disabled by default / Schemas that fail to validate due to an unresolved external `$ref` SHOULD be rejected rather than silently treated as permissive'
-    url: https://modelcontextprotocol.io/seps/2106-json-schema-2020-12#security-implications
 
   - text: "SDK maintainers SHOULD: Document the migration in SDK release notes; Where ergonomic, provide typed helpers (e.g. generics over a tool's `outputSchema`) so consumers do not need to write narrowing guards by hand"
     excluded: 'Migration/deprecation guidance for SDK maintainers; about SDK source code, not protocol-observable wire behavior'
     url: https://modelcontextprotocol.io/seps/2106-json-schema-2020-12#backward-compatibility
   - text: 'JSON Schema validation already handles type checking, value constraints, and required field validation, and implementations MUST continue to validate all inputs and outputs against declared schemas'
     excluded: 'Restates pre-existing schema-validation behavior and is too broad to attribute to a specific observable SEP-2106 check; input/output validation overlaps existing tool scenarios'
-    url: https://modelcontextprotocol.io/seps/2106-json-schema-2020-12#security-implications
   - text: 'An opt-in mode that fetches non-local `$ref`s SHOULD enforce an allowlist of hosts (or at minimum reject loopback, link-local, and private network addresses), apply timeouts and size limits, and log dereferenced URIs'
     excluded: 'Applies only when the non-default opt-in network-$ref fetch mode is enabled; not observable in default conformance runs'
-    url: https://modelcontextprotocol.io/seps/2106-json-schema-2020-12#security-implications
   - text: 'Implementations SHOULD apply reasonable bounds — for example, a maximum schema depth, a cap on the total number of subschemas, or a per-validation time budget — to prevent a malicious tool definition from acting as a CPU DoS vector against the validator'
     excluded: 'Internal validator resource limits (max schema depth, subschema cap, per-validation time budget); a defensive measure not observable on the wire'
-    url: https://modelcontextprotocol.io/seps/2106-json-schema-2020-12#security-implications

--- a/src/seps/sep-2106.yaml
+++ b/src/seps/sep-2106.yaml
@@ -1,0 +1,21 @@
+sep: 2106
+spec_url: https://modelcontextprotocol.io/specification/draft/server/tools#structured-content
+requirements:
+  - check: sep-2106-non-object-structured-content-fallback
+    text: 'For backwards compatibility, a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block'
+  - check: sep-2106-no-network-ref-deref
+    text: 'Implementations MUST NOT automatically dereference `$ref` values that resolve to a network URI (i.e. anything that is not a same-document JSON Pointer such as `#/$defs/Foo` or an internal `$anchor`); an opt-in mode that fetches non-local `$ref`s MUST be disabled by default / Schemas that fail to validate due to an unresolved external `$ref` SHOULD be rejected rather than silently treated as permissive'
+    url: https://modelcontextprotocol.io/seps/2106-json-schema-2020-12#security-implications
+
+  - text: "SDK maintainers SHOULD: Document the migration in SDK release notes; Where ergonomic, provide typed helpers (e.g. generics over a tool's `outputSchema`) so consumers do not need to write narrowing guards by hand"
+    excluded: 'Migration/deprecation guidance for SDK maintainers; about SDK source code, not protocol-observable wire behavior'
+    url: https://modelcontextprotocol.io/seps/2106-json-schema-2020-12#backward-compatibility
+  - text: 'JSON Schema validation already handles type checking, value constraints, and required field validation, and implementations MUST continue to validate all inputs and outputs against declared schemas'
+    excluded: 'Restates pre-existing schema-validation behavior and is too broad to attribute to a specific observable SEP-2106 check; input/output validation overlaps existing tool scenarios'
+    url: https://modelcontextprotocol.io/seps/2106-json-schema-2020-12#security-implications
+  - text: 'An opt-in mode that fetches non-local `$ref`s SHOULD enforce an allowlist of hosts (or at minimum reject loopback, link-local, and private network addresses), apply timeouts and size limits, and log dereferenced URIs'
+    excluded: 'Applies only when the non-default opt-in network-$ref fetch mode is enabled; not observable in default conformance runs'
+    url: https://modelcontextprotocol.io/seps/2106-json-schema-2020-12#security-implications
+  - text: 'Implementations SHOULD apply reasonable bounds — for example, a maximum schema depth, a cap on the total number of subschemas, or a per-validation time budget — to prevent a malicious tool definition from acting as a CPU DoS vector against the validator'
+    excluded: 'Internal validator resource limits (max schema depth, subschema cap, per-validation time budget); a defensive measure not observable on the wire'
+    url: https://modelcontextprotocol.io/seps/2106-json-schema-2020-12#security-implications


### PR DESCRIPTION
Adds the SEP-2484 requirement-traceability file for [SEP-2106: Tools `inputSchema` & `outputSchema` Conform to JSON Schema 2020-12](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2106), plus the scenarios that exercise it.

## Sourcing note

SEP-2106's changes to the normative spec pages (`tools.mdx` + generated `schema.mdx`) are **permissive relaxations** — outputSchema no longer restricted to `type: "object"`; full 2020-12 keywords (composition, conditionals, `$ref`/`$defs`) allowed in inputSchema; `structuredContent` may be any JSON value. These add **no new RFC 2119 obligations** (MAY-level → no rows). The one genuinely new obligation comes from allowing `$ref`: a network-`$ref`/SSRF security requirement, which lives in the SEP body, so `spec_url` points at the SEP doc.

## `src/seps/sep-2106.yaml`

**`check:` rows (1)**
- `sep-2106-no-network-ref-deref` — implementations MUST NOT auto-dereference network-URI `$ref` values; opt-in fetch MUST be off by default (merged with: unresolved external `$ref` SHOULD be rejected).

**`excluded:` rows (4)** — SDK-maintainer migration guidance; the broad "MUST continue to validate all inputs and outputs"; allowlist/timeouts for the non-default opt-in `$ref` fetch mode; internal DoS bounds. None are protocol-observable.

## Scenarios

### `json-schema-ref-no-deref` (new, client suite, `introducedIn: DRAFT-2026-v1`)
Covers the yaml's `check:` row. Advertises a tool whose `inputSchema` contains a `$ref` to a canary URL hosted by the scenario; the check fails if the client fetches it. Adversarial testing confirmed the canary catches fire-and-forget fetches, immediate `process.exit(0)`, and URL mutations (`127.0.0.1`, query strings, `HEAD`, case changes). The everything-client passes via the basic connect+listTools flow.

### `json-schema-2020-12` (extended, server suite)
Three new keyword-preservation checks for the broader vocabulary SEP-2106 permits in `inputSchema`: composition (`allOf`/`anyOf`), conditional (`if`/`then`/`else`), and reference (`$anchor`), alongside the existing SEP-1613 checks. **Soft-gated on the negotiated protocol version**: preserved → SUCCESS at any version; stripped → FAILURE only if the server negotiated `DRAFT-2026-v1`, SKIPPED otherwise (the published SDK negotiates `2025-11-25`, so older servers aren't failed against draft requirements). Includes a negative-test server (`sep-2106-stripped-schema.ts`).

These three are intentionally **not** yaml rows — they test a permissive capability (same treatment as SEP-1613) — so they will appear as `untracked` in the traceability manifest.

## Review notes (known/accepted)
- The advertised fixture schema in `everything-server.ts` is now stricter than its Zod call handler (requires phone-or-email). Nothing in the suite calls that tool with arguments; accepted as a test-fixture quirk.
- The SEP body's "servers using array/primitive `structuredContent` MUST also emit a TextContent block" is intentionally not in the yaml — the TextContent-fallback guidance predates SEP-2106.
- `src/seps/traceability.json` is not updated here; it is regenerated by the scheduled refresh workflow.

`npm run check` clean; full `vitest run` green (205 tests). Both scenarios verified end-to-end via the CLI against the everything-client / everything-server.