### PR TITLE
feat: add conformance tests for SEP-2106 (JSON Schema 2020-12 loosening)

### DIFF
--- a/examples/servers/typescript/everything-server.ts
+++ b/examples/servers/typescript/everything-server.ts
@@ -137,6 +137,51 @@ const JSON_SCHEMA_2020_12_INPUT_SCHEMA = {
   additionalProperties: false
 };
 
+// SEP-2106: array-at-root outputSchema for conformance testing.
+// Tests that SDKs preserve non-object outputSchema instead of wrapping it.
+const SEP_2106_ARRAY_OUTPUT_SCHEMA = {
+  type: 'array' as const,
+  items: {
+    type: 'object',
+    properties: {
+      hour: { type: 'string' },
+      temp: { type: 'number' },
+      conditions: { type: 'string' }
+    },
+    required: ['hour', 'temp', 'conditions']
+  }
+};
+
+// SEP-2106: oneOf composition inputSchema. type: "object" is required
+// (tool args are always objects), but the oneOf alternates between two
+// required keys — exactly the pattern SEP-2106's Specification §1 enables.
+const SEP_2106_ONEOF_INPUT_SCHEMA = {
+  type: 'object' as const,
+  oneOf: [
+    {
+      properties: { id: { type: 'string', format: 'uuid' } },
+      required: ['id']
+    },
+    {
+      properties: { name: { type: 'string', minLength: 1 } },
+      required: ['name']
+    }
+  ]
+};
+
+// SEP-2106: primitive-at-root outputSchema (raw number).
+const SEP_2106_PRIMITIVE_OUTPUT_SCHEMA = { type: 'number' as const };
+
+// Fixed payload for the array-output tool so the conformance check can
+// compare structuredContent against the TextContent fallback verbatim.
+const SEP_2106_FORECAST_PAYLOAD = [
+  { hour: '09:00', temp: 68, conditions: 'sunny' },
+  { hour: '10:00', temp: 72, conditions: 'partly cloudy' },
+  { hour: '11:00', temp: 75, conditions: 'cloudy' }
+];
+
+const SEP_2106_COUNT_PAYLOAD = 42;
+
 // Function to create a new MCP server instance (one per session)
 function createMcpServer() {
   const mcpServer = new McpServer(
@@ -782,6 +827,88 @@ function createMcpServer() {
     }
   );
 
+  // SEP-2106 tools are gated behind an env flag because their loosened
+  // outputSchema (type: "array", type: "number") is rejected by SDK Client
+  // versions that pre-date SEP-2106 — and the SDK Client is used by every
+  // other scenario in the suite. Enable via SEP_2106_ENABLED=1 when running
+  // the SEP-2106 scenario specifically.
+  if (process.env.SEP_2106_ENABLED === '1') {
+    // SEP-2106: array-at-root outputSchema + array structuredContent.
+    // The tool ignores inputs and returns a fixed forecast so the conformance
+    // scenario can deterministically diff structuredContent against the
+    // TextContent fallback (the existing SHOULD that is newly load-bearing
+    // for non-object structuredContent).
+    mcpServer.registerTool(
+      'sep_2106_array_output_tool',
+      {
+        description:
+          'Returns an array of hourly forecasts directly in structuredContent (SEP-2106)'
+      },
+      async () => {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(SEP_2106_FORECAST_PAYLOAD)
+            }
+          ],
+          structuredContent: SEP_2106_FORECAST_PAYLOAD as unknown as {
+            [key: string]: unknown;
+          }
+        };
+      }
+    );
+
+    // SEP-2106: oneOf composition inputSchema. Zod can't express oneOf
+    // natively, so the Zod schema accepts both fields as optional and the
+    // ListToolsRequestSchema override below re-injects the raw oneOf shape.
+    mcpServer.registerTool(
+      'sep_2106_oneof_input_tool',
+      {
+        description:
+          'Accepts either {id} OR {name} via inputSchema.oneOf composition (SEP-2106)',
+        inputSchema: {
+          id: z.string().optional(),
+          name: z.string().optional()
+        }
+      },
+      async (args: { id?: string; name?: string }) => {
+        const branch = args.id ? 'id' : args.name ? 'name' : 'none';
+        return {
+          content: [
+            {
+              type: 'text',
+              text: `Matched oneOf branch: ${branch} (args=${JSON.stringify(args)})`
+            }
+          ]
+        };
+      }
+    );
+
+    // SEP-2106: primitive-at-root outputSchema. structuredContent is a
+    // raw number, not wrapped in an object.
+    mcpServer.registerTool(
+      'sep_2106_primitive_output_tool',
+      {
+        description:
+          'Returns a raw number in structuredContent (SEP-2106 primitive output)'
+      },
+      async () => {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: String(SEP_2106_COUNT_PAYLOAD)
+            }
+          ],
+          structuredContent: SEP_2106_COUNT_PAYLOAD as unknown as {
+            [key: string]: unknown;
+          }
+        };
+      }
+    );
+  } // end SEP-2106 env gate
+
   // Dynamic tool (registered later via timer)
 
   // ===== RESOURCES =====
@@ -1078,6 +1205,40 @@ function createMcpServer() {
                 description: tool.description,
                 inputSchema: JSON_SCHEMA_2020_12_INPUT_SCHEMA
               };
+            }
+
+            // SEP-2106: re-inject raw schemas the Zod converter would strip
+            // or wrap. Gated by SEP_2106_ENABLED to match the tool-registration
+            // gate above (without the env flag these tools aren't registered,
+            // so these branches are unreachable — explicit guard keeps intent
+            // visible).
+            if (process.env.SEP_2106_ENABLED === '1') {
+              if (name === 'sep_2106_array_output_tool') {
+                return {
+                  name,
+                  description: tool.description,
+                  inputSchema: { type: 'object' as const, properties: {} },
+                  outputSchema:
+                    SEP_2106_ARRAY_OUTPUT_SCHEMA as unknown as Tool['outputSchema']
+                };
+              }
+              if (name === 'sep_2106_oneof_input_tool') {
+                return {
+                  name,
+                  description: tool.description,
+                  inputSchema:
+                    SEP_2106_ONEOF_INPUT_SCHEMA as unknown as Tool['inputSchema']
+                };
+              }
+              if (name === 'sep_2106_primitive_output_tool') {
+                return {
+                  name,
+                  description: tool.description,
+                  inputSchema: { type: 'object' as const, properties: {} },
+                  outputSchema:
+                    SEP_2106_PRIMITIVE_OUTPUT_SCHEMA as unknown as Tool['outputSchema']
+                };
+              }
             }
 
             // For other tools, use the SDK's own JSON Schema conversion

--- a/examples/servers/typescript/sep-2106-broken-schema.ts
+++ b/examples/servers/typescript/sep-2106-broken-schema.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+
+/**
+ * SEP-2106 Negative Test Server
+ *
+ * Advertises the three SEP-2106 test tools but deliberately violates the
+ * loosened-schema expectations:
+ *   - sep_2106_array_output_tool: outputSchema is wrapped in { type: object },
+ *     and structuredContent is wrapped in { items: [...] } instead of being
+ *     an array directly. No TextContent fallback is emitted.
+ *   - sep_2106_oneof_input_tool: inputSchema has no oneOf — the SDK stripped
+ *     the composition keyword.
+ *   - sep_2106_primitive_output_tool: outputSchema is wrapped in { type:
+ *     object, properties: { value: { type: number } } }, and structuredContent
+ *     is { value: 42 } instead of 42.
+ *
+ * The Sep2106Scenario should emit FAILURE/WARNING for every check against
+ * this server.
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema
+} from '@modelcontextprotocol/sdk/types.js';
+import express from 'express';
+
+const FORECAST_PAYLOAD = [
+  { hour: '09:00', temp: 68, conditions: 'sunny' },
+  { hour: '10:00', temp: 72, conditions: 'partly cloudy' },
+  { hour: '11:00', temp: 75, conditions: 'cloudy' }
+];
+
+function createServer() {
+  const server = new Server(
+    { name: 'sep-2106-broken-schema', version: '1.0.0' },
+    { capabilities: { tools: {} } }
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      {
+        name: 'sep_2106_array_output_tool',
+        description: '(broken) outputSchema wraps the array in an object',
+        inputSchema: { type: 'object', properties: {} },
+        // Wrong: SEP-2106 allows array-at-root; this server wraps it.
+        outputSchema: {
+          type: 'object',
+          properties: {
+            items: {
+              type: 'array',
+              items: { type: 'object' }
+            }
+          },
+          required: ['items']
+        }
+      },
+      {
+        name: 'sep_2106_oneof_input_tool',
+        description: '(broken) inputSchema.oneOf was stripped',
+        // Wrong: oneOf is missing entirely.
+        inputSchema: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            name: { type: 'string' }
+          }
+        }
+      },
+      {
+        name: 'sep_2106_primitive_output_tool',
+        description: '(broken) primitive output is wrapped in an object',
+        inputSchema: { type: 'object', properties: {} },
+        // Wrong: SEP-2106 allows primitive-at-root; this server wraps it.
+        outputSchema: {
+          type: 'object',
+          properties: { value: { type: 'number' } },
+          required: ['value']
+        }
+      }
+    ]
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const { name } = req.params;
+    if (name === 'sep_2106_array_output_tool') {
+      // Wrong: array wrapped in object, no TextContent fallback.
+      return {
+        content: [],
+        structuredContent: { items: FORECAST_PAYLOAD }
+      };
+    }
+    if (name === 'sep_2106_primitive_output_tool') {
+      // Wrong: number wrapped in object, no TextContent fallback.
+      return {
+        content: [],
+        structuredContent: { value: 42 }
+      };
+    }
+    if (name === 'sep_2106_oneof_input_tool') {
+      return {
+        content: [{ type: 'text', text: 'ok' }]
+      };
+    }
+    return {
+      content: [{ type: 'text', text: `Unknown tool: ${name}` }],
+      isError: true
+    };
+  });
+
+  return server;
+}
+
+const app = express();
+app.use(express.json());
+
+app.post('/mcp', async (req, res) => {
+  try {
+    const server = createServer();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined
+    });
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } catch (error) {
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: '2.0',
+        error: {
+          code: -32603,
+          message: `Internal error: ${error instanceof Error ? error.message : String(error)}`
+        },
+        id: null
+      });
+    }
+  }
+});
+
+const PORT = parseInt(process.env.PORT || '3008', 10);
+app.listen(PORT, '127.0.0.1', () => {
+  console.log(
+    `SEP-2106 negative test server running on http://localhost:${PORT}/mcp`
+  );
+});

--- a/examples/servers/typescript/sep-2106-compliant-server.ts
+++ b/examples/servers/typescript/sep-2106-compliant-server.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+/**
+ * SEP-2106 Compliant Reference Server
+ *
+ * A bare-bones Streamable-HTTP MCP server implemented in raw Express that
+ * speaks the SEP-2106 wire format end-to-end:
+ *   - `tools/list` advertises array and primitive `outputSchema` at the root
+ *   - `tools/list` advertises `inputSchema.oneOf` composition
+ *   - `tools/call` returns array and primitive `structuredContent` directly
+ *   - Non-object `structuredContent` is accompanied by a TextContent block
+ *     containing the serialized JSON (the existing SHOULD that becomes
+ *     load-bearing under SEP-2106)
+ *
+ * We bypass the MCP SDK because, as of the SDK version pinned in this repo,
+ * `CallToolResultSchema.structuredContent` is typed `Record<string, unknown>`
+ * and the SDK Server validates outgoing responses against that schema. The
+ * SDK therefore refuses to send a tools/call result with array or primitive
+ * structuredContent, returning JSON-RPC -32602 instead — which is exactly
+ * what SEP-2106 sets out to fix. Until the SDK ships SEP-2106 support, the
+ * only way to demonstrate a fully-compliant server is to skip the SDK and
+ * write JSON-RPC directly.
+ *
+ * Used by `src/scenarios/server/negative.test.ts` as the positive case for
+ * `Sep2106Scenario`. All nine SEP-2106 checks should succeed against this
+ * server.
+ */
+
+import express from 'express';
+
+const PROTOCOL_VERSION = 'DRAFT-2026-v1';
+
+const FORECAST_PAYLOAD = [
+  { hour: '09:00', temp: 68, conditions: 'sunny' },
+  { hour: '10:00', temp: 72, conditions: 'partly cloudy' },
+  { hour: '11:00', temp: 75, conditions: 'cloudy' }
+];
+
+const COUNT_PAYLOAD = 42;
+
+const ARRAY_OUTPUT_SCHEMA = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      hour: { type: 'string' },
+      temp: { type: 'number' },
+      conditions: { type: 'string' }
+    },
+    required: ['hour', 'temp', 'conditions']
+  }
+};
+
+const ONEOF_INPUT_SCHEMA = {
+  type: 'object',
+  oneOf: [
+    {
+      properties: { id: { type: 'string', format: 'uuid' } },
+      required: ['id']
+    },
+    {
+      properties: { name: { type: 'string', minLength: 1 } },
+      required: ['name']
+    }
+  ]
+};
+
+const PRIMITIVE_OUTPUT_SCHEMA = { type: 'number' };
+
+const TOOLS = [
+  {
+    name: 'sep_2106_array_output_tool',
+    description: 'Returns an array of hourly forecasts in structuredContent',
+    inputSchema: { type: 'object', properties: {} },
+    outputSchema: ARRAY_OUTPUT_SCHEMA
+  },
+  {
+    name: 'sep_2106_oneof_input_tool',
+    description: 'Accepts {id} OR {name} via inputSchema.oneOf',
+    inputSchema: ONEOF_INPUT_SCHEMA
+  },
+  {
+    name: 'sep_2106_primitive_output_tool',
+    description: 'Returns a raw number in structuredContent',
+    inputSchema: { type: 'object', properties: {} },
+    outputSchema: PRIMITIVE_OUTPUT_SCHEMA
+  }
+];
+
+function handleRequest(body: any): { status: number; payload: unknown } {
+  const { method, id, params } = body ?? {};
+
+  if (method === 'initialize') {
+    return {
+      status: 200,
+      payload: {
+        jsonrpc: '2.0',
+        id,
+        result: {
+          protocolVersion: PROTOCOL_VERSION,
+          serverInfo: { name: 'sep-2106-compliant', version: '1.0.0' },
+          capabilities: { tools: {} }
+        }
+      }
+    };
+  }
+
+  if (method === 'notifications/initialized') {
+    return { status: 202, payload: null };
+  }
+
+  if (method === 'tools/list') {
+    return {
+      status: 200,
+      payload: { jsonrpc: '2.0', id, result: { tools: TOOLS } }
+    };
+  }
+
+  if (method === 'tools/call') {
+    const name = params?.name;
+    if (name === 'sep_2106_array_output_tool') {
+      return {
+        status: 200,
+        payload: {
+          jsonrpc: '2.0',
+          id,
+          result: {
+            content: [{ type: 'text', text: JSON.stringify(FORECAST_PAYLOAD) }],
+            structuredContent: FORECAST_PAYLOAD
+          }
+        }
+      };
+    }
+    if (name === 'sep_2106_primitive_output_tool') {
+      return {
+        status: 200,
+        payload: {
+          jsonrpc: '2.0',
+          id,
+          result: {
+            content: [{ type: 'text', text: String(COUNT_PAYLOAD) }],
+            structuredContent: COUNT_PAYLOAD
+          }
+        }
+      };
+    }
+    if (name === 'sep_2106_oneof_input_tool') {
+      const branch = params?.arguments?.id
+        ? 'id'
+        : params?.arguments?.name
+          ? 'name'
+          : 'none';
+      return {
+        status: 200,
+        payload: {
+          jsonrpc: '2.0',
+          id,
+          result: {
+            content: [{ type: 'text', text: `branch=${branch}` }]
+          }
+        }
+      };
+    }
+    return {
+      status: 200,
+      payload: {
+        jsonrpc: '2.0',
+        id,
+        error: { code: -32602, message: `Unknown tool: ${name}` }
+      }
+    };
+  }
+
+  return {
+    status: 200,
+    payload: {
+      jsonrpc: '2.0',
+      id,
+      error: { code: -32601, message: `Method not found: ${method}` }
+    }
+  };
+}
+
+const app = express();
+app.use(express.json());
+
+app.post('/mcp', (req, res) => {
+  const { status, payload } = handleRequest(req.body);
+  if (payload === null) {
+    res.status(status).end();
+    return;
+  }
+  res.status(status).json(payload);
+});
+
+const PORT = parseInt(process.env.PORT || '3009', 10);
+app.listen(PORT, '127.0.0.1', () => {
+  console.log(
+    `SEP-2106 compliant test server running on http://localhost:${PORT}/mcp`
+  );
+});

--- a/src/scenarios/index.ts
+++ b/src/scenarios/index.ts
@@ -41,6 +41,7 @@ import {
 } from './server/tools';
 
 import { JsonSchema2020_12Scenario } from './server/json-schema-2020-12';
+import { Sep2106Scenario } from './server/sep-2106';
 
 import { ElicitationDefaultsScenario } from './server/elicitation-defaults';
 import { ElicitationEnumsScenario } from './server/elicitation-enums';
@@ -113,6 +114,12 @@ const pendingClientScenariosList: ClientScenario[] = [
   // $schema, $defs, and additionalProperties fields in tool schemas.
   new JsonSchema2020_12Scenario(),
 
+  // SEP-2106: loosened inputSchema/outputSchema/structuredContent.
+  // Pending until SDKs preserve composition keywords (oneOf/anyOf/allOf) and
+  // non-object outputSchema in tools/list, and accept array/primitive
+  // structuredContent on the wire. Reference impl: olaservo/typescript-sdk@sep-834-v1x.
+  new Sep2106Scenario(),
+
   // On hold until server-side SSE improvements are made
   // https://github.com/modelcontextprotocol/typescript-sdk/pull/1129
   new ServerSSEPollingScenario(),
@@ -150,6 +157,9 @@ const allClientScenariosList: ClientScenario[] = [
 
   // JSON Schema 2020-12 support (SEP-1613)
   new JsonSchema2020_12Scenario(),
+
+  // SEP-2106: loosened tool schemas (inputSchema composition, non-object outputSchema)
+  new Sep2106Scenario(),
 
   // Elicitation scenarios (SEP-1034)
   new ElicitationDefaultsScenario(),

--- a/src/scenarios/server/negative.test.ts
+++ b/src/scenarios/server/negative.test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { DNSRebindingProtectionScenario } from './dns-rebinding';
 import { ResourcesNotFoundErrorScenario } from './resources';
 import { CachingScenario } from './caching';
+import { Sep2106Scenario } from './sep-2106';
 
 function startServer(scriptPath: string, port: number): Promise<ChildProcess> {
   return new Promise((resolve, reject) => {
@@ -145,6 +146,107 @@ describe('Server scenario negative tests', () => {
         const check = checks.find((c) => c.id === checkId);
         expect(check).toBeDefined();
         expect(check?.status).toBe('FAILURE');
+      }
+    }, 15000);
+  });
+
+  describe('sep-2106-broken-schema', () => {
+    let serverProcess: ChildProcess | null = null;
+    const PORT = 3008;
+
+    beforeAll(async () => {
+      serverProcess = await startServer(
+        path.join(
+          process.cwd(),
+          'examples/servers/typescript/sep-2106-broken-schema.ts'
+        ),
+        PORT
+      );
+    }, 35000);
+
+    afterAll(async () => {
+      await stopServer(serverProcess);
+    });
+
+    it('emits FAILURE/WARNING against a server that flattens loosened SEP-2106 schemas', async () => {
+      const scenario = new Sep2106Scenario();
+      const checks = await scenario.run(`http://localhost:${PORT}/mcp`);
+
+      // Tools are advertised, so the *-tool-found checks pass.
+      // The shape/value checks should all fail.
+      const expectedFailures = [
+        'sep-2106-array-output-schema-preserved',
+        'sep-2106-array-structured-content',
+        'sep-2106-oneof-input-schema-preserved',
+        'sep-2106-primitive-output-schema-preserved',
+        'sep-2106-primitive-structured-content'
+      ];
+      for (const id of expectedFailures) {
+        const check = checks.find((c) => c.id === id);
+        expect(check, `check ${id} should exist`).toBeDefined();
+        expect(check?.status, `check ${id} should fail`).toBe('FAILURE');
+      }
+
+      // The TextContent fallback SHOULD: WARNING when missing.
+      const fallback = checks.find(
+        (c) => c.id === 'sep-2106-array-text-fallback'
+      );
+      expect(fallback).toBeDefined();
+      expect(fallback?.status).toBe('WARNING');
+    }, 15000);
+  });
+
+  describe('sep-2106-compliant-positive', () => {
+    let serverProcess: ChildProcess | null = null;
+    const PORT = 3009;
+
+    beforeAll(async () => {
+      serverProcess = await startServer(
+        path.join(
+          process.cwd(),
+          'examples/servers/typescript/sep-2106-compliant-server.ts'
+        ),
+        PORT
+      );
+    }, 35000);
+
+    afterAll(async () => {
+      await stopServer(serverProcess);
+    });
+
+    it('emits all SUCCESS against a SEP-2106-compliant server (positive case)', async () => {
+      const scenario = new Sep2106Scenario();
+      const checks = await scenario.run(`http://localhost:${PORT}/mcp`);
+
+      // Every check should be SUCCESS (no FAILURE, no WARNING).
+      const failures = checks.filter((c) => c.status === 'FAILURE');
+      const warnings = checks.filter((c) => c.status === 'WARNING');
+      expect(
+        failures,
+        `unexpected failures: ${failures.map((f) => `${f.id}: ${f.errorMessage}`).join('; ')}`
+      ).toHaveLength(0);
+      expect(
+        warnings,
+        `unexpected warnings: ${warnings.map((w) => `${w.id}: ${w.errorMessage}`).join('; ')}`
+      ).toHaveLength(0);
+
+      // Sanity: all 9 expected check IDs are present.
+      const expectedIds = [
+        'sep-2106-array-output-tool-found',
+        'sep-2106-array-output-schema-preserved',
+        'sep-2106-array-structured-content',
+        'sep-2106-array-text-fallback',
+        'sep-2106-oneof-input-tool-found',
+        'sep-2106-oneof-input-schema-preserved',
+        'sep-2106-primitive-output-tool-found',
+        'sep-2106-primitive-output-schema-preserved',
+        'sep-2106-primitive-structured-content'
+      ];
+      for (const id of expectedIds) {
+        expect(
+          checks.find((c) => c.id === id),
+          `${id} missing`
+        ).toBeDefined();
       }
     }, 15000);
   });

--- a/src/scenarios/server/sep-2106.ts
+++ b/src/scenarios/server/sep-2106.ts
@@ -1,0 +1,530 @@
+/**
+ * SEP-2106: Tools `inputSchema` & `outputSchema` Conform to JSON Schema 2020-12
+ *
+ * SEP-2106 loosens the wire-format restrictions on tool schemas:
+ *   - inputSchema keeps `type: "object"` but allows any JSON Schema 2020-12
+ *     keyword alongside it (oneOf/anyOf/allOf, if/then/else, $ref/$defs)
+ *   - outputSchema drops the `type: "object"` requirement (arrays, primitives,
+ *     compositions at root are now valid)
+ *   - structuredContent widens from `{[key: string]: unknown}` to `unknown`
+ *
+ * The spec diff in docs/specification/draft/server/tools.mdx adds no new RFC
+ * 2119 sentences — it is descriptive-only loosening. This scenario therefore
+ * runs as a *capability* test (mirroring the SEP-1613 json_schema_2020_12_tool
+ * pattern): a SEP-2106-compliant SDK can advertise the new schema shapes and
+ * round-trip non-object structuredContent without flattening or rewrapping.
+ *
+ * The one normative tie-in is the existing-but-newly-load-bearing SHOULD:
+ *   "For backwards compatibility, a tool that returns structured content
+ *    SHOULD also return the serialized JSON in a TextContent block."
+ * That SHOULD becomes critical once structuredContent can be array/primitive
+ * (pre-SEP clients only accept object structuredContent). Emitted as the
+ * `sep-2106-array-text-fallback` WARNING check below.
+ *
+ * Why raw HTTP instead of the SDK Client: the SDK Client's response validator
+ * rejects non-object outputSchema and non-object structuredContent — exactly
+ * the shapes this scenario needs to inspect. Using raw HTTP bypasses the
+ * validator so the scenario can see what the server actually put on the wire.
+ */
+
+import http from 'http';
+import { DRAFT_PROTOCOL_VERSION } from '../../types.js';
+import type { ClientScenario, ConformanceCheck } from '../../types.js';
+
+const ARRAY_TOOL = 'sep_2106_array_output_tool';
+const ONEOF_TOOL = 'sep_2106_oneof_input_tool';
+const PRIMITIVE_TOOL = 'sep_2106_primitive_output_tool';
+
+const SPEC_REFERENCES = [
+  {
+    id: 'SEP-2106',
+    url: 'https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2106'
+  },
+  {
+    id: 'tools#structured-content',
+    url: 'https://modelcontextprotocol.io/specification/draft/server/tools#structured-content'
+  }
+];
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+interface RawResponse {
+  status: number;
+  headers: http.IncomingHttpHeaders;
+  body: unknown;
+}
+
+/**
+ * POST a JSON-RPC request to a Streamable-HTTP MCP endpoint. Handles both
+ * application/json and text/event-stream responses (the transport may pick
+ * either; SSE is parsed back to the first `data:` JSON payload).
+ */
+function postJsonRpc(
+  serverUrl: string,
+  body: object,
+  headers: Record<string, string> = {}
+): Promise<RawResponse> {
+  const url = new URL(serverUrl);
+  const bodyStr = JSON.stringify(body);
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: url.hostname,
+        port: url.port,
+        path: url.pathname,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+          'Content-Length': Buffer.byteLength(bodyStr),
+          ...headers
+        }
+      },
+      (res) => {
+        res.setEncoding('utf8');
+        let raw = '';
+        res.on('data', (chunk) => {
+          raw += chunk;
+        });
+        res.on('end', () => {
+          const contentType = (res.headers['content-type'] ?? '').toLowerCase();
+          let parsed: unknown = raw;
+          if (raw.length === 0) {
+            parsed = null;
+          } else if (contentType.includes('text/event-stream')) {
+            // Find the first non-empty data: payload and parse it as JSON.
+            const dataLines = raw
+              .split(/\r?\n/)
+              .filter((l) => l.startsWith('data:'))
+              .map((l) => l.slice(5).trim())
+              .filter((l) => l.length > 0);
+            const joined = dataLines.join('');
+            try {
+              parsed = joined ? JSON.parse(joined) : null;
+            } catch {
+              parsed = raw;
+            }
+          } else if (contentType.includes('application/json')) {
+            try {
+              parsed = JSON.parse(raw);
+            } catch {
+              parsed = raw;
+            }
+          }
+          resolve({
+            status: res.statusCode || 0,
+            headers: res.headers,
+            body: parsed
+          });
+        });
+      }
+    );
+    req.on('error', reject);
+    req.write(bodyStr);
+    req.end();
+  });
+}
+
+function extractSessionId(res: RawResponse): string | undefined {
+  const raw = res.headers['mcp-session-id'];
+  if (!raw) return undefined;
+  return Array.isArray(raw) ? raw[0] : raw;
+}
+
+/**
+ * Initialize a session with the server using raw JSON-RPC. Returns the
+ * mcp-session-id (may be undefined for stateless servers). Throws on
+ * non-2xx status or JSON-RPC error.
+ */
+async function initSession(serverUrl: string): Promise<string | undefined> {
+  const initRes = await postJsonRpc(serverUrl, {
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: DRAFT_PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: { name: 'sep-2106-raw-client', version: '1.0.0' }
+    }
+  });
+  if (initRes.status < 200 || initRes.status >= 300) {
+    throw new Error(
+      `initialize failed with HTTP ${initRes.status}: ${JSON.stringify(initRes.body)}`
+    );
+  }
+  const initBody = initRes.body as { error?: unknown } | null;
+  if (initBody && typeof initBody === 'object' && 'error' in initBody) {
+    throw new Error(
+      `initialize returned JSON-RPC error: ${JSON.stringify(initBody.error)}`
+    );
+  }
+  const sessionId = extractSessionId(initRes);
+
+  // Fire-and-forget notifications/initialized; some servers (StreamableHTTP
+  // session-based) require it before serving tools/list.
+  const notifHeaders: Record<string, string> = {};
+  if (sessionId) notifHeaders['mcp-session-id'] = sessionId;
+  try {
+    await postJsonRpc(
+      serverUrl,
+      { jsonrpc: '2.0', method: 'notifications/initialized' },
+      notifHeaders
+    );
+  } catch {
+    // Notification ack is best-effort.
+  }
+  return sessionId;
+}
+
+interface ToolRecord {
+  name: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+async function rawListTools(
+  serverUrl: string,
+  sessionId: string | undefined,
+  id: number
+): Promise<ToolRecord[]> {
+  const headers: Record<string, string> = {};
+  if (sessionId) headers['mcp-session-id'] = sessionId;
+  const res = await postJsonRpc(
+    serverUrl,
+    { jsonrpc: '2.0', id, method: 'tools/list', params: {} },
+    headers
+  );
+  if (res.status < 200 || res.status >= 300) {
+    throw new Error(
+      `tools/list failed with HTTP ${res.status}: ${JSON.stringify(res.body)}`
+    );
+  }
+  const body = res.body as {
+    result?: { tools?: ToolRecord[] };
+    error?: unknown;
+  } | null;
+  if (body && typeof body === 'object' && 'error' in body) {
+    throw new Error(
+      `tools/list returned JSON-RPC error: ${JSON.stringify(body.error)}`
+    );
+  }
+  return body?.result?.tools ?? [];
+}
+
+interface CallResult {
+  content?: Array<Record<string, unknown>>;
+  structuredContent?: unknown;
+  isError?: boolean;
+  [key: string]: unknown;
+}
+
+async function rawCallTool(
+  serverUrl: string,
+  sessionId: string | undefined,
+  id: number,
+  name: string
+): Promise<CallResult> {
+  const headers: Record<string, string> = {};
+  if (sessionId) headers['mcp-session-id'] = sessionId;
+  const res = await postJsonRpc(
+    serverUrl,
+    {
+      jsonrpc: '2.0',
+      id,
+      method: 'tools/call',
+      params: { name, arguments: {} }
+    },
+    headers
+  );
+  if (res.status < 200 || res.status >= 300) {
+    throw new Error(
+      `tools/call(${name}) failed with HTTP ${res.status}: ${JSON.stringify(res.body)}`
+    );
+  }
+  const body = res.body as { result?: CallResult; error?: unknown } | null;
+  if (body && typeof body === 'object' && 'error' in body) {
+    throw new Error(
+      `tools/call(${name}) returned JSON-RPC error: ${JSON.stringify(body.error)}`
+    );
+  }
+  return body?.result ?? {};
+}
+
+export class Sep2106Scenario implements ClientScenario {
+  name = 'sep-2106-json-schema-loosening';
+  readonly source = { introducedIn: DRAFT_PROTOCOL_VERSION } as const;
+  description = `Validates SEP-2106: loosened inputSchema/outputSchema/structuredContent (JSON Schema 2020-12).
+
+**Server Implementation Requirements:**
+
+The server MUST advertise three tools whose schemas exercise the loosened restrictions:
+
+1. \`${ARRAY_TOOL}\` — \`outputSchema\` is a JSON Schema with \`type: "array"\` at the root. The \`tools/call\` response MUST place a JSON array directly in \`structuredContent\` (not wrapped in an object) and SHOULD include a \`TextContent\` block containing the serialized JSON for backward compatibility with pre-SEP-2106 clients.
+
+2. \`${ONEOF_TOOL}\` — \`inputSchema\` is \`{ type: "object", oneOf: [...] }\` where the two oneOf branches require different keys (e.g. \`id\` vs \`name\`). The SDK MUST preserve the \`oneOf\` array in the \`tools/list\` response.
+
+3. \`${PRIMITIVE_TOOL}\` — \`outputSchema\` is a JSON Schema with a primitive type at the root (e.g. \`{ type: "number" }\`). The \`tools/call\` response MUST place a raw number directly in \`structuredContent\`.
+
+**Verification**: The scenario lists tools, calls the array and primitive tools, and checks that the new schema shapes survive the round-trip without being stripped or rewrapped. Uses raw HTTP rather than the SDK Client because pre-SEP-2106 SDK validators reject non-object outputSchema/structuredContent.`;
+
+  async run(serverUrl: string): Promise<ConformanceCheck[]> {
+    const checks: ConformanceCheck[] = [];
+
+    let sessionId: string | undefined;
+    try {
+      sessionId = await initSession(serverUrl);
+    } catch (error) {
+      checks.push({
+        id: 'sep-2106-error',
+        name: 'Sep2106Error',
+        description: 'SEP-2106 conformance test setup',
+        status: 'FAILURE',
+        timestamp: now(),
+        errorMessage: `Failed to initialize session: ${error instanceof Error ? error.message : String(error)}`,
+        specReferences: SPEC_REFERENCES
+      });
+      return checks;
+    }
+
+    let tools: ToolRecord[];
+    try {
+      tools = await rawListTools(serverUrl, sessionId, 2);
+    } catch (error) {
+      checks.push({
+        id: 'sep-2106-error',
+        name: 'Sep2106Error',
+        description: 'SEP-2106 conformance test tools/list',
+        status: 'FAILURE',
+        timestamp: now(),
+        errorMessage: `Failed to list tools: ${error instanceof Error ? error.message : String(error)}`,
+        specReferences: SPEC_REFERENCES
+      });
+      return checks;
+    }
+
+    const advertised = tools.map((t) => t.name);
+    const arrayTool = tools.find((t) => t.name === ARRAY_TOOL);
+    const oneofTool = tools.find((t) => t.name === ONEOF_TOOL);
+    const primitiveTool = tools.find((t) => t.name === PRIMITIVE_TOOL);
+
+    // ─── Array-output tool ───────────────────────────────────────────────
+    checks.push({
+      id: 'sep-2106-array-output-tool-found',
+      name: 'Sep2106ArrayOutputToolFound',
+      description: `Server advertises tool '${ARRAY_TOOL}'`,
+      status: arrayTool ? 'SUCCESS' : 'FAILURE',
+      timestamp: now(),
+      errorMessage: arrayTool
+        ? undefined
+        : `Tool '${ARRAY_TOOL}' not found. Available tools: ${advertised.join(', ') || 'none'}`,
+      specReferences: SPEC_REFERENCES,
+      details: { advertised }
+    });
+
+    if (arrayTool) {
+      const output = arrayTool.outputSchema;
+      const isArrayRoot = !!output && output.type === 'array';
+
+      checks.push({
+        id: 'sep-2106-array-output-schema-preserved',
+        name: 'Sep2106ArrayOutputSchemaPreserved',
+        description: `${ARRAY_TOOL} advertises an array-at-root outputSchema (SEP-2106 loosened outputSchema)`,
+        status: isArrayRoot ? 'SUCCESS' : 'FAILURE',
+        timestamp: now(),
+        errorMessage: !output
+          ? `outputSchema is missing on '${ARRAY_TOOL}'`
+          : !isArrayRoot
+            ? `outputSchema.type is ${JSON.stringify(output.type)}, expected 'array'. SDK may have wrapped the array in an object — SEP-2106 removes the type: "object" requirement on outputSchema.`
+            : undefined,
+        specReferences: SPEC_REFERENCES,
+        details: { outputSchema: output }
+      });
+
+      try {
+        const callResult = await rawCallTool(
+          serverUrl,
+          sessionId,
+          3,
+          ARRAY_TOOL
+        );
+        const sc = callResult.structuredContent;
+        const isArraySc = Array.isArray(sc);
+
+        checks.push({
+          id: 'sep-2106-array-structured-content',
+          name: 'Sep2106ArrayStructuredContent',
+          description: `${ARRAY_TOOL} returns a JSON array directly in structuredContent (SEP-2106 widens structuredContent to any JSON value)`,
+          status: isArraySc ? 'SUCCESS' : 'FAILURE',
+          timestamp: now(),
+          errorMessage: isArraySc
+            ? undefined
+            : sc === undefined
+              ? 'structuredContent is missing from the call result'
+              : `structuredContent is ${typeof sc}, expected array. SDK may have wrapped the array in an object before sending.`,
+          specReferences: SPEC_REFERENCES,
+          details: { structuredContent: sc }
+        });
+
+        // Backcompat SHOULD: serialized JSON in a TextContent block. Newly
+        // load-bearing because pre-SEP clients only accept object
+        // structuredContent and would otherwise drop the array silently.
+        const content = callResult.content ?? [];
+        const textBlock = content.find((c) => c?.type === 'text') as
+          | { text?: unknown }
+          | undefined;
+        let textMatchesStructured = false;
+        let parsedText: unknown = undefined;
+        if (textBlock && typeof textBlock.text === 'string') {
+          try {
+            parsedText = JSON.parse(textBlock.text);
+            textMatchesStructured =
+              JSON.stringify(parsedText) === JSON.stringify(sc);
+          } catch {
+            textMatchesStructured = false;
+          }
+        }
+
+        checks.push({
+          id: 'sep-2106-array-text-fallback',
+          name: 'Sep2106ArrayTextFallback',
+          description:
+            'For backward compatibility, a tool that returns non-object structuredContent SHOULD also emit a TextContent block containing the serialized JSON',
+          status: textMatchesStructured ? 'SUCCESS' : 'WARNING',
+          timestamp: now(),
+          errorMessage: textMatchesStructured
+            ? undefined
+            : !textBlock
+              ? 'No TextContent block in the call response; pre-SEP-2106 clients will not see the array data'
+              : typeof textBlock.text !== 'string'
+                ? 'TextContent block found but its text is not a string'
+                : 'TextContent block does not parse to the same JSON as structuredContent',
+          specReferences: SPEC_REFERENCES,
+          details: { textBlock, parsedText, structuredContent: sc }
+        });
+      } catch (err) {
+        checks.push({
+          id: 'sep-2106-array-structured-content',
+          name: 'Sep2106ArrayStructuredContent',
+          description: `Call to ${ARRAY_TOOL} failed`,
+          status: 'FAILURE',
+          timestamp: now(),
+          errorMessage: `tools/call threw: ${err instanceof Error ? err.message : String(err)}`,
+          specReferences: SPEC_REFERENCES
+        });
+      }
+    }
+
+    // ─── oneOf-input tool ────────────────────────────────────────────────
+    checks.push({
+      id: 'sep-2106-oneof-input-tool-found',
+      name: 'Sep2106OneOfInputToolFound',
+      description: `Server advertises tool '${ONEOF_TOOL}'`,
+      status: oneofTool ? 'SUCCESS' : 'FAILURE',
+      timestamp: now(),
+      errorMessage: oneofTool
+        ? undefined
+        : `Tool '${ONEOF_TOOL}' not found. Available tools: ${advertised.join(', ') || 'none'}`,
+      specReferences: SPEC_REFERENCES,
+      details: { advertised }
+    });
+
+    if (oneofTool) {
+      const input = oneofTool.inputSchema;
+      const oneOf = input?.oneOf;
+      const isOneOfPreserved = Array.isArray(oneOf) && oneOf.length >= 2;
+
+      checks.push({
+        id: 'sep-2106-oneof-input-schema-preserved',
+        name: 'Sep2106OneOfInputSchemaPreserved',
+        description: `${ONEOF_TOOL} advertises inputSchema.oneOf (SEP-2106 loosened inputSchema)`,
+        status: isOneOfPreserved ? 'SUCCESS' : 'FAILURE',
+        timestamp: now(),
+        errorMessage: isOneOfPreserved
+          ? undefined
+          : !input
+            ? 'inputSchema is missing'
+            : oneOf === undefined
+              ? 'inputSchema.oneOf was stripped by the SDK — SEP-2106 requires that composition keywords survive tools/list'
+              : `inputSchema.oneOf is not a valid composition array: ${JSON.stringify(oneOf)}`,
+        specReferences: SPEC_REFERENCES,
+        details: { inputSchema: input }
+      });
+    }
+
+    // ─── Primitive-output tool ───────────────────────────────────────────
+    checks.push({
+      id: 'sep-2106-primitive-output-tool-found',
+      name: 'Sep2106PrimitiveOutputToolFound',
+      description: `Server advertises tool '${PRIMITIVE_TOOL}'`,
+      status: primitiveTool ? 'SUCCESS' : 'FAILURE',
+      timestamp: now(),
+      errorMessage: primitiveTool
+        ? undefined
+        : `Tool '${PRIMITIVE_TOOL}' not found. Available tools: ${advertised.join(', ') || 'none'}`,
+      specReferences: SPEC_REFERENCES,
+      details: { advertised }
+    });
+
+    if (primitiveTool) {
+      const output = primitiveTool.outputSchema;
+      const isPrimitiveRoot = !!output && output.type === 'number';
+
+      checks.push({
+        id: 'sep-2106-primitive-output-schema-preserved',
+        name: 'Sep2106PrimitiveOutputSchemaPreserved',
+        description: `${PRIMITIVE_TOOL} advertises a primitive outputSchema (SEP-2106 loosened outputSchema)`,
+        status: isPrimitiveRoot ? 'SUCCESS' : 'FAILURE',
+        timestamp: now(),
+        errorMessage: !output
+          ? `outputSchema is missing on '${PRIMITIVE_TOOL}'`
+          : !isPrimitiveRoot
+            ? `outputSchema.type is ${JSON.stringify(output.type)}, expected 'number'. SDK may have wrapped the primitive in an object.`
+            : undefined,
+        specReferences: SPEC_REFERENCES,
+        details: { outputSchema: output }
+      });
+
+      try {
+        const callResult = await rawCallTool(
+          serverUrl,
+          sessionId,
+          4,
+          PRIMITIVE_TOOL
+        );
+        const sc = callResult.structuredContent;
+        const isNumberSc = typeof sc === 'number';
+
+        checks.push({
+          id: 'sep-2106-primitive-structured-content',
+          name: 'Sep2106PrimitiveStructuredContent',
+          description: `${PRIMITIVE_TOOL} returns a raw number in structuredContent (SEP-2106 widens structuredContent)`,
+          status: isNumberSc ? 'SUCCESS' : 'FAILURE',
+          timestamp: now(),
+          errorMessage: isNumberSc
+            ? undefined
+            : sc === undefined
+              ? 'structuredContent is missing from the call result'
+              : `structuredContent is ${typeof sc} (${JSON.stringify(sc)}), expected number. SDK may have wrapped the primitive in an object.`,
+          specReferences: SPEC_REFERENCES,
+          details: { structuredContent: sc }
+        });
+      } catch (err) {
+        checks.push({
+          id: 'sep-2106-primitive-structured-content',
+          name: 'Sep2106PrimitiveStructuredContent',
+          description: `Call to ${PRIMITIVE_TOOL} failed`,
+          status: 'FAILURE',
+          timestamp: now(),
+          errorMessage: `tools/call threw: ${err instanceof Error ? err.message : String(err)}`,
+          specReferences: SPEC_REFERENCES
+        });
+      }
+    }
+
+    return checks;
+  }
+}

--- a/src/seps/sep-2106.yaml
+++ b/src/seps/sep-2106.yaml
@@ -1,0 +1,8 @@
+sep: 2106
+spec_url: https://modelcontextprotocol.io/specification/draft/server/tools#structured-content
+requirements:
+  - check: sep-2106-array-text-fallback
+    text: 'For backwards compatibility, a tool that returns structured content SHOULD also return the serialized JSON in a TextContent block'
+
+  - text: 'SEP-2106 loosens inputSchema/outputSchema/structuredContent restrictions but adds no new RFC 2119 sentences to the spec text; SEP-2106 conformance is asserted by capability checks (sep-2106-*-tool-found, sep-2106-*-schema-preserved, sep-2106-*-structured-content) emitted by src/scenarios/server/sep-2106.ts and tracked in the manifest under untracked.'
+    excluded: 'descriptive-only spec change; capability-test SEP modeled after SEP-1613'


### PR DESCRIPTION
## Summary

Adds conformance support for [SEP-2106](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2106) (merged 2026-05-18), which loosens the tool-schema restrictions:

- `inputSchema` may now carry any JSON Schema 2020-12 keyword alongside `type: "object"` (composition: `oneOf`/`anyOf`/`allOf`/`not`, conditional: `if`/`then`/`else`, references: `$ref`/`$defs`/`$anchor`)
- `outputSchema` drops the `type: "object"` requirement entirely — arrays, primitives, and compositions are now valid at the root
- `structuredContent` widens from `{[key: string]: unknown}` to `unknown`

SEP-2106's spec diff in `docs/specification/draft/server/tools.mdx` is **descriptive-only** — it adds no new RFC 2119 sentences. This PR therefore follows the **SEP-1613 capability-test pattern**: a SEP-2106-compliant SDK can advertise the new schema shapes and round-trip non-object `structuredContent` without flattening or rewrapping.

### What's in the PR

- **`src/scenarios/server/sep-2106.ts`** — `Sep2106Scenario` (single class, 9 checks per AGENTS.md "fewer scenarios, more checks"):
  | check ID | severity | what it asserts |
  |---|---|---|
  | `sep-2106-array-output-tool-found` | FAILURE | tool advertised |
  | `sep-2106-array-output-schema-preserved` | FAILURE | `outputSchema.type === 'array'` survives `tools/list` |
  | `sep-2106-array-structured-content` | FAILURE | `tools/call` returns array directly in `structuredContent` |
  | `sep-2106-array-text-fallback` | **WARNING** | the elevated SHOULD: TextContent block carries serialized JSON for pre-SEP clients |
  | `sep-2106-oneof-input-tool-found` | FAILURE | tool advertised |
  | `sep-2106-oneof-input-schema-preserved` | FAILURE | `inputSchema.oneOf` survives `tools/list` |
  | `sep-2106-primitive-output-tool-found` | FAILURE | tool advertised |
  | `sep-2106-primitive-output-schema-preserved` | FAILURE | `outputSchema.type === 'number'` survives |
  | `sep-2106-primitive-structured-content` | FAILURE | `tools/call` returns raw number in `structuredContent` |
- **`src/seps/sep-2106.yaml`** — traceability with one `check:` row (the elevated TextContent-fallback SHOULD) and one `excluded:` row noting that the eight capability check IDs surface in the manifest under `untracked` per the SEP-2484 contract for descriptive-only SEPs.
- **`examples/servers/typescript/everything-server.ts`** — three test tools (`sep_2106_array_output_tool`, `sep_2106_oneof_input_tool`, `sep_2106_primitive_output_tool`) plus a `ListToolsRequestSchema` override that re-injects raw schemas the Zod converter would strip — **gated behind `SEP_2106_ENABLED=1`**.
- **`examples/servers/typescript/sep-2106-broken-schema.ts`** — negative-test server (wraps array in object, omits TextContent fallback).
- **`examples/servers/typescript/sep-2106-compliant-server.ts`** — raw-Express positive-test server that bypasses the SDK to emit fully-compliant wire output.
- **`src/scenarios/server/negative.test.ts`** — two new `describe` blocks pinning specific failing/passing check IDs (per AGENTS.md §"prove it passes and fails").
- **`src/scenarios/index.ts`** — registered in both `pendingClientScenariosList` and `allClientScenariosList` mirroring SEP-1613.

### Why raw HTTP (and the env-var gate)

The currently-pinned SDK validates both incoming and outgoing `structuredContent` as `Record<string, unknown>`. That means:

1. The **SDK Client** rejects any `tools/list` response containing a non-object `outputSchema` — breaking unrelated scenarios that share the everything-server. → tools gated behind `SEP_2106_ENABLED=1`.
2. The **SDK Server** refuses to send a `tools/call` result with array/primitive `structuredContent`, returning JSON-RPC -32602 — so the only way to demonstrate a fully-compliant green-path server today is to bypass the SDK. → `sep-2106-compliant-server.ts` uses raw Express.
3. `Sep2106Scenario` itself uses raw HTTP for the same reason — it needs to see what the server actually put on the wire, not what the SDK validator allows through.

Once the SDK ships SEP-2106 support, the pending entry in `src/scenarios/index.ts` can be removed and the env-var gate can stay (or go) depending on whether the everything-server's existing tools also get migrated to the new shapes.

### Spec-vs-keyword note for reviewers

Per AGENTS.md §"Reviewing PRs > SEP scenarios", severity must come from the spec text. The spec diff for SEP-2106 in `docs/specification/draft/server/tools.mdx` is:

> **Structured** content is returned as a JSON value in the `structuredContent` field of a result. This can be any JSON value (object, array, string, number, boolean, or null) that conforms to the tool's `outputSchema` if one is defined.

Plus two example blocks. No new RFC 2119 keywords. The only normative tie-in is the existing-but-unchanged "SHOULD also return the serialized JSON in a TextContent block" line, which is newly load-bearing under SEP-2106 — captured as the one `check:` row in the yaml and emitted at WARNING severity.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm test` — 200/200 passing, including:
  - `sep-2106-broken-schema` negative case (pins five expected `FAILURE`s + one `WARNING`)
  - `sep-2106-compliant-positive` (all 9 checks `SUCCESS` against the raw-Express server)
- [ ] Reviewer to verify spec-keyword severity mapping against `docs/specification/draft/server/tools.mdx` (no new RFC 2119 sentences → capability-test framing is the right call)
- [ ] Once a reference SDK ships SEP-2106 support: `npm start -- sdk <sdk>@<ref> --mode client --scenario sep-2106-json-schema-loosening` should go green end-to-end; at that point the `pendingClientScenariosList` entry can be removed in a follow-up.

---

*Note*: implementation assisted by Claude Code 🦉 (full transcript available on request); design/review/spec-keyword judgments are mine.