### PR TITLE
fix: avoid bash backslash mangling of github.action_path on Windows (fixes #150)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -42,14 +42,14 @@ runs:
     - name: Build conformance tests
       shell: bash
       run: |
-        cd "${{ github.action_path }}"
+        cd "$GITHUB_ACTION_PATH"
         npm ci
         npm run build
 
     - name: Run conformance tests
       shell: bash
       run: |
-        CONFORMANCE="${{ github.action_path }}/dist/index.js"
+        CONFORMANCE="$GITHUB_ACTION_PATH/dist/index.js"
 
         # Build the command arguments
         ARGS="${{ inputs.mode }}"


### PR DESCRIPTION
Fixes #150.

### The bug

When the action runs on a Windows runner, `${{ github.action_path }}` resolves to a backslash-separated path like:

```
D:\a\_actions\modelcontextprotocol\conformance\v0.1.14
```

GitHub Actions then inlines that **string** directly into the body of the `bash` `run:` block. Bash sees `\a`, `\m`, `\c`, etc. as escape sequences (or as ambiguous characters whose backslashes get consumed depending on the surrounding context), and the resulting path is mangled.

That matches the symptom in #150 exactly — the error reports a lookup at:

```
D:\a\webman-mcp\webman-mcp\a_actionsmodelcontextprotocolconformancev0.1.14\dist\index.js
```

The literal `\a`, `\_`, `\m`, etc. were consumed during bash's processing of the inlined string, and the residue was treated as a relative path appended to the workflow's CWD (`D:\a\webman-mcp\webman-mcp\`).

### The fix

Replace the two `${{ github.action_path }}` usages inside `bash` `run:` blocks with the auto-injected `$GITHUB_ACTION_PATH` environment variable. GitHub Actions sets this variable on every composite-action step automatically. Because bash evaluates `$GITHUB_ACTION_PATH` as a **variable expansion** (not a template inlining), the value is treated as an opaque string — no escape processing on the backslashes.

Two-line diff:

```diff
-        cd "${{ github.action_path }}"
+        cd "$GITHUB_ACTION_PATH"
-        CONFORMANCE="${{ github.action_path }}/dist/index.js"
+        CONFORMANCE="$GITHUB_ACTION_PATH/dist/index.js"
```

The `${{ inputs.* }}` references elsewhere in the file are kept as-is — inputs are typed strings from the workflow and don't carry Windows path separators.

### Why this is the right fix (vs. alternatives)

- **`sed 's|\\\\|/|g'`** — converts backslashes to forward slashes at runtime. Works on Windows bash, but adds a runtime step and obscures the cause.
- **`env: ACTION_PATH: ${{ github.action_path }}`** — explicit env block, also works. Equivalent to using `$GITHUB_ACTION_PATH` but more verbose and duplicates what GHA already provides.
- **`$GITHUB_ACTION_PATH` directly** — minimal, idiomatic, matches what other composite actions in the ecosystem use (e.g., `actions/setup-node`, `pnpm/action-setup`). Picked this.

### Verification

The fix can be verified by re-running the user's workflow at https://github.com/luoyue712/webman-mcp/actions/runs/22035652643 (linked in #150) with this action ref. Locally I confirmed the env-var form preserves Windows-style paths through bash variable expansion (no backslash consumption).

No behavioural change on Linux/macOS runners — `$GITHUB_ACTION_PATH` resolves identically to `${{ github.action_path }}` on those platforms.
