### PR TITLE
chore: bump version to 0.2.0-alpha.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/conformance",
-  "version": "0.2.0-alpha.1",
+  "version": "0.2.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/conformance",
-      "version": "0.2.0-alpha.1",
+      "version": "0.2.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/conformance",
-  "version": "0.2.0-alpha.1",
+  "version": "0.2.0-alpha.2",
   "type": "module",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",


### PR DESCRIPTION
Bump version to 0.2.0-alpha.2 for the next alpha release.

Includes everything merged through #321, notably:
- Client-side spec-version inference, skip behavior, and `--force` on the runner
- `--spec-version` passthrough on the `sdk` command with per-SDK defaults
- Version-aware MockServer / Connection abstractions
- Various everything-server and auth scenario fixes

After merge, publish with `npm publish --tag alpha`.