### PR TITLE
chore(sep-2350): exclude the server single-challenge requirement from traceability

### DIFF
--- a/src/seps/sep-2350.yaml
+++ b/src/seps/sep-2350.yaml
@@ -4,8 +4,8 @@ requirements:
   - check: sep-2350-scope-union-on-reauth
     text: 'When re-authorizing, clients SHOULD include these scopes alongside any previously granted scopes to avoid losing permissions needed for other operations. / Clients SHOULD compute the union of previously requested scopes and newly challenged scopes when initiating re-authorization.'
     url: https://modelcontextprotocol.io/specification/draft/basic/authorization#protected-resource-metadata-discovery-requirements
-  - check: sep-2350-server-single-challenge
-    text: 'Regardless of the approach chosen, servers SHOULD include all scopes required for the current operation in a single challenge.'
+  - text: 'Regardless of the approach chosen, servers SHOULD include all scopes required for the current operation in a single challenge.'
+    excluded: '"All scopes required for the current operation" has no harness-observable ground truth; the challenge is the only place the server declares its requirements. Detecting the negative (incremental challenging) would need server-side auth scenarios that do not exist yet and would test the example app''s scope config rather than SDK behavior; the spec also permits dynamic per-request scope determination, so a second challenge is not conclusively non-conformant.'
 
   - text: 'When responding with insufficient scope errors, servers SHOULD include the scopes needed to satisfy the current operation in the scope parameter, consistent with RFC 6750 Section 3.1.'
     excluded: 'reword of pre-existing requirement (request->operation, +RFC6750 cite); no normative delta; harness already emits scope= in WWW-Authenticate'

--- a/src/seps/traceability.json
+++ b/src/seps/traceability.json
@@ -500,14 +500,13 @@
           "status": "tested",
           "text": "When re-authorizing, clients SHOULD include these scopes alongside any previously granted scopes to avoid losing permissions needed for other operations. / Clients SHOULD compute the union of previously requested scopes and newly challenged scopes when initiating re-authorization.",
           "url": "https://modelcontextprotocol.io/specification/draft/basic/authorization#protected-resource-metadata-discovery-requirements"
-        },
-        {
-          "check": "sep-2350-server-single-challenge",
-          "status": "untested",
-          "text": "Regardless of the approach chosen, servers SHOULD include all scopes required for the current operation in a single challenge."
         }
       ],
       "excluded": [
+        {
+          "text": "Regardless of the approach chosen, servers SHOULD include all scopes required for the current operation in a single challenge.",
+          "reason": "\"All scopes required for the current operation\" has no harness-observable ground truth; the challenge is the only place the server declares its requirements. Detecting the negative (incremental challenging) would need server-side auth scenarios that do not exist yet and would test the example app's scope config rather than SDK behavior; the spec also permits dynamic per-request scope determination, so a second challenge is not conclusively non-conformant."
+        },
         {
           "text": "When responding with insufficient scope errors, servers SHOULD include the scopes needed to satisfy the current operation in the scope parameter, consistent with RFC 6750 Section 3.1.",
           "reason": "reword of pre-existing requirement (request->operation, +RFC6750 cite); no normative delta; harness already emits scope= in WWW-Authenticate"
@@ -517,8 +516,8 @@
       "untracked": [],
       "summary": {
         "tested": 1,
-        "untested": 1,
-        "excluded": 1,
+        "untested": 0,
+        "excluded": 2,
         "untracked": 0,
         "unkeyed": 0
       }


### PR DESCRIPTION
Marks the SEP-2350 server-side row — *"servers SHOULD include all scopes required for the current operation in a single challenge"* — as excluded from traceability rather than untested.

"All scopes required for the current operation" has no harness-observable ground truth: the WWW-Authenticate challenge is the only place the server declares what an operation requires, so there is nothing independent to compare it against. Detecting the negative (incremental challenging) would need server-side auth scenarios that don't exist yet and would test the example app's scope configuration rather than SDK behavior; the spec also permits dynamic per-request scope determination, so a second challenge isn't conclusively non-conformant.

The client-side half of SEP-2350 (scope union on re-authorization) remains tested by `auth/scope-step-up`. The traceability.json update is byte-identical to the generator's output for the new yaml.