### PR TITLE
chore: additional server conformance tests for SEP-2575

### DIFF
--- a/examples/servers/typescript/everything-server.ts
+++ b/examples/servers/typescript/everything-server.ts
@@ -1122,25 +1122,26 @@ app.post('/mcp', async (req, res) => {
         'Transfer-Encoding': 'chunked'
       });
 
-      const subscriptionList = params.subscriptions || [];
+      const requestedNotifications = params.notifications || {};
       const trackingSubId = 'sub-token-stateless-123';
 
+      const wantsTools = requestedNotifications.toolsListChanged === true;
+      const wantsPrompts = requestedNotifications.promptsListChanged === true;
+
       // First message MUST be notifications/subscriptions/acknowledged carrying tracking token in _meta
+      // The `notifications` field echoes the subset of the requested filter the server honors.
       const ackFrame = {
         jsonrpc: '2.0',
         method: 'notifications/subscriptions/acknowledged',
         params: {
-          _meta: { 'io.modelcontextprotocol/subscriptionId': trackingSubId }
+          _meta: { 'io.modelcontextprotocol/subscriptionId': trackingSubId },
+          notifications: {
+            ...(wantsTools ? { toolsListChanged: true } : {}),
+            ...(wantsPrompts ? { promptsListChanged: true } : {})
+          }
         }
       };
       res.write(JSON.stringify(ackFrame) + '\n');
-
-      const wantsTools = subscriptionList.some(
-        (s: any) => s.type === 'tools/list-changed'
-      );
-      const wantsPrompts = subscriptionList.some(
-        (s: any) => s.type === 'prompts/list-changed'
-      );
 
       if (wantsTools) {
         res.write(

--- a/examples/servers/typescript/everything-server.ts
+++ b/examples/servers/typescript/everything-server.ts
@@ -1113,6 +1113,60 @@ app.post('/mcp', async (req, res) => {
       });
     }
 
+    // Subscriptions Listening Endpoint Stream Handler (SSE/Chunked Line)
+    if (method === 'subscriptions/listen') {
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+        'Transfer-Encoding': 'chunked'
+      });
+
+      const subscriptionList = params.subscriptions || [];
+      const trackingSubId = 'sub-token-stateless-123';
+
+      // First message MUST be notifications/subscriptions/acknowledged carrying tracking token in _meta
+      const ackFrame = {
+        jsonrpc: '2.0',
+        method: 'notifications/subscriptions/acknowledged',
+        params: {
+          _meta: { 'io.modelcontextprotocol/subscriptionId': trackingSubId }
+        }
+      };
+      res.write(JSON.stringify(ackFrame) + '\n');
+
+      const wantsTools = subscriptionList.some(
+        (s: any) => s.type === 'tools/list-changed'
+      );
+      const wantsPrompts = subscriptionList.some(
+        (s: any) => s.type === 'prompts/list-changed'
+      );
+
+      if (wantsTools) {
+        res.write(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'notifications/tools/list-changed',
+            _meta: { 'io.modelcontextprotocol/subscriptionId': trackingSubId },
+            params: { toolsListChanged: true }
+          }) + '\n'
+        );
+      }
+
+      if (wantsPrompts) {
+        res.write(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'notifications/prompts/list-changed',
+            _meta: { 'io.modelcontextprotocol/subscriptionId': trackingSubId },
+            params: { promptsListChanged: true }
+          }) + '\n'
+        );
+      }
+
+      return res.end();
+    }
+
     if (method === 'server/discover') {
       return res.json({
         jsonrpc: '2.0',
@@ -1120,8 +1174,8 @@ app.post('/mcp', async (req, res) => {
         result: {
           supportedVersions: ['DRAFT-2026-v1'],
           capabilities: {
-            tools: { listChanged: false }, // Explicitly declare capability flags to resolve check assertions
-            prompts: { listChanged: false }
+            tools: { listChanged: true }, // Explicitly announce dynamic capabilities matching Section 7 expectations
+            prompts: { listChanged: true }
           },
           serverInfo: { name: 'everything-stateless-server', version: '1.0.0' }
         }
@@ -1137,6 +1191,17 @@ app.post('/mcp', async (req, res) => {
             {
               name: 'test_missing_capability',
               description: 'Test tool requiring sampling',
+              inputSchema: { type: 'object', properties: {} }
+            },
+            {
+              name: 'test_streaming_elicitation',
+              description:
+                'Diagnostic tool validating response progress streams',
+              inputSchema: { type: 'object', properties: {} }
+            },
+            {
+              name: 'test_logging_tool',
+              description: 'Diagnostic logging validator tool',
               inputSchema: { type: 'object', properties: {} }
             }
           ]
@@ -1174,6 +1239,72 @@ app.post('/mcp', async (req, res) => {
           jsonrpc: '2.0',
           id,
           result: { content: [{ type: 'text', text: 'Success' }] }
+        });
+      }
+
+      // Progressive IncompleteResult Stream Generator Handling
+      if (name === 'test_streaming_elicitation') {
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+          'Transfer-Encoding': 'chunked'
+        });
+
+        res.write(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'notifications/progress', // Emits standard progress notice
+            params: { progressToken: 'token-abc', total: 100, value: 50 }
+          }) + '\n'
+        );
+
+        return res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id,
+            result: { content: [{ type: 'text', text: 'Streaming complete' }] }
+          })
+        );
+      }
+
+      // Contextual Logging Constraints Verification Handler
+      if (name === 'test_logging_tool') {
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+          'Transfer-Encoding': 'chunked'
+        });
+
+        // RULE: No logs allowed if meta configuration lacks explicit log level bounds
+        if (meta && meta['io.modelcontextprotocol/logLevel']) {
+          res.write(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              method: 'notifications/message',
+              params: {
+                level: 'info',
+                text: 'Diagnostic trace logging activated'
+              }
+            }) + '\n'
+          );
+        }
+
+        return res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id,
+            result: { content: [{ type: 'text', text: 'Logging evaluated' }] }
+          })
+        );
+      }
+
+      // Helper mutation hooks used by dynamic tests to force stream activity evaluation
+      if (
+        name === 'test_trigger_tool_change' ||
+        name === 'test_trigger_prompt_change'
+      ) {
+        return res.json({
+          jsonrpc: '2.0',
+          id,
+          result: { content: [{ type: 'text', text: 'Mutation triggered' }] }
         });
       }
     }

--- a/examples/servers/typescript/everything-server.ts
+++ b/examples/servers/typescript/everything-server.ts
@@ -1041,6 +1041,38 @@ function isInitializeRequest(body: any): boolean {
 // Use createMcpExpressApp for DNS rebinding protection on localhost
 const app = createMcpExpressApp();
 
+// Open subscriptions/listen streams (SEP-2575). Notifications are delivered
+// to whichever streams are open *at the time of the change* and whose filter
+// requested that notification type.
+interface ListenStream {
+  res: import('express').Response;
+  subscriptionId: string;
+  wantsTools: boolean;
+  wantsPrompts: boolean;
+}
+const activeListenStreams: ListenStream[] = [];
+
+function notifyListenStreams(
+  type: 'tools' | 'prompts',
+  notificationMethod: string
+) {
+  for (const stream of activeListenStreams) {
+    const wants = type === 'tools' ? stream.wantsTools : stream.wantsPrompts;
+    if (!wants) continue;
+    stream.res.write(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        method: notificationMethod,
+        params: {
+          _meta: {
+            'io.modelcontextprotocol/subscriptionId': stream.subscriptionId
+          }
+        }
+      }) + '\n'
+    );
+  }
+}
+
 // Configure CORS to expose Mcp-Session-Id header for browser-based clients
 app.use(
   cors({
@@ -1123,7 +1155,8 @@ app.post('/mcp', async (req, res) => {
       });
 
       const requestedNotifications = params.notifications || {};
-      const trackingSubId = 'sub-token-stateless-123';
+      // The subscription ID matches the JSON-RPC id of the listen request.
+      const trackingSubId = String(id ?? 'sub-token-stateless-123');
 
       const wantsTools = requestedNotifications.toolsListChanged === true;
       const wantsPrompts = requestedNotifications.promptsListChanged === true;
@@ -1143,29 +1176,21 @@ app.post('/mcp', async (req, res) => {
       };
       res.write(JSON.stringify(ackFrame) + '\n');
 
-      if (wantsTools) {
-        res.write(
-          JSON.stringify({
-            jsonrpc: '2.0',
-            method: 'notifications/tools/list_changed',
-            _meta: { 'io.modelcontextprotocol/subscriptionId': trackingSubId },
-            params: { toolsListChanged: true }
-          }) + '\n'
-        );
-      }
-
-      if (wantsPrompts) {
-        res.write(
-          JSON.stringify({
-            jsonrpc: '2.0',
-            method: 'notifications/prompts/list_changed',
-            _meta: { 'io.modelcontextprotocol/subscriptionId': trackingSubId },
-            params: { promptsListChanged: true }
-          }) + '\n'
-        );
-      }
-
-      return res.end();
+      // Keep the stream open and register it so list-changed notifications
+      // triggered by later requests are delivered to it. The stream ends when
+      // the client disconnects (which is also how the client cancels it).
+      const stream: ListenStream = {
+        res,
+        subscriptionId: trackingSubId,
+        wantsTools,
+        wantsPrompts
+      };
+      activeListenStreams.push(stream);
+      res.on('close', () => {
+        const index = activeListenStreams.indexOf(stream);
+        if (index !== -1) activeListenStreams.splice(index, 1);
+      });
+      return;
     }
 
     if (method === 'server/discover') {
@@ -1297,11 +1322,18 @@ app.post('/mcp', async (req, res) => {
         );
       }
 
-      // Helper mutation hooks used by dynamic tests to force stream activity evaluation
+      // Helper mutation hooks used by dynamic tests to force stream activity
+      // evaluation. The list change is fanned out to whichever
+      // subscriptions/listen streams are currently open and asked for it.
       if (
         name === 'test_trigger_tool_change' ||
         name === 'test_trigger_prompt_change'
       ) {
+        if (name === 'test_trigger_tool_change') {
+          notifyListenStreams('tools', 'notifications/tools/list_changed');
+        } else {
+          notifyListenStreams('prompts', 'notifications/prompts/list_changed');
+        }
         return res.json({
           jsonrpc: '2.0',
           id,

--- a/examples/servers/typescript/everything-server.ts
+++ b/examples/servers/typescript/everything-server.ts
@@ -1147,7 +1147,7 @@ app.post('/mcp', async (req, res) => {
         res.write(
           JSON.stringify({
             jsonrpc: '2.0',
-            method: 'notifications/tools/list-changed',
+            method: 'notifications/tools/list_changed',
             _meta: { 'io.modelcontextprotocol/subscriptionId': trackingSubId },
             params: { toolsListChanged: true }
           }) + '\n'
@@ -1158,7 +1158,7 @@ app.post('/mcp', async (req, res) => {
         res.write(
           JSON.stringify({
             jsonrpc: '2.0',
-            method: 'notifications/prompts/list-changed',
+            method: 'notifications/prompts/list_changed',
             _meta: { 'io.modelcontextprotocol/subscriptionId': trackingSubId },
             params: { promptsListChanged: true }
           }) + '\n'

--- a/src/scenarios/server/stateless.test.ts
+++ b/src/scenarios/server/stateless.test.ts
@@ -307,10 +307,10 @@ describe('Stateless Server Scenario Negative Tests', () => {
                 'io.modelcontextprotocol/subscriptionId': 'sub-leak-test'
               }
             },
-            // LEAK VIOLATION: Server sends tools/list-changed on a prompt-only stream
+            // LEAK VIOLATION: Server sends tools/list_changed on a prompt-only stream
             {
               jsonrpc: '2.0',
-              method: 'notifications/tools/list-changed',
+              method: 'notifications/tools/list_changed',
               _meta: {
                 'io.modelcontextprotocol/subscriptionId': 'sub-leak-test'
               }

--- a/src/scenarios/server/stateless.test.ts
+++ b/src/scenarios/server/stateless.test.ts
@@ -13,7 +13,69 @@ describe('Stateless Server Scenario Negative Tests', () => {
     global.fetch = async (_url: any, init: any) => {
       const body = JSON.parse(init.body);
       const headers = init.headers || {};
-      const responseConfig = await handler(body, headers);
+
+      let responseConfig = await handler(body, headers);
+
+      // GLOBAL SPEC-COMPLIANT FALLBACKS: Provides successful data loops for downstream checks
+      // if individual tests are focusing exclusively on separate fields (like discovery or meta checks).
+      if (!responseConfig) {
+        if (body.method === 'subscriptions/listen') {
+          responseConfig = {
+            isStream: true,
+            status: 200,
+            frames: [
+              {
+                jsonrpc: '2.0',
+                method: 'notifications/subscriptions/acknowledged',
+                params: {
+                  _meta: {
+                    'io.modelcontextprotocol/subscriptionId':
+                      'global-valid-sub-id'
+                  }
+                }
+              }
+            ]
+          };
+        } else if (body.method === 'tools/call') {
+          responseConfig = {
+            isStream: true,
+            status: 200,
+            frames: [
+              {
+                jsonrpc: '2.0',
+                result: {
+                  content: [{ type: 'text', text: 'Progress chunk details' }]
+                }
+              }
+            ]
+          };
+        }
+      }
+
+      if (responseConfig?.isStream) {
+        const streamData = responseConfig.frames.map(
+          (f: any) => JSON.stringify(f) + '\n'
+        );
+        let frameIndex = 0;
+
+        const mockReader = {
+          read: async () => {
+            if (frameIndex >= streamData.length) {
+              return { value: undefined, done: true };
+            }
+            const chunk = new TextEncoder().encode(streamData[frameIndex++]);
+            return { value: chunk, done: false };
+          }
+        };
+
+        return {
+          status: responseConfig?.status ?? 200,
+          body: {
+            getReader: () => mockReader,
+            releaseLock: () => {}
+          }
+        } as unknown as Response;
+      }
 
       return {
         status: responseConfig?.status ?? 404,
@@ -134,5 +196,215 @@ describe('Stateless Server Scenario Negative Tests', () => {
       'sep-2575-server-unsupported-version-error'
     );
     expect(negotiationMatchCheck?.status).toBe('FAILURE');
+  });
+
+  test('Fails validation when stream does not send subscription acknowledgement or tracking ID', async () => {
+    const mockUrl = mockFetchTarget((reqBody) => {
+      if (reqBody.method === 'subscriptions/listen') {
+        return {
+          isStream: true,
+          status: 200,
+          frames: [
+            {
+              jsonrpc: '2.0',
+              method: 'notifications/some-unrelated-event',
+              params: { _meta: {} }
+            }
+          ]
+        };
+      }
+    });
+
+    const scenario = new ServerStatelessScenario();
+    const checks = await scenario.run(mockUrl);
+
+    const ackCheck = findCheck(
+      checks,
+      'sep-2575-server-sends-subscription-ack'
+    );
+    const idCheck = findCheck(checks, 'sep-2575-server-tags-subscription-id');
+
+    expect(ackCheck?.status).toBe('FAILURE');
+    expect(idCheck?.status).toBe('FAILURE');
+  });
+
+  test('Fails validation when tool response stream leaks raw independent JSON-RPC requests', async () => {
+    const mockUrl = mockFetchTarget((reqBody) => {
+      if (
+        reqBody.method === 'tools/call' &&
+        reqBody.params?.name === 'test_streaming_elicitation'
+      ) {
+        return {
+          isStream: true,
+          status: 200,
+          frames: [
+            {
+              jsonrpc: '2.0',
+              id: 'server-driven-id-999',
+              method: 'client/some-arbitrary-request',
+              params: {}
+            }
+          ]
+        };
+      }
+    });
+
+    const scenario = new ServerStatelessScenario();
+    const checks = await scenario.run(mockUrl);
+
+    const independentRequestCheck = findCheck(
+      checks,
+      'sep-2575-http-server-no-independent-requests-on-stream'
+    );
+    expect(independentRequestCheck?.status).toBe('FAILURE');
+  });
+
+  test('Fails validation when logging occurs without an explicit client request logLevel metadata', async () => {
+    const mockUrl = mockFetchTarget((reqBody) => {
+      if (
+        reqBody.method === 'tools/call' &&
+        reqBody.params?.name === 'test_logging_tool'
+      ) {
+        return {
+          isStream: true,
+          status: 200,
+          frames: [
+            {
+              jsonrpc: '2.0',
+              method: 'notifications/message',
+              params: { level: 'debug', text: 'Stray log frame' }
+            }
+          ]
+        };
+      }
+    });
+
+    const scenario = new ServerStatelessScenario();
+    const checks = await scenario.run(mockUrl);
+
+    const logWithoutLevelCheck = findCheck(
+      checks,
+      'sep-2575-server-no-log-without-loglevel'
+    );
+    expect(logWithoutLevelCheck?.status).toBe('FAILURE');
+  });
+
+  test('Fails validation when server leaks out-of-filter notifications on a subscription stream', async () => {
+    const mockUrl = mockFetchTarget((reqBody) => {
+      // The scenario subscribes ONLY to prompts/list-changed
+      if (
+        reqBody.method === 'subscriptions/listen' &&
+        reqBody.params?.subscriptions?.[0]?.type === 'prompts/list-changed'
+      ) {
+        return {
+          isStream: true,
+          status: 200,
+          frames: [
+            {
+              jsonrpc: '2.0',
+              method: 'notifications/subscriptions/acknowledged',
+              _meta: {
+                'io.modelcontextprotocol/subscriptionId': 'sub-leak-test'
+              }
+            },
+            // LEAK VIOLATION: Server sends tools/list-changed on a prompt-only stream
+            {
+              jsonrpc: '2.0',
+              method: 'notifications/tools/list-changed',
+              _meta: {
+                'io.modelcontextprotocol/subscriptionId': 'sub-leak-test'
+              }
+            }
+          ]
+        };
+      }
+    });
+
+    const scenario = new ServerStatelessScenario();
+    const checks = await scenario.run(mockUrl);
+
+    const filterCheck = findCheck(
+      checks,
+      'sep-2575-server-honors-notification-filter'
+    );
+    expect(filterCheck?.status).toBe('FAILURE');
+  });
+
+  test('Fails validation when server drops tools or prompts list changed notifications despite declaring capabilities', async () => {
+    const mockUrl = mockFetchTarget((reqBody) => {
+      // 1. Declare BOTH capabilities so neither check is skipped
+      if (reqBody.method === 'server/discover') {
+        return {
+          status: 200,
+          body: {
+            jsonrpc: '2.0',
+            id: reqBody.id,
+            result: {
+              supportedVersions: ['DRAFT-2026-v1'],
+              capabilities: {
+                tools: { listChanged: true },
+                prompts: { listChanged: true }
+              },
+              serverInfo: { name: 'test-server', version: '1.0' }
+            }
+          }
+        };
+      }
+
+      // 2. Allow BOTH mutation triggers to succeed
+      if (
+        reqBody.method === 'tools/call' &&
+        (reqBody.params?.name === 'test_trigger_prompt_change' ||
+          reqBody.params?.name === 'test_trigger_tool_change')
+      ) {
+        return {
+          status: 200,
+          body: {
+            jsonrpc: '2.0',
+            id: reqBody.id,
+            result: { content: [{ type: 'text', text: 'mutated' }] }
+          }
+        };
+      }
+
+      // 3. Provide the streams but withhold the required notifications for BOTH channels
+      if (reqBody.method === 'subscriptions/listen') {
+        const subType = reqBody.params?.subscriptions?.[0]?.type;
+        if (
+          subType === 'prompts/list-changed' ||
+          subType === 'tools/list-changed'
+        ) {
+          return {
+            isStream: true,
+            status: 200,
+            frames: [
+              {
+                jsonrpc: '2.0',
+                method: 'notifications/subscriptions/acknowledged',
+                _meta: {
+                  'io.modelcontextprotocol/subscriptionId': `sub-${subType}-test`
+                }
+              }
+              // MISSING VIOLATION: We never send the expected notifications/[type]/list-changed
+            ]
+          };
+        }
+      }
+    });
+
+    const scenario = new ServerStatelessScenario();
+    const checks = await scenario.run(mockUrl);
+
+    const promptsCheck = findCheck(
+      checks,
+      'sep-2575-server-sends-prompts-list-changed-on-subscription'
+    );
+    const toolsCheck = findCheck(
+      checks,
+      'sep-2575-server-sends-tools-list-changed-on-subscription'
+    );
+
+    expect(promptsCheck?.status).toBe('FAILURE');
+    expect(toolsCheck?.status).toBe('FAILURE');
   });
 });

--- a/src/scenarios/server/stateless.test.ts
+++ b/src/scenarios/server/stateless.test.ts
@@ -330,7 +330,7 @@ describe('Stateless Server Scenario Negative Tests', () => {
     expect(filterCheck?.status).toBe('FAILURE');
   });
 
-  test('Fails validation when server drops tools or prompts list changed notifications despite declaring capabilities', async () => {
+  test('Warns when server drops tools or prompts list changed notifications despite declaring capabilities', async () => {
     const mockUrl = mockFetchTarget((reqBody) => {
       // 1. Declare BOTH capabilities so neither check is skipped
       if (reqBody.method === 'server/discover') {
@@ -404,7 +404,8 @@ describe('Stateless Server Scenario Negative Tests', () => {
       'sep-2575-server-sends-tools-list-changed-on-subscription'
     );
 
-    expect(promptsCheck?.status).toBe('FAILURE');
-    expect(toolsCheck?.status).toBe('FAILURE');
+    // These map to SHOULD requirements, so severity is WARNING not FAILURE.
+    expect(promptsCheck?.status).toBe('WARNING');
+    expect(toolsCheck?.status).toBe('WARNING');
   });
 });

--- a/src/scenarios/server/stateless.test.ts
+++ b/src/scenarios/server/stateless.test.ts
@@ -291,10 +291,10 @@ describe('Stateless Server Scenario Negative Tests', () => {
 
   test('Fails validation when server leaks out-of-filter notifications on a subscription stream', async () => {
     const mockUrl = mockFetchTarget((reqBody) => {
-      // The scenario subscribes ONLY to prompts/list-changed
+      // The scenario subscribes ONLY to prompts list-changed notifications
       if (
         reqBody.method === 'subscriptions/listen' &&
-        reqBody.params?.subscriptions?.[0]?.type === 'prompts/list-changed'
+        reqBody.params?.notifications?.promptsListChanged === true
       ) {
         return {
           isStream: true,
@@ -369,10 +369,10 @@ describe('Stateless Server Scenario Negative Tests', () => {
 
       // 3. Provide the streams but withhold the required notifications for BOTH channels
       if (reqBody.method === 'subscriptions/listen') {
-        const subType = reqBody.params?.subscriptions?.[0]?.type;
+        const filter = reqBody.params?.notifications;
         if (
-          subType === 'prompts/list-changed' ||
-          subType === 'tools/list-changed'
+          filter?.promptsListChanged === true ||
+          filter?.toolsListChanged === true
         ) {
           return {
             isStream: true,
@@ -382,10 +382,10 @@ describe('Stateless Server Scenario Negative Tests', () => {
                 jsonrpc: '2.0',
                 method: 'notifications/subscriptions/acknowledged',
                 _meta: {
-                  'io.modelcontextprotocol/subscriptionId': `sub-${subType}-test`
+                  'io.modelcontextprotocol/subscriptionId': 'sub-drop-test'
                 }
               }
-              // MISSING VIOLATION: We never send the expected notifications/[type]/list-changed
+              // MISSING VIOLATION: We never send the expected notifications/*/list_changed
             ]
           };
         }

--- a/src/scenarios/server/stateless.ts
+++ b/src/scenarios/server/stateless.ts
@@ -170,7 +170,17 @@ export class ServerStatelessScenario implements ClientScenario {
 
         try {
           while (frames.length < maxFrames) {
-            const { value, done } = await reader.read();
+            let value: Uint8Array | undefined;
+            let done = false;
+            try {
+              ({ value, done } = await reader.read());
+            } catch {
+              // The stream was aborted (timeout) or dropped. A compliant
+              // server holds a subscriptions/listen stream open indefinitely,
+              // so hitting the timeout is the normal way these reads end —
+              // return whatever frames arrived before it fired.
+              break;
+            }
 
             if (value) {
               buffer += decoder.decode(value, { stream: true });

--- a/src/scenarios/server/stateless.ts
+++ b/src/scenarios/server/stateless.ts
@@ -57,15 +57,32 @@ export class ServerStatelessScenario implements ClientScenario {
       name: string,
       description: string,
       fn: () =>
-        | Promise<{ error?: string; skipped?: boolean; details?: any } | void>
-        | ({ error?: string; skipped?: boolean; details?: any } | void),
+        | Promise<
+            | {
+                error?: string;
+                warning?: boolean;
+                skipped?: boolean;
+                details?: any;
+              }
+            | void
+          >
+        | ({
+            error?: string;
+            warning?: boolean;
+            skipped?: boolean;
+            details?: any;
+          } | void),
       fallbackDetails = {}
     ) {
       try {
         const result = await fn();
         const errorMessage = result?.error;
+        // SHOULD-level requirements report WARNING rather than FAILURE
+        // (severity follows the spec keyword).
         const status = errorMessage
-          ? 'FAILURE'
+          ? result?.warning
+            ? 'WARNING'
+            : 'FAILURE'
           : result?.skipped
             ? 'SKIPPED'
             : 'SUCCESS';
@@ -961,7 +978,7 @@ export class ServerStatelessScenario implements ClientScenario {
     await runCheck(
       'sep-2575-server-sends-prompts-list-changed-on-subscription',
       'ServerSendsPromptsListChangedOnSubscription',
-      'List-changed-capable servers notify listen streams with promptsListChanged: true',
+      'List-changed-capable servers notify listen streams with promptsListChanged: true (SHOULD)',
       async () => {
         // Automatically pass/skip if the server didn't declare this capability during discovery
         if (!discoverCapabilities?.prompts?.listChanged) {
@@ -1006,6 +1023,7 @@ export class ServerStatelessScenario implements ClientScenario {
 
         if (frames.length === 0) {
           return {
+            warning: true,
             error:
               'Failed to open or receive frames from the subscriptions/listen stream endpoint'
           };
@@ -1016,8 +1034,9 @@ export class ServerStatelessScenario implements ClientScenario {
         );
         if (!changeFrame) {
           return {
+            warning: true,
             error:
-              'Mutated prompt fields on target SUT but no list verification event popped on subscription listener'
+              'Mutated the prompt list but no notifications/prompts/list_changed arrived on the open subscription stream. This is a SHOULD requirement.'
           };
         }
         return { details: { changeFrame } };
@@ -1027,7 +1046,7 @@ export class ServerStatelessScenario implements ClientScenario {
     await runCheck(
       'sep-2575-server-sends-tools-list-changed-on-subscription',
       'ServerSendsToolsListChangedOnSubscription',
-      'List-changed-capable servers notify listen streams with toolsListChanged: true',
+      'List-changed-capable servers notify listen streams with toolsListChanged: true (SHOULD)',
       async () => {
         // Automatically pass/skip if the server didn't declare this capability during discovery
         if (!discoverCapabilities?.tools?.listChanged) {
@@ -1072,6 +1091,7 @@ export class ServerStatelessScenario implements ClientScenario {
 
         if (frames.length === 0) {
           return {
+            warning: true,
             error:
               'Failed to open or receive frames from the subscriptions/listen stream endpoint'
           };
@@ -1082,8 +1102,9 @@ export class ServerStatelessScenario implements ClientScenario {
         );
         if (!changeFrame) {
           return {
+            warning: true,
             error:
-              'Mutated tool entries on target SUT but no notification found on streaming line'
+              'Mutated the tool list but no notifications/tools/list_changed arrived on the open subscription stream. This is a SHOULD requirement.'
           };
         }
         return { details: { changeFrame } };

--- a/src/scenarios/server/stateless.ts
+++ b/src/scenarios/server/stateless.ts
@@ -125,12 +125,16 @@ export class ServerStatelessScenario implements ClientScenario {
       return { res, data };
     };
 
-    // Helper to read multi-frame streaming endpoints (like subscriptions/listen)
+    // Helper to read multi-frame streaming endpoints (like subscriptions/listen).
+    // `onFirstFrame` runs once after the first frame arrives (i.e. after the
+    // server has acknowledged the subscription) so callers can trigger
+    // side effects on a separate connection while this stream is still open.
     const listenToStream = async (
       method: string,
       params?: any,
       maxFrames = 3,
-      timeoutMs = 1000
+      timeoutMs = 1000,
+      onFirstFrame?: () => Promise<void>
     ): Promise<any[]> => {
       const headers = {
         'Content-Type': 'application/json',
@@ -167,6 +171,17 @@ export class ServerStatelessScenario implements ClientScenario {
         const decoder = new TextDecoder();
         const frames: any[] = [];
         let buffer = '';
+        let firstFrameCallbackFired = false;
+        const maybeFireFirstFrameCallback = async () => {
+          if (firstFrameCallbackFired || frames.length === 0 || !onFirstFrame)
+            return;
+          firstFrameCallbackFired = true;
+          try {
+            await onFirstFrame();
+          } catch {
+            // The trigger failed; the caller inspects its own captured result.
+          }
+        };
 
         try {
           while (frames.length < maxFrames) {
@@ -200,6 +215,7 @@ export class ServerStatelessScenario implements ClientScenario {
                   // Keep segment buffering
                 }
               }
+              await maybeFireFirstFrameCallback();
             }
 
             if (done) {
@@ -864,16 +880,22 @@ export class ServerStatelessScenario implements ClientScenario {
           notifications: { promptsListChanged: true }
         };
 
-        await sendRpc('tools/call', {
-          name: 'test_trigger_tool_change',
-          arguments: {},
-          _meta: validMeta
-        });
+        // Open a stream filtered to prompts only, then mutate the *tool* list
+        // on a separate connection once the subscription is acknowledged. A
+        // compliant server must not deliver the resulting tools notification
+        // to this stream.
         const narrowFrames = await listenToStream(
           'subscriptions/listen',
           narrowParams,
           3,
-          500
+          1500,
+          async () => {
+            await sendRpc('tools/call', {
+              name: 'test_trigger_tool_change',
+              arguments: {},
+              _meta: validMeta
+            });
+          }
         );
 
         if (narrowFrames[0]?.error?.code === -32601) {
@@ -928,12 +950,25 @@ export class ServerStatelessScenario implements ClientScenario {
           _meta: validMeta,
           notifications: { promptsListChanged: true }
         };
-        const trigger = await sendRpc('tools/call', {
-          name: 'test_trigger_prompt_change',
-          arguments: {},
-          _meta: validMeta
-        });
-        if (trigger.data?.error?.code === -32601) {
+
+        // Open the subscription first; mutate the prompt list on a separate
+        // connection once it is acknowledged. A compliant server only
+        // notifies streams that are open at the time of the change.
+        let trigger: any = null;
+        const frames = await listenToStream(
+          'subscriptions/listen',
+          promptsParams,
+          2,
+          1500,
+          async () => {
+            trigger = await sendRpc('tools/call', {
+              name: 'test_trigger_prompt_change',
+              arguments: {},
+              _meta: validMeta
+            });
+          }
+        );
+        if (trigger?.data?.error?.code === -32601) {
           return {
             skipped: true,
             details: {
@@ -942,17 +977,10 @@ export class ServerStatelessScenario implements ClientScenario {
           };
         }
 
-        const frames = await listenToStream(
-          'subscriptions/listen',
-          promptsParams,
-          3,
-          600
-        );
-
         if (frames.length === 0) {
           return {
             error:
-              'Mutated configuration parameters but subscription event monitoring stream returned zero frames'
+              'Failed to open or receive frames from the subscriptions/listen stream endpoint'
           };
         }
 
@@ -988,12 +1016,25 @@ export class ServerStatelessScenario implements ClientScenario {
           _meta: validMeta,
           notifications: { toolsListChanged: true }
         };
-        const trigger = await sendRpc('tools/call', {
-          name: 'test_trigger_tool_change',
-          arguments: {},
-          _meta: validMeta
-        });
-        if (trigger.data?.error?.code === -32601) {
+
+        // Open the subscription first; mutate the tool list on a separate
+        // connection once it is acknowledged. A compliant server only
+        // notifies streams that are open at the time of the change.
+        let trigger: any = null;
+        const frames = await listenToStream(
+          'subscriptions/listen',
+          toolsParams,
+          2,
+          1500,
+          async () => {
+            trigger = await sendRpc('tools/call', {
+              name: 'test_trigger_tool_change',
+              arguments: {},
+              _meta: validMeta
+            });
+          }
+        );
+        if (trigger?.data?.error?.code === -32601) {
           return {
             skipped: true,
             details: {
@@ -1002,17 +1043,10 @@ export class ServerStatelessScenario implements ClientScenario {
           };
         }
 
-        const frames = await listenToStream(
-          'subscriptions/listen',
-          toolsParams,
-          3,
-          600
-        );
-
         if (frames.length === 0) {
           return {
             error:
-              'Mutated underlying tooling array indexes but listener subscription returned zero chunks'
+              'Failed to open or receive frames from the subscriptions/listen stream endpoint'
           };
         }
 

--- a/src/scenarios/server/stateless.ts
+++ b/src/scenarios/server/stateless.ts
@@ -755,7 +755,7 @@ export class ServerStatelessScenario implements ClientScenario {
     // ==========================================
     const subscriptionParams = {
       _meta: validMeta,
-      subscriptions: [{ type: 'tools/list-changed' }]
+      notifications: { toolsListChanged: true }
     };
 
     let streamFrames: any[] = [];
@@ -851,7 +851,7 @@ export class ServerStatelessScenario implements ClientScenario {
       async () => {
         const narrowParams = {
           _meta: validMeta,
-          subscriptions: [{ type: 'prompts/list-changed' }]
+          notifications: { promptsListChanged: true }
         };
 
         await sendRpc('tools/call', {
@@ -917,7 +917,7 @@ export class ServerStatelessScenario implements ClientScenario {
 
         const promptsParams = {
           _meta: validMeta,
-          subscriptions: [{ type: 'prompts/list-changed' }]
+          notifications: { promptsListChanged: true }
         };
         const trigger = await sendRpc('tools/call', {
           name: 'test_trigger_prompt_change',
@@ -979,7 +979,7 @@ export class ServerStatelessScenario implements ClientScenario {
 
         const toolsParams = {
           _meta: validMeta,
-          subscriptions: [{ type: 'tools/list-changed' }]
+          notifications: { toolsListChanged: true }
         };
         const trigger = await sendRpc('tools/call', {
           name: 'test_trigger_tool_change',

--- a/src/scenarios/server/stateless.ts
+++ b/src/scenarios/server/stateless.ts
@@ -57,15 +57,12 @@ export class ServerStatelessScenario implements ClientScenario {
       name: string,
       description: string,
       fn: () =>
-        | Promise<
-            | {
-                error?: string;
-                warning?: boolean;
-                skipped?: boolean;
-                details?: any;
-              }
-            | void
-          >
+        | Promise<{
+            error?: string;
+            warning?: boolean;
+            skipped?: boolean;
+            details?: any;
+          } | void>
         | ({
             error?: string;
             warning?: boolean;
@@ -746,6 +743,19 @@ export class ServerStatelessScenario implements ClientScenario {
           };
         }
 
+        // If the call was rejected outright (e.g. the diagnostic tool does
+        // not exist), nothing was streamed and the requirement was not
+        // exercised - report SKIPPED rather than a vacuous SUCCESS.
+        if (frames.every((f) => f?.error !== undefined)) {
+          return {
+            skipped: true,
+            details: {
+              note: 'Server does not expose diagnostic tool test_streaming_elicitation; the response stream could not be exercised.',
+              response: frames[0]
+            }
+          };
+        }
+
         const hasIndependentRequest = frames.some(
           (f) => f.method && !f.method.startsWith('notifications/')
         );
@@ -776,6 +786,20 @@ export class ServerStatelessScenario implements ClientScenario {
           return {
             error:
               'Logging target endpoint context dropped or failed to yield frame structures'
+          };
+        }
+
+        // If the call was rejected outright (e.g. the diagnostic tool does
+        // not exist), the server never had anything to log and the
+        // requirement was not exercised - report SKIPPED rather than a
+        // vacuous SUCCESS.
+        if (frames.every((f) => f?.error !== undefined)) {
+          return {
+            skipped: true,
+            details: {
+              note: 'Server does not expose diagnostic tool test_logging_tool; the no-log-without-logLevel requirement could not be exercised.',
+              response: frames[0]
+            }
           };
         }
 
@@ -843,9 +867,7 @@ export class ServerStatelessScenario implements ClientScenario {
           };
         }
         const firstFrame = streamFrames[0];
-        if (
-          firstFrame?.method !== 'notifications/subscriptions/acknowledged'
-        ) {
+        if (firstFrame?.method !== 'notifications/subscriptions/acknowledged') {
           return {
             error: `Expected first frame method to be 'notifications/subscriptions/acknowledged', got '${firstFrame?.method}'`,
             details: { firstFrame }
@@ -891,8 +913,7 @@ export class ServerStatelessScenario implements ClientScenario {
         }
 
         const untaggedFrames = notificationFrames.filter(
-          (f) =>
-            !f?.params?._meta?.['io.modelcontextprotocol/subscriptionId']
+          (f) => !f?.params?._meta?.['io.modelcontextprotocol/subscriptionId']
         );
         if (untaggedFrames.length > 0) {
           return {

--- a/src/scenarios/server/stateless.ts
+++ b/src/scenarios/server/stateless.ts
@@ -881,10 +881,9 @@ export class ServerStatelessScenario implements ClientScenario {
           };
         }
 
-        const leakedToolFrame = narrowFrames.find((f) => {
-          const m = f?.method ?? f?.body?.method ?? f?.params?.method;
-          return m === 'notifications/tools/list-changed';
-        });
+        const leakedToolFrame = narrowFrames.find(
+          (f) => f?.method === 'notifications/tools/list_changed'
+        );
 
         if (leakedToolFrame) {
           return {
@@ -948,9 +947,7 @@ export class ServerStatelessScenario implements ClientScenario {
         }
 
         const changeFrame = frames.find(
-          (f) =>
-            f.method === 'notifications/prompts/list-changed' ||
-            f.params?.promptsListChanged === true
+          (f) => f.method === 'notifications/prompts/list_changed'
         );
         if (!changeFrame) {
           return {
@@ -1010,9 +1007,7 @@ export class ServerStatelessScenario implements ClientScenario {
         }
 
         const changeFrame = frames.find(
-          (f) =>
-            f.method === 'notifications/tools/list-changed' ||
-            f.params?.toolsListChanged === true
+          (f) => f.method === 'notifications/tools/list_changed'
         );
         if (!changeFrame) {
           return {

--- a/src/scenarios/server/stateless.ts
+++ b/src/scenarios/server/stateless.ts
@@ -784,13 +784,23 @@ export class ServerStatelessScenario implements ClientScenario {
       notifications: { toolsListChanged: true }
     };
 
+    // Open a tools-filtered stream and (best-effort) trigger a tool-list
+    // change once it is acknowledged, so the stream carries at least one
+    // post-acknowledgment notification for the subscription-id check.
     let streamFrames: any[] = [];
     try {
       streamFrames = await listenToStream(
         'subscriptions/listen',
         subscriptionParams,
         2,
-        800
+        800,
+        async () => {
+          await sendRpc('tools/call', {
+            name: 'test_trigger_tool_change',
+            arguments: {},
+            _meta: validMeta
+          });
+        }
       );
     } catch {
       // Stream pipeline tracking failed
@@ -816,14 +826,11 @@ export class ServerStatelessScenario implements ClientScenario {
           };
         }
         const firstFrame = streamFrames[0];
-        const resolvedMethod =
-          firstFrame?.method ??
-          firstFrame?.body?.method ??
-          firstFrame?.params?.method;
-
-        if (resolvedMethod !== 'notifications/subscriptions/acknowledged') {
+        if (
+          firstFrame?.method !== 'notifications/subscriptions/acknowledged'
+        ) {
           return {
-            error: `Expected first frame method to be 'notifications/subscriptions/acknowledged', got '${resolvedMethod}'`,
+            error: `Expected first frame method to be 'notifications/subscriptions/acknowledged', got '${firstFrame?.method}'`,
             details: { firstFrame }
           };
         }
@@ -850,23 +857,43 @@ export class ServerStatelessScenario implements ClientScenario {
               'Failed to open stream line or tracking frames are missing completely'
           };
         }
-        const ackFrame =
-          streamFrames.find((f) => {
-            const m = f?.method ?? f?.body?.method ?? f?.params?.method;
-            return m === 'notifications/subscriptions/acknowledged';
-          }) ?? streamFrames[0];
 
-        const subId =
-          ackFrame?.params?._meta?.['io.modelcontextprotocol/subscriptionId'];
-
-        if (!subId) {
+        // Every notification delivered on the stream (the acknowledgment and
+        // anything after it) must carry the subscription id in params._meta.
+        const notificationFrames = streamFrames.filter(
+          (f) =>
+            typeof f?.method === 'string' &&
+            f.method.startsWith('notifications/')
+        );
+        if (notificationFrames.length === 0) {
           return {
             error:
-              'Subscription acknowledgment frame is missing the tracking subscriptionId in _meta',
-            details: { ackFrame }
+              'subscriptions/listen stream carried no notification frames to inspect',
+            details: { streamFrames }
           };
         }
-        return { details: { subscriptionId: subId, ackFrame } };
+
+        const untaggedFrames = notificationFrames.filter(
+          (f) =>
+            !f?.params?._meta?.['io.modelcontextprotocol/subscriptionId']
+        );
+        if (untaggedFrames.length > 0) {
+          return {
+            error: `${untaggedFrames.length} of ${notificationFrames.length} listen-stream notification(s) are missing io.modelcontextprotocol/subscriptionId in params._meta`,
+            details: { untaggedFrames }
+          };
+        }
+
+        const subId =
+          notificationFrames[0]?.params?._meta?.[
+            'io.modelcontextprotocol/subscriptionId'
+          ];
+        return {
+          details: {
+            subscriptionId: subId,
+            inspectedNotificationCount: notificationFrames.length
+          }
+        };
       }
     );
 

--- a/src/scenarios/server/stateless.ts
+++ b/src/scenarios/server/stateless.ts
@@ -38,8 +38,14 @@ export class ServerStatelessScenario implements ClientScenario {
    - Absent or altered protocol version header metadata must trigger a \`-32001 Header Mismatch\` error with an HTTP 400 boundary state.
 4. **Client Capability Constraints (2 Checks)**
    - Accessing platform capabilities without explicit declaration drops requests with a \`-32003 MissingRequiredClientCapabilityError\` containing needed capabilities, returning an HTTP status code \`400 Bad Request\`.
-5. **Methods & Routing Mechanics (3 Checks)**
-   - Removed legacy endpoints (\`initialize\`, \`ping\`, \`logging/setLevel\`, etc.) or generic unknown methods must cleanly yield an HTTP status code \`404 Not Found\` alongside a JSON-RPC \`-32601 Method not found\` payload. All error returns must preserve original request ID mappings.`;
+5. **Methods & Routing Mechanics (5 Checks)**
+   - Removed legacy endpoints (\`initialize\`, \`ping\`, \`logging/setLevel\`, etc.) or generic unknown methods must cleanly yield an HTTP status code \`404 Not Found\` alongside a JSON-RPC \`-32601 Method not found\` payload. All error returns must preserve original request ID mappings.
+   - Validates response streams contain only \`IncompleteResult\` chunks and never independent top-level JSON-RPC requests, while enforcing that no log messages are emitted when \`_meta.../logLevel\` is omitted.
+6. **Subscription Streams & Filtering (3 Checks)**
+   - Mandates that \`notifications/subscriptions/acknowledged\` is the first message on a \`subscriptions/listen\` stream, and that subsequent notifications carry a matching \`_meta.../subscriptionId\`.
+   - Verifies strict containment where servers do not dispatch notification types that fall outside the client's explicit requested subscription filter list.
+7. **Dynamic List Mutations (2 Checks)**
+   - Evaluates that list-changed capable servers notify active listen streams with \`promptsListChanged: true\` or \`toolsListChanged: true\` upon live configuration or capability modifications.  `;
 
   async run(serverUrl: string): Promise<ConformanceCheck[]> {
     const checks: ConformanceCheck[] = [];
@@ -117,6 +123,100 @@ export class ServerStatelessScenario implements ClientScenario {
         // Response might not be JSON
       }
       return { res, data };
+    };
+
+    // Helper to read multi-frame streaming endpoints (like subscriptions/listen)
+    const listenToStream = async (
+      method: string,
+      params?: any,
+      maxFrames = 3,
+      timeoutMs = 1000
+    ): Promise<any[]> => {
+      const headers = {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'MCP-Protocol-Version': DRAFT_PROTOCOL_VERSION
+      };
+
+      const body = JSON.stringify({
+        jsonrpc: '2.0',
+        id: Date.now(),
+        method,
+        ...(params !== undefined ? { params } : {})
+      });
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => {
+        controller.abort();
+      }, timeoutMs);
+
+      try {
+        const res = await fetch(serverUrl, {
+          method: 'POST',
+          headers,
+          body,
+          signal: controller.signal
+        });
+
+        if (!res.body) {
+          clearTimeout(timeoutId);
+          return [];
+        }
+
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        const frames: any[] = [];
+        let buffer = '';
+
+        try {
+          while (frames.length < maxFrames) {
+            const { value, done } = await reader.read();
+
+            if (value) {
+              buffer += decoder.decode(value, { stream: true });
+              const lines = buffer.split(/\r?\n/);
+              buffer = lines.pop() || '';
+
+              for (const line of lines) {
+                const cleanLine = line.trim();
+                if (!cleanLine) continue;
+
+                const jsonText = cleanLine.startsWith('data:')
+                  ? cleanLine.replace(/^data:\s*/, '')
+                  : cleanLine;
+                try {
+                  frames.push(JSON.parse(jsonText));
+                } catch {
+                  // Keep segment buffering
+                }
+              }
+            }
+
+            if (done) {
+              const finalLine = buffer.trim();
+              if (finalLine) {
+                const jsonText = finalLine.startsWith('data:')
+                  ? finalLine.replace(/^data:\s*/, '')
+                  : finalLine;
+                try {
+                  frames.push(JSON.parse(jsonText));
+                } catch {
+                  // Trailing formatting mismatch
+                }
+              }
+              break;
+            }
+          }
+        } finally {
+          reader.releaseLock();
+        }
+
+        clearTimeout(timeoutId);
+        return frames;
+      } catch {
+        clearTimeout(timeoutId);
+        return [];
+      }
     };
 
     const validMeta = {
@@ -403,7 +503,7 @@ export class ServerStatelessScenario implements ClientScenario {
     const responseAbsent = await sendRpc(
       'server/discover',
       { _meta: headerMismatchMeta },
-      { 'MCP-Protocol-Version': 'mismatch.version' },
+      { 'MCP-Protocol-Version': DRAFT_PROTOCOL_VERSION },
       302
     ).catch(() => null);
     const resAbsent: any = responseAbsent?.res ?? null;
@@ -512,7 +612,7 @@ export class ServerStatelessScenario implements ClientScenario {
     );
 
     // ==========================================
-    // 5. Methods & Routing Mechanics (3 Checks)
+    // 5. Methods & Routing Mechanics (5 Checks)
     // ==========================================
     const expectedSlugs = [
       'initialize',
@@ -580,7 +680,350 @@ export class ServerStatelessScenario implements ClientScenario {
       }
     );
 
-    // Final catchall ensuring JSON-RPC id integrity validation rules ran successfully
+    await runCheck(
+      'sep-2575-http-server-no-independent-requests-on-stream',
+      'HttpServerNoIndependentRequestsOnStream',
+      'Request stream contains only IncompleteResult, never independent JSON-RPC requests',
+      async () => {
+        const frames = await listenToStream(
+          'tools/call',
+          {
+            name: 'test_streaming_elicitation',
+            arguments: {},
+            _meta: validMeta
+          },
+          3,
+          600
+        );
+
+        if (frames.length === 0) {
+          return {
+            error:
+              'Failed to receive progressive stream chunk execution frames from tools/call handler endpoint'
+          };
+        }
+
+        const hasIndependentRequest = frames.some(
+          (f) => f.method && !f.method.startsWith('notifications/')
+        );
+        if (hasIndependentRequest) {
+          return {
+            error:
+              'Server emitted an independent standard request layout inside a response progress execution block stream context',
+            details: { frames }
+          };
+        }
+        return { details: { inspectedFramesCount: frames.length } };
+      }
+    );
+
+    await runCheck(
+      'sep-2575-server-no-log-without-loglevel',
+      'ServerNoLogWithoutLogLevel',
+      "No notifications/message for requests that didn't set _meta.../logLevel",
+      async () => {
+        const frames = await listenToStream(
+          'tools/call',
+          { name: 'test_logging_tool', arguments: {}, _meta: validMeta },
+          3,
+          500
+        );
+
+        if (frames.length === 0) {
+          return {
+            error:
+              'Logging target endpoint context dropped or failed to yield frame structures'
+          };
+        }
+
+        const logFrame = frames.find(
+          (f) => f.method === 'notifications/message'
+        );
+        if (logFrame) {
+          return {
+            error:
+              'Server dispatched a notifications/message payload chunk even though the client request did not authorize a log level context descriptor',
+            details: { logFrame }
+          };
+        }
+        return { details: { framesFound: frames.length } };
+      }
+    );
+
+    // ==========================================
+    // 6. Subscription Streams & Filtering (3 Checks)
+    // ==========================================
+    const subscriptionParams = {
+      _meta: validMeta,
+      subscriptions: [{ type: 'tools/list-changed' }]
+    };
+
+    let streamFrames: any[] = [];
+    try {
+      streamFrames = await listenToStream(
+        'subscriptions/listen',
+        subscriptionParams,
+        2,
+        800
+      );
+    } catch {
+      // Stream pipeline tracking failed
+    }
+
+    await runCheck(
+      'sep-2575-server-sends-subscription-ack',
+      'ServerSendsSubscriptionAck',
+      'notifications/subscriptions/acknowledged is the first message on a subscriptions/listen stream',
+      () => {
+        if (streamFrames[0]?.error?.code === -32601) {
+          return {
+            skipped: true,
+            details: {
+              note: 'Server does not support subscriptions/listen (Method not found)'
+            }
+          };
+        }
+        if (streamFrames.length === 0) {
+          return {
+            error:
+              'Failed to open or receive frames from the subscriptions/listen stream endpoint'
+          };
+        }
+        const firstFrame = streamFrames[0];
+        const resolvedMethod =
+          firstFrame?.method ??
+          firstFrame?.body?.method ??
+          firstFrame?.params?.method;
+
+        if (resolvedMethod !== 'notifications/subscriptions/acknowledged') {
+          return {
+            error: `Expected first frame method to be 'notifications/subscriptions/acknowledged', got '${resolvedMethod}'`,
+            details: { firstFrame }
+          };
+        }
+        return { details: { firstFrame } };
+      }
+    );
+
+    await runCheck(
+      'sep-2575-server-tags-subscription-id',
+      'ServerTagsSubscriptionId',
+      'Listen-stream notifications carry _meta.../subscriptionId',
+      () => {
+        if (streamFrames[0]?.error?.code === -32601) {
+          return {
+            skipped: true,
+            details: {
+              note: 'Server does not support subscriptions/listen (Method not found)'
+            }
+          };
+        }
+        if (streamFrames.length === 0) {
+          return {
+            error:
+              'Failed to open stream line or tracking frames are missing completely'
+          };
+        }
+        const ackFrame =
+          streamFrames.find((f) => {
+            const m = f?.method ?? f?.body?.method ?? f?.params?.method;
+            return m === 'notifications/subscriptions/acknowledged';
+          }) ?? streamFrames[0];
+
+        const subId =
+          ackFrame?.params?._meta?.['io.modelcontextprotocol/subscriptionId'];
+
+        if (!subId) {
+          return {
+            error:
+              'Subscription acknowledgment frame is missing the tracking subscriptionId in _meta',
+            details: { ackFrame }
+          };
+        }
+        return { details: { subscriptionId: subId, ackFrame } };
+      }
+    );
+
+    await runCheck(
+      'sep-2575-server-honors-notification-filter',
+      'ServerHonorsNotificationFilter',
+      "Server doesn't send notification types the client didn't request",
+      async () => {
+        const narrowParams = {
+          _meta: validMeta,
+          subscriptions: [{ type: 'prompts/list-changed' }]
+        };
+
+        await sendRpc('tools/call', {
+          name: 'test_trigger_tool_change',
+          arguments: {},
+          _meta: validMeta
+        });
+        const narrowFrames = await listenToStream(
+          'subscriptions/listen',
+          narrowParams,
+          3,
+          500
+        );
+
+        if (narrowFrames[0]?.error?.code === -32601) {
+          return {
+            skipped: true,
+            details: {
+              note: 'Server does not support subscriptions/listen (Method not found)'
+            }
+          };
+        }
+        if (narrowFrames.length === 0) {
+          return {
+            error:
+              'Strict subscription filtering line failed to return communication frames'
+          };
+        }
+
+        const leakedToolFrame = narrowFrames.find((f) => {
+          const m = f?.method ?? f?.body?.method ?? f?.params?.method;
+          return m === 'notifications/tools/list-changed';
+        });
+
+        if (leakedToolFrame) {
+          return {
+            error:
+              'Server leaked a tools/list-changed notification over a stream explicitly filtered to prompts only',
+            details: { leakedToolFrame }
+          };
+        }
+        return { details: { narrowFramesCount: narrowFrames.length } };
+      }
+    );
+
+    // ==========================================
+    // 7. Dynamic List Mutations (2 Checks)
+    // ==========================================
+    await runCheck(
+      'sep-2575-server-sends-prompts-list-changed-on-subscription',
+      'ServerSendsPromptsListChangedOnSubscription',
+      'List-changed-capable servers notify listen streams with promptsListChanged: true',
+      async () => {
+        // Automatically pass/skip if the server didn't declare this capability during discovery
+        if (!discoverCapabilities?.prompts?.listChanged) {
+          return {
+            skipped: true,
+            details: {
+              note: 'Server did not declare prompts.listChanged capability in server/discover'
+            }
+          };
+        }
+
+        const promptsParams = {
+          _meta: validMeta,
+          subscriptions: [{ type: 'prompts/list-changed' }]
+        };
+        const trigger = await sendRpc('tools/call', {
+          name: 'test_trigger_prompt_change',
+          arguments: {},
+          _meta: validMeta
+        });
+        if (trigger.data?.error?.code === -32601) {
+          return {
+            skipped: true,
+            details: {
+              note: 'Server does not expose diagnostic hook test_trigger_prompt_change to mutate lists'
+            }
+          };
+        }
+
+        const frames = await listenToStream(
+          'subscriptions/listen',
+          promptsParams,
+          3,
+          600
+        );
+
+        if (frames.length === 0) {
+          return {
+            error:
+              'Mutated configuration parameters but subscription event monitoring stream returned zero frames'
+          };
+        }
+
+        const changeFrame = frames.find(
+          (f) =>
+            f.method === 'notifications/prompts/list-changed' ||
+            f.params?.promptsListChanged === true
+        );
+        if (!changeFrame) {
+          return {
+            error:
+              'Mutated prompt fields on target SUT but no list verification event popped on subscription listener'
+          };
+        }
+        return { details: { changeFrame } };
+      }
+    );
+
+    await runCheck(
+      'sep-2575-server-sends-tools-list-changed-on-subscription',
+      'ServerSendsToolsListChangedOnSubscription',
+      'List-changed-capable servers notify listen streams with toolsListChanged: true',
+      async () => {
+        // Automatically pass/skip if the server didn't declare this capability during discovery
+        if (!discoverCapabilities?.tools?.listChanged) {
+          return {
+            skipped: true,
+            details: {
+              note: 'Server did not declare tools.listChanged capability in server/discover'
+            }
+          };
+        }
+
+        const toolsParams = {
+          _meta: validMeta,
+          subscriptions: [{ type: 'tools/list-changed' }]
+        };
+        const trigger = await sendRpc('tools/call', {
+          name: 'test_trigger_tool_change',
+          arguments: {},
+          _meta: validMeta
+        });
+        if (trigger.data?.error?.code === -32601) {
+          return {
+            skipped: true,
+            details: {
+              note: 'Server does not expose diagnostic hook test_trigger_tool_change to mutate lists'
+            }
+          };
+        }
+
+        const frames = await listenToStream(
+          'subscriptions/listen',
+          toolsParams,
+          3,
+          600
+        );
+
+        if (frames.length === 0) {
+          return {
+            error:
+              'Mutated underlying tooling array indexes but listener subscription returned zero chunks'
+          };
+        }
+
+        const changeFrame = frames.find(
+          (f) =>
+            f.method === 'notifications/tools/list-changed' ||
+            f.params?.toolsListChanged === true
+        );
+        if (!changeFrame) {
+          return {
+            error:
+              'Mutated tool entries on target SUT but no notification found on streaming line'
+          };
+        }
+        return { details: { changeFrame } };
+      }
+    );
+
     if (!checks.some((c) => c.id === 'sep-2575-http-server-error-jsonrpc-id')) {
       checks.push({
         id: 'sep-2575-http-server-error-jsonrpc-id',

--- a/src/seps/sep-2575.yaml
+++ b/src/seps/sep-2575.yaml
@@ -13,10 +13,6 @@ requirements:
   - check: sep-2575-server-tags-subscription-id
     text: 'On notifications delivered via a subscriptions/listen stream, the server MUST include io.modelcontextprotocol/subscriptionId in _meta so the client can correlate the notification with the originating subscription request.'
     url: https://modelcontextprotocol.io/specification/draft/basic/index#meta
-  - check: sep-2575-server-stateless-no-prior-context
-    text: 'A server MUST NOT treat connection or process identity as a proxy for conversation or session continuity. / Servers MUST NOT rely on prior requests over the same connection to establish context (e.g., capabilities, protocol version, client identity).'
-  - check: sep-2575-server-stateless-no-connection-reuse-required
-    text: 'Servers MUST NOT require that a client reuse the same connection to perform related operations.'
   - check: sep-2575-server-unsupported-version-error
     text: 'If the server does not implement the requested version (whether the version is unknown to the server, or is a known version the server has chosen not to support), it MUST respond with an UnsupportedProtocolVersionError listing the versions it does support.'
     url: https://modelcontextprotocol.io/specification/draft/basic/lifecycle#protocol-version-negotiation
@@ -29,12 +25,6 @@ requirements:
   - check: sep-2575-http-server-no-independent-requests-on-stream
     text: 'The server MUST NOT send independent JSON-RPC requests on this stream. Server-to-client interactions are embedded as input requests inside an IncompleteResult.'
     url: https://modelcontextprotocol.io/specification/draft/basic/transports#receiving-messages-1
-  - check: sep-2575-http-server-disconnect-is-cancel
-    text: 'Closing the SSE response stream MUST be treated by the server as cancellation of that request.'
-    url: https://modelcontextprotocol.io/specification/draft/basic/transports#cancellation-1
-  - check: sep-2575-http-server-stops-on-cancel
-    text: 'The server SHOULD stop work on the cancelled request as soon as practical and MUST NOT send any further messages for it [HTTP].'
-    url: https://modelcontextprotocol.io/specification/draft/basic/transports#cancellation-1
   - check: sep-2575-http-client-sends-version-header
     text: 'Every POST request to the MCP endpoint MUST include an MCP-Protocol-Version header.'
     url: https://modelcontextprotocol.io/specification/draft/basic/transports#protocol-version-header
@@ -78,6 +68,16 @@ requirements:
     text: 'The server MUST NOT emit notifications/message for a request that does not include [io.modelcontextprotocol/logLevel in _meta].'
     url: https://modelcontextprotocol.io/specification/draft/server/utilities/logging#per-request-log-level
 
+  - text: 'A server MUST NOT treat connection or process identity as a proxy for conversation or session continuity. / Servers MUST NOT rely on prior requests over the same connection to establish context (e.g., capabilities, protocol version, client identity).'
+    excluded: 'internal server state, not directly wire-observable; the observable consequence (rejecting requests with incomplete _meta rather than falling back to remembered state) is covered by sep-2575-request-meta-invalid-* — see https://github.com/modelcontextprotocol/conformance/issues/296'
+  - text: 'Servers MUST NOT require that a client reuse the same connection to perform related operations.'
+    excluded: 'not observable from a black-box harness; every harness request already arrives on an independent connection — see https://github.com/modelcontextprotocol/conformance/issues/296'
+  - text: 'Closing the SSE response stream MUST be treated by the server as cancellation of that request.'
+    excluded: '"treated as cancellation" is internal server state; once the stream is closed there is no channel left on which to observe the effect — see https://github.com/modelcontextprotocol/conformance/issues/296'
+    url: https://modelcontextprotocol.io/specification/draft/basic/transports#cancellation-1
+  - text: 'The server SHOULD stop work on the cancelled request as soon as practical and MUST NOT send any further messages for it [HTTP].'
+    excluded: '"stop work as soon as practical" is unobservable from a black-box harness, and "no further messages" cannot be verified once the response stream is closed — see https://github.com/modelcontextprotocol/conformance/issues/296'
+    url: https://modelcontextprotocol.io/specification/draft/basic/transports#cancellation-1
   - text: 'State that needs to span multiple requests (e.g., long-running tasks, application-level handles) MUST be referenced by an explicit identifier the client passes on each request.'
     excluded: 'architectural guidance, observable only via subscriptionId/task-id rows already listed'
   - text: 'To distinguish notifications belonging to different concurrent subscriptions, clients MUST correlate notifications using the io.modelcontextprotocol/subscriptionId field carried in _meta.'


### PR DESCRIPTION
Added the 7 additional checks from part B of #296. This adds additional conformance tests for https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2575 to validate the stateless-MCP behavior.

## Motivation and Context
Ensure that servers adhere to the SEP.

## How Has This Been Tested?
Locally and against MCP Toolbox's PR for SEP-2575.

## Breaking Changes
n/a

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed
