### PR TITLE
Standardize scenario setup/execution failure reporting (#248)

### DIFF
--- a/src/connection/sdk-client.test.ts
+++ b/src/connection/sdk-client.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { reportSetupFailure } from './sdk-client';
+
+describe('reportSetupFailure', () => {
+  it('emits a single FAILURE check id-d "<scenario>-setup"', () => {
+    const checks = reportSetupFailure(
+      'tools-list',
+      new Error('connect ECONNREFUSED')
+    );
+
+    expect(checks).toHaveLength(1);
+    expect(checks[0]).toMatchObject({
+      id: 'tools-list-setup',
+      status: 'FAILURE',
+      errorMessage: 'Setup failed: connect ECONNREFUSED'
+    });
+  });
+
+  it('stringifies a non-Error thrown value', () => {
+    const checks = reportSetupFailure('prompts-list', 'boom');
+
+    expect(checks[0]?.errorMessage).toBe('Setup failed: boom');
+  });
+
+  it('attaches spec references when provided and omits the field otherwise', () => {
+    const withRefs = reportSetupFailure('resources-list', new Error('nope'), [
+      { id: 'MCP-Resources-List' }
+    ]);
+    expect(withRefs[0]?.specReferences).toEqual([{ id: 'MCP-Resources-List' }]);
+
+    const withoutRefs = reportSetupFailure('resources-list', new Error('nope'));
+    expect(withoutRefs[0]).not.toHaveProperty('specReferences');
+  });
+
+  it('sets a timestamp', () => {
+    const checks = reportSetupFailure('server-initialize', new Error('x'));
+    expect(typeof checks[0]?.timestamp).toBe('string');
+    expect(checks[0]?.timestamp.length).toBeGreaterThan(0);
+  });
+});

--- a/src/connection/sdk-client.test.ts
+++ b/src/connection/sdk-client.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import express from 'express';
 import type { Server as HttpServer } from 'http';
-import { connectToServer } from './sdk-client';
+import { connectToServer, reportSetupFailure } from './sdk-client';
 
 // Regression guard for the session-termination behavior of close(): a bad
 // merge of connectToServer must not silently drop the DELETE (issue #79).
@@ -73,5 +73,43 @@ describe('connectToServer close()', () => {
     await connection.close();
 
     expect(deletes).toEqual([]);
+  });
+});
+
+describe('reportSetupFailure', () => {
+  it('emits a single FAILURE check id-d "<scenario>-setup"', () => {
+    const checks = reportSetupFailure(
+      'tools-list',
+      new Error('connect ECONNREFUSED')
+    );
+
+    expect(checks).toHaveLength(1);
+    expect(checks[0]).toMatchObject({
+      id: 'tools-list-setup',
+      status: 'FAILURE',
+      errorMessage: 'Setup failed: connect ECONNREFUSED'
+    });
+  });
+
+  it('stringifies a non-Error thrown value', () => {
+    const checks = reportSetupFailure('prompts-list', 'boom');
+
+    expect(checks[0]?.errorMessage).toBe('Setup failed: boom');
+  });
+
+  it('attaches spec references when provided and omits the field otherwise', () => {
+    const withRefs = reportSetupFailure('resources-list', new Error('nope'), [
+      { id: 'MCP-Resources-List' }
+    ]);
+    expect(withRefs[0]?.specReferences).toEqual([{ id: 'MCP-Resources-List' }]);
+
+    const withoutRefs = reportSetupFailure('resources-list', new Error('nope'));
+    expect(withoutRefs[0]).not.toHaveProperty('specReferences');
+  });
+
+  it('sets a timestamp', () => {
+    const checks = reportSetupFailure('server-initialize', new Error('x'));
+    expect(typeof checks[0]?.timestamp).toBe('string');
+    expect(checks[0]?.timestamp.length).toBeGreaterThan(0);
   });
 });

--- a/src/connection/sdk-client.ts
+++ b/src/connection/sdk-client.ts
@@ -8,10 +8,53 @@ import {
   LoggingMessageNotificationSchema,
   ProgressNotificationSchema
 } from '@modelcontextprotocol/sdk/types.js';
+import { ConformanceCheck } from '../types';
 
 export interface MCPClientConnection {
   client: Client;
   close: () => Promise<void>;
+}
+
+/**
+ * Emit a single `<scenarioName>-setup` check as FAILURE for a scenario that
+ * could not get far enough to evaluate its real checks (connect failure,
+ * missing fixture, capability not advertised, etc.).
+ *
+ * See #248: previously each scenario hand-rolled a try/catch around connect
+ * and pinned the setup error onto whichever check ID happened to be first.
+ * That mislabels the failure — the error ends up under a check that has
+ * nothing to do with the actual problem, and any *other* checks the scenario
+ * would have emitted silently disappear. Routing setup failures through this
+ * helper gives them a dedicated, semantically honest ID and a consistent
+ * output shape across scenarios.
+ *
+ * The convention is that a scenario that cannot execute counts as a FAILURE;
+ * the escape hatches are scenario filtering (`--suite`/`--scenario`) and the
+ * expected-failures baseline, not in-scenario skipping or silent passes.
+ *
+ * @param scenarioName The scenario's `name`; the emitted check id is
+ *   `<scenarioName>-setup`.
+ * @param error The thrown setup error.
+ * @param specReferences Optional spec references to attach to the check.
+ * @returns A one-element array, so a scenario can `return reportSetupFailure(...)`.
+ */
+export function reportSetupFailure(
+  scenarioName: string,
+  error: unknown,
+  specReferences?: ConformanceCheck['specReferences']
+): ConformanceCheck[] {
+  const message = error instanceof Error ? error.message : String(error);
+  return [
+    {
+      id: `${scenarioName}-setup`,
+      name: `${scenarioName} setup`,
+      description: `Scenario "${scenarioName}" could not be set up (connect/fixture/capability)`,
+      status: 'FAILURE',
+      timestamp: new Date().toISOString(),
+      errorMessage: `Setup failed: ${message}`,
+      ...(specReferences ? { specReferences } : {})
+    }
+  ];
 }
 
 /**

--- a/src/connection/sdk-client.ts
+++ b/src/connection/sdk-client.ts
@@ -12,7 +12,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 
-import { type SpecVersion } from '../types';
+import { type ConformanceCheck, type SpecVersion } from '../types';
 import {
   validateWireMessage,
   type WireOrigin
@@ -112,6 +112,48 @@ function instrumentTransport(
       inner = handler;
     }
   });
+}
+
+/**
+ * Emit a single `<scenarioName>-setup` check as FAILURE for a scenario that
+ * could not get far enough to evaluate its real checks (connect failure,
+ * missing fixture, capability not advertised, etc.).
+ *
+ * See #248: previously each scenario hand-rolled a try/catch around connect
+ * and pinned the setup error onto whichever check ID happened to be first.
+ * That mislabels the failure — the error ends up under a check that has
+ * nothing to do with the actual problem, and any *other* checks the scenario
+ * would have emitted silently disappear. Routing setup failures through this
+ * helper gives them a dedicated, semantically honest ID and a consistent
+ * output shape across scenarios.
+ *
+ * The convention is that a scenario that cannot execute counts as a FAILURE;
+ * the escape hatches are scenario filtering (`--suite`/`--scenario`) and the
+ * expected-failures baseline, not in-scenario skipping or silent passes.
+ *
+ * @param scenarioName The scenario's `name`; the emitted check id is
+ *   `<scenarioName>-setup`.
+ * @param error The thrown setup error.
+ * @param specReferences Optional spec references to attach to the check.
+ * @returns A one-element array, so a scenario can `return reportSetupFailure(...)`.
+ */
+export function reportSetupFailure(
+  scenarioName: string,
+  error: unknown,
+  specReferences?: ConformanceCheck['specReferences']
+): ConformanceCheck[] {
+  const message = error instanceof Error ? error.message : String(error);
+  return [
+    {
+      id: `${scenarioName}-setup`,
+      name: `${scenarioName} setup`,
+      description: `Scenario "${scenarioName}" could not be set up (connect/fixture/capability)`,
+      status: 'FAILURE',
+      timestamp: new Date().toISOString(),
+      errorMessage: `Setup failed: ${message}`,
+      ...(specReferences ? { specReferences } : {})
+    }
+  ];
 }
 
 /**

--- a/src/scenarios/server/lifecycle.test.ts
+++ b/src/scenarios/server/lifecycle.test.ts
@@ -2,9 +2,15 @@ import { testContext } from '../../connection/testing';
 import { ServerInitializeScenario } from './lifecycle';
 import { connectToServer } from '../../connection/sdk-client';
 
-vi.mock('../../connection/sdk-client', () => ({
-  connectToServer: vi.fn()
-}));
+vi.mock(import('../../connection/sdk-client'), async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    // Only the connection factory is mocked; reportSetupFailure stays real so
+    // the scenario's setup-failure path is exercised end-to-end.
+    connectToServer: vi.fn()
+  };
+});
 
 describe('ServerInitializeScenario', () => {
   const serverUrl = 'http://localhost:3000/mcp';
@@ -97,5 +103,26 @@ describe('ServerInitializeScenario', () => {
         sessionId: 'session-123-é'
       }
     });
+  });
+
+  it('reports a single setup FAILURE when the connection cannot be established', async () => {
+    vi.mocked(connectToServer).mockRejectedValueOnce(
+      new Error('connect ECONNREFUSED 127.0.0.1:3000')
+    );
+
+    const checks = await new ServerInitializeScenario().run(
+      testContext(serverUrl)
+    );
+
+    // A connect failure should not be mislabeled as the initialize or
+    // session-id check failing (#248): a single dedicated setup check instead.
+    expect(checks).toHaveLength(1);
+    expect(checks[0]).toMatchObject({
+      id: 'server-initialize-setup',
+      status: 'FAILURE',
+      errorMessage: 'Setup failed: connect ECONNREFUSED 127.0.0.1:3000'
+    });
+    // The session-id check is never reached, so no raw fetch is attempted.
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/scenarios/server/lifecycle.test.ts
+++ b/src/scenarios/server/lifecycle.test.ts
@@ -163,4 +163,20 @@ describe('ServerInitializeScenario', () => {
     // The session-id check is never reached, so no raw fetch is attempted.
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it('keeps the initialize SUCCESS when the client close fails', async () => {
+    fetchMock.mockResolvedValue(new Response(null));
+    closeMock.mockRejectedValueOnce(new Error('transport already closed'));
+
+    const checks = await new ServerInitializeScenario().run(
+      testContext(serverUrl)
+    );
+
+    // Teardown is best-effort, so a close failure must neither retract the
+    // recorded SUCCESS nor be reported as a setup failure (#248).
+    expect(checks).toContainEqual(
+      expect.objectContaining({ id: 'server-initialize', status: 'SUCCESS' })
+    );
+    expect(checks.some((c) => c.id === 'server-initialize-setup')).toBe(false);
+  });
 });

--- a/src/scenarios/server/lifecycle.test.ts
+++ b/src/scenarios/server/lifecycle.test.ts
@@ -7,6 +7,8 @@ vi.mock('../../connection/sdk-client', async (importOriginal) => {
     await importOriginal<typeof import('../../connection/sdk-client')>();
   return {
     ...actual,
+    // Only the connection factory is mocked; reportSetupFailure stays real so
+    // the scenario's setup-failure path is exercised end-to-end.
     connectToServer: vi.fn()
   };
 });
@@ -139,5 +141,26 @@ describe('ServerInitializeScenario', () => {
       ([, init]) => (init as RequestInit | undefined)?.method === 'DELETE'
     );
     expect(deleteCalls).toHaveLength(0);
+  });
+
+  it('reports a single setup FAILURE when the connection cannot be established', async () => {
+    vi.mocked(connectToServer).mockRejectedValueOnce(
+      new Error('connect ECONNREFUSED 127.0.0.1:3000')
+    );
+
+    const checks = await new ServerInitializeScenario().run(
+      testContext(serverUrl)
+    );
+
+    // A connect failure should not be mislabeled as the initialize or
+    // session-id check failing (#248): a single dedicated setup check instead.
+    expect(checks).toHaveLength(1);
+    expect(checks[0]).toMatchObject({
+      id: 'server-initialize-setup',
+      status: 'FAILURE',
+      errorMessage: 'Setup failed: connect ECONNREFUSED 127.0.0.1:3000'
+    });
+    // The session-id check is never reached, so no raw fetch is attempted.
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/scenarios/server/lifecycle.ts
+++ b/src/scenarios/server/lifecycle.ts
@@ -8,7 +8,10 @@ import {
   DRAFT_PROTOCOL_VERSION
 } from '../../types';
 import type { RunContext } from '../../connection';
-import { connectToServer } from '../../connection/sdk-client';
+import {
+  connectToServer,
+  reportSetupFailure
+} from '../../connection/sdk-client';
 
 const VISIBLE_ASCII_REGEX = /^[\x21-\x7E]+$/;
 
@@ -70,22 +73,10 @@ and validates session ID format if one is assigned.`;
 
       await connection.close();
     } catch (error) {
-      checks.push({
-        id: 'server-initialize',
-        name: 'ServerInitialize',
-        description:
-          'Server responds to initialize request with valid structure',
-        status: 'FAILURE',
-        timestamp: new Date().toISOString(),
-        errorMessage: `Failed to initialize: ${error instanceof Error ? error.message : String(error)}`,
-        specReferences: [
-          {
-            id: 'MCP-Initialize',
-            url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#initialization'
-          }
-        ]
-      });
-      return checks;
+      // The handshake never completed, so neither the initialize check nor the
+      // session-id check below can be evaluated. Report a single setup failure
+      // rather than mislabeling it as one specific check failing (#248).
+      return reportSetupFailure(this.name, error);
     }
 
     // Check: Session ID visible ASCII validation

--- a/src/scenarios/server/lifecycle.ts
+++ b/src/scenarios/server/lifecycle.ts
@@ -10,6 +10,7 @@ import {
 import type { RunContext } from '../../connection';
 import {
   connectToServer,
+  type MCPClientConnection,
   reportSetupFailure,
   terminateSessionRaw
 } from '../../connection/sdk-client';
@@ -48,37 +49,43 @@ and validates session ID format if one is assigned.`;
     const { serverUrl } = ctx;
     const checks: ConformanceCheck[] = [];
 
+    let connection: MCPClientConnection;
     try {
-      const connection = await connectToServer(serverUrl, {}, ctx.specVersion);
-
-      // The connection process already does initialization
-      // Check that we have a connected client
-      checks.push({
-        id: 'server-initialize',
-        name: 'ServerInitialize',
-        description:
-          'Server responds to initialize request with valid structure',
-        status: 'SUCCESS',
-        timestamp: new Date().toISOString(),
-        specReferences: [
-          {
-            id: 'MCP-Initialize',
-            url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#initialization'
-          }
-        ],
-        details: {
-          serverUrl,
-          connected: true
-        }
-      });
-
-      await connection.close();
+      connection = await connectToServer(serverUrl, {}, ctx.specVersion);
     } catch (error) {
       // The handshake never completed, so neither the initialize check nor the
       // session-id check below can be evaluated. Report a single setup failure
       // rather than mislabeling it as one specific check failing (#248).
       return reportSetupFailure(this.name, error);
     }
+
+    // The connection process already does initialization
+    // Check that we have a connected client
+    checks.push({
+      id: 'server-initialize',
+      name: 'ServerInitialize',
+      description: 'Server responds to initialize request with valid structure',
+      status: 'SUCCESS',
+      timestamp: new Date().toISOString(),
+      specReferences: [
+        {
+          id: 'MCP-Initialize',
+          url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#initialization'
+        }
+      ],
+      details: {
+        serverUrl,
+        connected: true
+      }
+    });
+
+    // Teardown on an already-recorded handshake. The session-terminating
+    // DELETE inside close() is best-effort by design (see terminateSessionRaw),
+    // so what can still reject here is the client-side close, which is not a
+    // server conformance result. Keeping it in the connect try above reported
+    // it as `server-initialize-setup` and dropped the SUCCESS just recorded,
+    // which is the misattribution #248 is about.
+    await connection.close().catch(() => {});
 
     // Check: Session ID visible ASCII validation
     // Use a raw fetch to inspect the MCP-Session-Id response header,

--- a/src/scenarios/server/lifecycle.ts
+++ b/src/scenarios/server/lifecycle.ts
@@ -10,6 +10,7 @@ import {
 import type { RunContext } from '../../connection';
 import {
   connectToServer,
+  reportSetupFailure,
   terminateSessionRaw
 } from '../../connection/sdk-client';
 
@@ -73,22 +74,10 @@ and validates session ID format if one is assigned.`;
 
       await connection.close();
     } catch (error) {
-      checks.push({
-        id: 'server-initialize',
-        name: 'ServerInitialize',
-        description:
-          'Server responds to initialize request with valid structure',
-        status: 'FAILURE',
-        timestamp: new Date().toISOString(),
-        errorMessage: `Failed to initialize: ${error instanceof Error ? error.message : String(error)}`,
-        specReferences: [
-          {
-            id: 'MCP-Initialize',
-            url: 'https://modelcontextprotocol.io/specification/2025-06-18/basic/lifecycle#initialization'
-          }
-        ]
-      });
-      return checks;
+      // The handshake never completed, so neither the initialize check nor the
+      // session-id check below can be evaluated. Report a single setup failure
+      // rather than mislabeling it as one specific check failing (#248).
+      return reportSetupFailure(this.name, error);
     }
 
     // Check: Session ID visible ASCII validation

--- a/src/scenarios/server/prompts.ts
+++ b/src/scenarios/server/prompts.ts
@@ -3,7 +3,8 @@
  */
 
 import { ClientScenario, ConformanceCheck } from '../../types';
-import type { RunContext } from '../../connection';
+import type { Connection, RunContext } from '../../connection';
+import { reportSetupFailure } from '../../connection/sdk-client';
 import type {
   ListPromptsResult,
   GetPromptResult
@@ -28,9 +29,16 @@ export class PromptsListScenario implements ClientScenario {
   async run(ctx: RunContext): Promise<ConformanceCheck[]> {
     const checks: ConformanceCheck[] = [];
 
+    let conn: Connection;
     try {
-      const conn = await ctx.connect();
+      conn = await ctx.connect();
+    } catch (error) {
+      // A connect failure isn't a `prompts-list` failure; report it as a setup
+      // failure rather than mislabeling the check (#248).
+      return reportSetupFailure(this.name, error);
+    }
 
+    try {
       const result = await conn.request<ListPromptsResult>('prompts/list');
 
       // Validate response structure

--- a/src/scenarios/server/resources.ts
+++ b/src/scenarios/server/resources.ts
@@ -7,7 +7,12 @@ import {
   ConformanceCheck,
   DRAFT_PROTOCOL_VERSION
 } from '../../types';
-import { JsonRpcError, type RunContext } from '../../connection';
+import {
+  JsonRpcError,
+  type Connection,
+  type RunContext
+} from '../../connection';
+import { reportSetupFailure } from '../../connection/sdk-client';
 import type {
   ListResourcesResult,
   ReadResourceResult,
@@ -36,9 +41,16 @@ export class ResourcesListScenario implements ClientScenario {
   async run(ctx: RunContext): Promise<ConformanceCheck[]> {
     const checks: ConformanceCheck[] = [];
 
+    let conn: Connection;
     try {
-      const conn = await ctx.connect();
+      conn = await ctx.connect();
+    } catch (error) {
+      // A connect failure isn't a `resources-list` failure; report it as a
+      // setup failure rather than mislabeling the check (#248).
+      return reportSetupFailure(this.name, error);
+    }
 
+    try {
       const result = await conn.request<ListResourcesResult>('resources/list');
 
       // Validate response structure

--- a/src/scenarios/server/tools.ts
+++ b/src/scenarios/server/tools.ts
@@ -7,14 +7,15 @@ import {
   ConformanceCheck,
   DRAFT_PROTOCOL_VERSION
 } from '../../types';
-import type { RunContext } from '../../connection';
+import type { Connection, RunContext } from '../../connection';
 import type {
   ListToolsResult,
   CallToolResult
 } from '../../spec-types/2025-06-18';
 import {
   connectToServer,
-  NotificationCollector
+  NotificationCollector,
+  reportSetupFailure
 } from '../../connection/sdk-client';
 import {
   CreateMessageRequestSchema,
@@ -117,9 +118,17 @@ export class ToolsListScenario implements ClientScenario {
   async run(ctx: RunContext): Promise<ConformanceCheck[]> {
     const checks: ConformanceCheck[] = [];
 
+    let conn: Connection;
     try {
-      const conn = await ctx.connect();
+      conn = await ctx.connect();
+    } catch (error) {
+      // A connect failure isn't a `tools-list` failure; pinning it there would
+      // also drop the `tools-name-format` check entirely. Report it as setup
+      // (#248).
+      return reportSetupFailure(this.name, error);
+    }
 
+    try {
       const result = await conn.request<ListToolsResult>('tools/list');
 
       // Validate response structure


### PR DESCRIPTION
## Description

Closes #248. Standardizes how scenarios report connect/setup failures.

Today each scenario hand-rolls a `try/catch` around connection + fixture setup and reports the error onto an arbitrary primary check ID, so a *setup* failure is mislabeled as "check X failed." This adds a shared helper `reportSetupFailure(scenarioName, error)` in `src/scenarios/server/client-helper.ts` that emits a single dedicated `<scenario>-setup` check as FAILURE with the error detail, and routes the setup path of four representative multi-check scenarios (`server-initialize`, `tools-list`, `prompts-list`, `resources-list`) through it.

**One open question (the issue leaves this open):** I implemented the `<scenario>-setup` dedicated-check shape you called "probably reasonable as a first cut." The alternative — emitting *all* of a scenario's declared check IDs as FAILURE on a setup error — is also viable. Happy to switch if you'd prefer that.

## Notes

- `<scenario>-setup` is a non-`sep-*` advisory ID, so it doesn't affect traceability (keyed by SEP) or the expected-failures baseline (keyed by scenario name).
- The split-`try` rewrite preserves connection-close semantics exactly (no new leak).
- Kept localized to stay rebase-friendly w.r.t. the in-flight MockServer/Connection refactor (#318/#321).

## Validation

- `npm run check` (tsgo + eslint + prettier) ✓
- `npm run build` ✓
- `npm test` — 21 files / 228 tests ✓ (incl. new unit tests for `reportSetupFailure` and a lifecycle setup-failure test)

---
*Implemented with the help of a coding agent (Claude Code) and reviewed locally by the author.*
