### PR TITLE
chore: bump version to 0.2.0-alpha.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/conformance",
-  "version": "0.1.16",
+  "version": "0.2.0-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/conformance",
-      "version": "0.1.16",
+      "version": "0.2.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/conformance",
-  "version": "0.1.16",
+  "version": "0.2.0-alpha.0",
   "type": "module",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",


### PR DESCRIPTION
## Summary

Bump the package version to `0.2.0-alpha.0` so an alpha prerelease can be published via the CI workflow's `publish_alpha` dispatch (`npm publish --tag alpha`). The minor bump reflects the volume of new scenarios since `0.1.16` (SEP-2106, SEP-2243, SEP-2322, SEP-2350, SEP-2352, SEP-2468, SEP-2549, SEP-2575, the SDK runner, and the traceability manifest).

`latest` stays on `0.1.16`; consumers opt in with `npm install @modelcontextprotocol/conformance@alpha`.

## Test plan

- [ ] After merge: dispatch the CI workflow with `publish_alpha: true` and confirm `npm view @modelcontextprotocol/conformance@alpha version` reports `0.2.0-alpha.0`