### PR TITLE
feat: add SEP-2567 (sessionless Streamable HTTP) requirement traceability and server scenario

### DIFF
--- a/src/scenarios/index.ts
+++ b/src/scenarios/index.ts
@@ -19,6 +19,7 @@ import { MRTRClientScenario } from './client/mrtr-client';
 // Import all new server test scenarios
 import { ServerInitializeScenario } from './server/lifecycle';
 import { ServerStatelessScenario } from './server/stateless';
+import { ServerSessionlessScenario } from './server/sessionless';
 
 import {
   PingScenario,
@@ -130,6 +131,7 @@ const allClientScenariosList: ClientScenario[] = [
   // Lifecycle scenarios
   new ServerInitializeScenario(),
   new ServerStatelessScenario(),
+  new ServerSessionlessScenario(),
 
   // Utilities scenarios
   new LoggingSetLevelScenario(),

--- a/src/scenarios/server/sessionless.test.ts
+++ b/src/scenarios/server/sessionless.test.ts
@@ -1,0 +1,338 @@
+import { testContext } from '../../connection/testing';
+import { ServerSessionlessScenario } from './sessionless';
+import { describe, test, expect, afterEach } from 'vitest';
+import { ConformanceCheck, DRAFT_PROTOCOL_VERSION } from '../../types';
+
+const findCheck = (checks: ConformanceCheck[], id: string) =>
+  checks.find((c) => c.id === id);
+
+interface MockRequest {
+  httpMethod: string;
+  rpcMethod?: string;
+  rpcId?: string | number | null;
+  headers: Record<string, string>;
+}
+
+interface MockResponse {
+  status: number;
+  headers?: Record<string, string>;
+  json?: unknown;
+}
+
+type MockHandler = (req: MockRequest) => MockResponse | undefined;
+
+const originalFetch = global.fetch;
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+/**
+ * Install a mocked MCP server behind global.fetch. The handler sees every
+ * request (HTTP method, JSON-RPC method, lower-cased headers) and returns a
+ * response config; returning undefined falls through to a -32601/404.
+ */
+function installMockServer(handler: MockHandler): string {
+  global.fetch = (async (_url: unknown, init: RequestInit = {}) => {
+    const httpMethod = init.method ?? 'GET';
+    const headers: Record<string, string> = {};
+    for (const [key, value] of Object.entries(
+      (init.headers ?? {}) as Record<string, string>
+    )) {
+      headers[key.toLowerCase()] = String(value);
+    }
+    let body: { method?: string; id?: string | number | null } | undefined;
+    if (typeof init.body === 'string') {
+      try {
+        body = JSON.parse(init.body);
+      } catch {
+        // not JSON
+      }
+    }
+    const config = handler({
+      httpMethod,
+      rpcMethod: body?.method,
+      rpcId: body?.id,
+      headers
+    }) ?? {
+      status: 404,
+      json: {
+        jsonrpc: '2.0',
+        id: body?.id ?? null,
+        error: { code: -32601, message: 'Method not found' }
+      }
+    };
+    return new Response(
+      config.json !== undefined ? JSON.stringify(config.json) : null,
+      {
+        status: config.status,
+        headers: {
+          'content-type': 'application/json',
+          ...(config.headers ?? {})
+        }
+      }
+    );
+  }) as typeof fetch;
+  return 'http://mock-sessionless-server.local/mcp';
+}
+
+/**
+ * A compliant draft-only (2026-only) server: declares all three list
+ * capabilities, serves stable lists, 404/-32601s the legacy initialize
+ * handshake, 405s GET/DELETE, and never mints session IDs.
+ */
+function compliantDraftOnlyServer(req: MockRequest): MockResponse | undefined {
+  if (req.httpMethod === 'GET' || req.httpMethod === 'DELETE') {
+    return { status: 405 };
+  }
+  const ok = (result: unknown): MockResponse => ({
+    status: 200,
+    json: { jsonrpc: '2.0', id: req.rpcId, result }
+  });
+  switch (req.rpcMethod) {
+    case 'server/discover':
+      return ok({
+        supportedVersions: [DRAFT_PROTOCOL_VERSION],
+        capabilities: { tools: {}, resources: {}, prompts: {} },
+        serverInfo: { name: 'mock-sessionless-server', version: '1.0.0' }
+      });
+    case 'tools/list':
+      return ok({ tools: [{ name: 'alpha' }, { name: 'beta' }] });
+    case 'resources/list':
+      return ok({ resources: [{ uri: 'file:///stable.txt' }] });
+    case 'prompts/list':
+      return ok({ prompts: [{ name: 'stable-prompt' }] });
+    default:
+      return undefined; // initialize and unknown methods: 404 / -32601
+  }
+}
+
+async function runScenario(mockUrl: string): Promise<ConformanceCheck[]> {
+  const scenario = new ServerSessionlessScenario();
+  return scenario.run(testContext(mockUrl, DRAFT_PROTOCOL_VERSION));
+}
+
+describe('Sessionless Server Scenario', () => {
+  test('compliant draft-only server passes every check', async () => {
+    const mockUrl = installMockServer(compliantDraftOnlyServer);
+    const checks = await runScenario(mockUrl);
+
+    expect(checks.length).toBe(7);
+    for (const check of checks) {
+      expect(check.status, `${check.id}: ${check.errorMessage}`).toBe(
+        'SUCCESS'
+      );
+    }
+  });
+
+  test('flags a server that requires a session header', async () => {
+    const mockUrl = installMockServer((req) => {
+      if (req.httpMethod === 'POST' && !req.headers['mcp-session-id']) {
+        return {
+          status: 400,
+          json: {
+            jsonrpc: '2.0',
+            id: req.rpcId ?? null,
+            error: {
+              code: -32000,
+              message: 'Bad Request: Mcp-Session-Id required'
+            }
+          }
+        };
+      }
+      return compliantDraftOnlyServer(req);
+    });
+    const checks = await runScenario(mockUrl);
+
+    const check = findCheck(
+      checks,
+      'sep-2567-server-accepts-requests-without-session-id'
+    );
+    expect(check?.status).toBe('FAILURE');
+    expect(check?.errorMessage).toContain('Mcp-Session-Id');
+  });
+
+  test('flags a draft-only server that mints session IDs', async () => {
+    const mockUrl = installMockServer((req) => {
+      const response = compliantDraftOnlyServer(req);
+      if (req.httpMethod === 'POST' && response?.status === 200) {
+        return {
+          ...response,
+          headers: { 'Mcp-Session-Id': 'minted-session-id' }
+        };
+      }
+      return response;
+    });
+    const checks = await runScenario(mockUrl);
+
+    const check = findCheck(checks, 'sep-2567-server-ignores-session-id');
+    expect(check?.status).toBe('WARNING');
+    expect(check?.errorMessage).toContain('minted');
+  });
+
+  test('flags a draft-only server that rejects requests carrying a stale session id', async () => {
+    const mockUrl = installMockServer((req) => {
+      if (req.httpMethod === 'POST' && req.headers['mcp-session-id']) {
+        return {
+          status: 404,
+          json: {
+            jsonrpc: '2.0',
+            id: req.rpcId ?? null,
+            error: { code: -32001, message: 'Session not found' }
+          }
+        };
+      }
+      return compliantDraftOnlyServer(req);
+    });
+    const checks = await runScenario(mockUrl);
+
+    const check = findCheck(checks, 'sep-2567-server-ignores-session-id');
+    expect(check?.status).toBe('WARNING');
+    expect(check?.errorMessage).toContain('not served normally');
+  });
+
+  test('flags a draft-only server that serves GET or DELETE', async () => {
+    const mockUrl = installMockServer((req) => {
+      if (req.httpMethod === 'GET') {
+        return { status: 200, json: {} };
+      }
+      if (req.httpMethod === 'DELETE') {
+        return { status: 404 };
+      }
+      return compliantDraftOnlyServer(req);
+    });
+    const checks = await runScenario(mockUrl);
+
+    const check = findCheck(checks, 'sep-2567-server-rejects-get-and-delete');
+    expect(check?.status).toBe('WARNING');
+    expect(check?.errorMessage).toContain('GET returned 200');
+    expect(check?.errorMessage).toContain('DELETE returned 404');
+  });
+
+  test('flags a draft-only server that chokes on Last-Event-ID', async () => {
+    const mockUrl = installMockServer((req) => {
+      if (req.httpMethod === 'POST' && req.headers['last-event-id']) {
+        return {
+          status: 400,
+          json: {
+            jsonrpc: '2.0',
+            id: req.rpcId ?? null,
+            error: { code: -32600, message: 'Cannot resume stream' }
+          }
+        };
+      }
+      return compliantDraftOnlyServer(req);
+    });
+    const checks = await runScenario(mockUrl);
+
+    const check = findCheck(checks, 'sep-2567-server-ignores-last-event-id');
+    expect(check?.status).toBe('WARNING');
+  });
+
+  test('flags a tools list that varies between connections', async () => {
+    let callCount = 0;
+    const mockUrl = installMockServer((req) => {
+      if (req.rpcMethod === 'tools/list') {
+        callCount++;
+        return {
+          status: 200,
+          json: {
+            jsonrpc: '2.0',
+            id: req.rpcId,
+            result: { tools: [{ name: `per-connection-tool-${callCount}` }] }
+          }
+        };
+      }
+      return compliantDraftOnlyServer(req);
+    });
+    const checks = await runScenario(mockUrl);
+
+    const tools = findCheck(checks, 'sep-2567-tools-list-connection-invariant');
+    expect(tools?.status).toBe('FAILURE');
+    expect(tools?.errorMessage).toContain('diverged');
+
+    // The other list endpoints are stable and must still pass.
+    expect(
+      findCheck(checks, 'sep-2567-resources-list-connection-invariant')?.status
+    ).toBe('SUCCESS');
+    expect(
+      findCheck(checks, 'sep-2567-prompts-list-connection-invariant')?.status
+    ).toBe('SUCCESS');
+  });
+
+  test('skips list checks for capabilities the server does not declare', async () => {
+    const mockUrl = installMockServer((req) => {
+      if (req.rpcMethod === 'server/discover') {
+        return {
+          status: 200,
+          json: {
+            jsonrpc: '2.0',
+            id: req.rpcId,
+            result: {
+              supportedVersions: [DRAFT_PROTOCOL_VERSION],
+              capabilities: { tools: {} },
+              serverInfo: { name: 'tools-only-server', version: '1.0.0' }
+            }
+          }
+        };
+      }
+      return compliantDraftOnlyServer(req);
+    });
+    const checks = await runScenario(mockUrl);
+
+    expect(
+      findCheck(checks, 'sep-2567-tools-list-connection-invariant')?.status
+    ).toBe('SUCCESS');
+    expect(
+      findCheck(checks, 'sep-2567-resources-list-connection-invariant')?.status
+    ).toBe('SKIPPED');
+    expect(
+      findCheck(checks, 'sep-2567-prompts-list-connection-invariant')?.status
+    ).toBe('SKIPPED');
+  });
+
+  test('skips backward-compatibility checks for dual-era servers', async () => {
+    const mockUrl = installMockServer((req) => {
+      if (req.rpcMethod === 'initialize') {
+        // Legacy era: serve the initialize handshake and mint a session.
+        return {
+          status: 200,
+          headers: { 'Mcp-Session-Id': 'legacy-session-id' },
+          json: {
+            jsonrpc: '2.0',
+            id: req.rpcId,
+            result: {
+              protocolVersion: '2025-11-25',
+              capabilities: {},
+              serverInfo: { name: 'dual-era-server', version: '1.0.0' }
+            }
+          }
+        };
+      }
+      if (req.httpMethod === 'GET' || req.httpMethod === 'DELETE') {
+        // Legacy sessions are served, so these are not 405.
+        return { status: 400 };
+      }
+      return compliantDraftOnlyServer(req);
+    });
+    const checks = await runScenario(mockUrl);
+
+    expect(
+      findCheck(checks, 'sep-2567-server-rejects-get-and-delete')?.status
+    ).toBe('SKIPPED');
+    expect(
+      findCheck(checks, 'sep-2567-server-ignores-session-id')?.status
+    ).toBe('SKIPPED');
+    expect(
+      findCheck(checks, 'sep-2567-server-ignores-last-event-id')?.status
+    ).toBe('SKIPPED');
+
+    // The sessionless core invariants still apply to the modern era.
+    expect(
+      findCheck(checks, 'sep-2567-server-accepts-requests-without-session-id')
+        ?.status
+    ).toBe('SUCCESS');
+    expect(
+      findCheck(checks, 'sep-2567-tools-list-connection-invariant')?.status
+    ).toBe('SUCCESS');
+  });
+});

--- a/src/scenarios/server/sessionless.ts
+++ b/src/scenarios/server/sessionless.ts
@@ -1,0 +1,522 @@
+/**
+ * Sessionless Streamable HTTP scenarios for MCP servers (SEP-2567).
+ *
+ * SEP-2567 removes protocol-level sessions and the `Mcp-Session-Id` header
+ * from the Streamable HTTP transport. This scenario verifies the observable
+ * consequences against a server speaking the draft revision:
+ *
+ * - requests that carry no session header are served normally (there is no
+ *   session mechanism left to require);
+ * - list endpoints (`tools/list`, `resources/list`, `prompts/list`) do not
+ *   vary per-connection or as a side effect of other requests — every
+ *   harness request arrives on an independent connection, so two snapshots
+ *   with unrelated requests interleaved must agree;
+ * - a server that supports only this revision handles legacy session-era
+ *   traffic as the spec's backward-compatibility section says it SHOULD:
+ *   405 for GET/DELETE, ignore `Mcp-Session-Id` (and do not mint or echo
+ *   session IDs), ignore `Last-Event-ID`.
+ *
+ * The backward-compatibility checks only apply to servers that support
+ * *only* the draft revision. Dual-era servers (which also serve the legacy
+ * `initialize` handshake) implement the corresponding revision's behavior
+ * instead, so those checks report SKIPPED for them. Era is detected by
+ * probing with a legacy-shaped `initialize` request.
+ */
+
+import {
+  ClientScenario,
+  ConformanceCheck,
+  DRAFT_PROTOCOL_VERSION
+} from '../../types';
+import {
+  sendStatelessRequest,
+  readSseJsonRpcResponse,
+  type RunContext,
+  type StatelessResponse
+} from '../../connection';
+
+const SEP_URL =
+  'https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2567';
+const TRANSPORT_BACKCOMPAT_URL =
+  'https://modelcontextprotocol.io/specification/draft/basic/transports/streamable-http#earlier-streamable-http-revisions';
+
+const SESSION_HEADER = 'Mcp-Session-Id';
+
+interface ListEndpoint {
+  capability: 'tools' | 'resources' | 'prompts';
+  method: 'tools/list' | 'resources/list' | 'prompts/list';
+  /** Result field holding the list. */
+  field: 'tools' | 'resources' | 'prompts';
+  /** Item property that identifies a list entry. */
+  idKey: 'name' | 'uri';
+  specUrl: string;
+}
+
+const LIST_ENDPOINTS: ListEndpoint[] = [
+  {
+    capability: 'tools',
+    method: 'tools/list',
+    field: 'tools',
+    idKey: 'name',
+    specUrl:
+      'https://modelcontextprotocol.io/specification/draft/server/tools#capabilities'
+  },
+  {
+    capability: 'resources',
+    method: 'resources/list',
+    field: 'resources',
+    idKey: 'uri',
+    specUrl:
+      'https://modelcontextprotocol.io/specification/draft/server/resources#capabilities'
+  },
+  {
+    capability: 'prompts',
+    method: 'prompts/list',
+    field: 'prompts',
+    idKey: 'name',
+    specUrl:
+      'https://modelcontextprotocol.io/specification/draft/server/prompts#capabilities'
+  }
+];
+
+/** Read a response header defensively (mocks may omit `headers`). */
+function getHeader(res: { headers?: Headers }, name: string): string | null {
+  return typeof res.headers?.get === 'function' ? res.headers.get(name) : null;
+}
+
+export class ServerSessionlessScenario implements ClientScenario {
+  name = 'server-sessionless';
+  readonly source = { introducedIn: DRAFT_PROTOCOL_VERSION } as const;
+  description = `Test sessionless Streamable HTTP operation (SEP-2567).
+
+SEP-2567 removes protocol-level sessions and the Mcp-Session-Id header from
+the Streamable HTTP transport. This scenario verifies:
+
+1. **No session required** — a request without any Mcp-Session-Id header is
+   served normally; the server does not reject it demanding a session.
+2. **List-endpoint connection invariance** — for each list capability the
+   server declares (tools, resources, prompts), two list snapshots taken on
+   independent connections, with unrelated requests interleaved, return the
+   same set. The set may legitimately vary by the authorization presented on
+   the request, but not per-connection.
+3. **Legacy-traffic handling (2026-only servers, SHOULD)** — a server that
+   supports only this revision responds 405 to HTTP GET/DELETE, ignores an
+   Mcp-Session-Id request header without minting or echoing session IDs, and
+   ignores Last-Event-ID. Dual-era servers (which still serve the legacy
+   initialize handshake) implement the legacy revision's behavior instead,
+   so these checks are SKIPPED for them.`;
+
+  async run(ctx: RunContext): Promise<ConformanceCheck[]> {
+    const { serverUrl, specVersion } = ctx;
+    const checks: ConformanceCheck[] = [];
+    const timestamp = new Date().toISOString();
+
+    function pushCheck(args: {
+      id: string;
+      name: string;
+      description: string;
+      specUrl?: string;
+      error?: string;
+      warning?: boolean;
+      skipped?: boolean;
+      details?: Record<string, unknown>;
+    }) {
+      checks.push({
+        id: args.id,
+        name: args.name,
+        description: args.description,
+        status: args.error
+          ? args.warning
+            ? 'WARNING'
+            : 'FAILURE'
+          : args.skipped
+            ? 'SKIPPED'
+            : 'SUCCESS',
+        timestamp,
+        errorMessage: args.error || undefined,
+        specReferences: [
+          { id: 'SEP-2567', url: SEP_URL },
+          ...(args.specUrl ? [{ id: 'spec', url: args.specUrl }] : [])
+        ],
+        details: args.details
+      });
+    }
+
+    const send = (
+      method: string,
+      params?: Record<string, unknown>,
+      headers?: Record<string, string>
+    ): Promise<StatelessResponse> =>
+      sendStatelessRequest(serverUrl, method, params, {
+        headers,
+        specVersion
+      });
+
+    // ==========================================================
+    // 1. Requests without a session header are served normally.
+    // ==========================================================
+    let discoverCapabilities: Record<string, unknown> = {};
+    let noSessionResponse: StatelessResponse | null = null;
+    let noSessionError: string | undefined;
+    try {
+      noSessionResponse = await send('server/discover');
+      const result = (
+        noSessionResponse.body as { result?: unknown } | undefined
+      )?.result as { capabilities?: Record<string, unknown> } | undefined;
+      if (noSessionResponse.status !== 200 || !result) {
+        const rpcError = (
+          noSessionResponse.body as { error?: { message?: string } } | undefined
+        )?.error;
+        noSessionError =
+          `Expected a server/discover request without an ${SESSION_HEADER} ` +
+          `header to succeed, got HTTP ${noSessionResponse.status}` +
+          (rpcError?.message ? ` (${rpcError.message})` : '');
+      } else if (
+        result.capabilities &&
+        typeof result.capabilities === 'object'
+      ) {
+        discoverCapabilities = result.capabilities as Record<string, unknown>;
+      }
+    } catch (e) {
+      noSessionError = `Request without ${SESSION_HEADER} failed: ${String(e)}`;
+    }
+
+    pushCheck({
+      id: 'sep-2567-server-accepts-requests-without-session-id',
+      name: 'ServerAcceptsRequestsWithoutSessionId',
+      description:
+        'Protocol-level sessions are removed at the draft revision: a request ' +
+        `carrying no ${SESSION_HEADER} header is served normally`,
+      specUrl: 'https://modelcontextprotocol.io/specification/draft/changelog',
+      error: noSessionError,
+      details: { httpStatus: noSessionResponse?.status }
+    });
+
+    // ==========================================================
+    // 2. List endpoints do not vary per-connection or as a side
+    //    effect of other requests on the connection.
+    // ==========================================================
+
+    // Collect the full (paginated) list for an endpoint. Every request goes
+    // out as an independent HTTP request — there is no session or pinned
+    // connection to scope the result to.
+    const collectList = async (
+      endpoint: ListEndpoint
+    ): Promise<{ ids: string[]; error?: string }> => {
+      const ids: string[] = [];
+      let cursor: string | undefined;
+      for (let page = 0; page < 10; page++) {
+        const res = await send(
+          endpoint.method,
+          cursor !== undefined ? { cursor } : undefined
+        );
+        const body = res.body as
+          | {
+              result?: { nextCursor?: string } & Record<string, unknown>;
+              error?: { code?: number; message?: string };
+            }
+          | undefined;
+        if (res.status !== 200 || !body?.result) {
+          return {
+            ids,
+            error:
+              `${endpoint.method} returned HTTP ${res.status}` +
+              (body?.error ? ` (${body.error.message})` : '')
+          };
+        }
+        const items = body.result[endpoint.field];
+        if (!Array.isArray(items)) {
+          return {
+            ids,
+            error: `${endpoint.method} result has no ${endpoint.field} array`
+          };
+        }
+        for (const item of items) {
+          ids.push(String((item as Record<string, unknown>)[endpoint.idKey]));
+        }
+        cursor = body.result.nextCursor;
+        if (cursor === undefined) break;
+      }
+      return { ids: ids.sort() };
+    };
+
+    const declaredEndpoints = LIST_ENDPOINTS.filter(
+      (e) => discoverCapabilities[e.capability]
+    );
+
+    for (const endpoint of LIST_ENDPOINTS) {
+      const checkId = `sep-2567-${endpoint.capability}-list-connection-invariant`;
+      const checkName = `${endpoint.capability[0].toUpperCase()}${endpoint.capability.slice(1)}ListConnectionInvariant`;
+      const description =
+        `${endpoint.method} returns the same set across independent ` +
+        'connections and is not changed as a side effect of other requests';
+
+      if (!discoverCapabilities[endpoint.capability]) {
+        pushCheck({
+          id: checkId,
+          name: checkName,
+          description,
+          specUrl: endpoint.specUrl,
+          skipped: true,
+          details: {
+            note: `Server did not declare the ${endpoint.capability} capability in server/discover`
+          }
+        });
+        continue;
+      }
+
+      try {
+        const first = await collectList(endpoint);
+        if (first.error) {
+          pushCheck({
+            id: checkId,
+            name: checkName,
+            description,
+            specUrl: endpoint.specUrl,
+            error: first.error
+          });
+          continue;
+        }
+
+        // Interleave unrelated, side-effect-free requests before the second
+        // snapshot: a discovery call plus one page of each *other* declared
+        // list endpoint.
+        await send('server/discover');
+        for (const other of declaredEndpoints) {
+          if (other.capability !== endpoint.capability) {
+            await send(other.method);
+          }
+        }
+
+        const second = await collectList(endpoint);
+        if (second.error) {
+          pushCheck({
+            id: checkId,
+            name: checkName,
+            description,
+            specUrl: endpoint.specUrl,
+            error: second.error
+          });
+          continue;
+        }
+
+        const same =
+          first.ids.length === second.ids.length &&
+          first.ids.every((id, i) => id === second.ids[i]);
+        pushCheck({
+          id: checkId,
+          name: checkName,
+          description,
+          specUrl: endpoint.specUrl,
+          error: same
+            ? undefined
+            : `${endpoint.method} diverged between two requests with identical ` +
+              `inputs: [${first.ids.join(', ')}] then [${second.ids.join(', ')}]. ` +
+              'The set must not vary per-connection or as a side effect of ' +
+              'other requests.',
+          details: { first: first.ids, second: second.ids }
+        });
+      } catch (e) {
+        pushCheck({
+          id: checkId,
+          name: checkName,
+          description,
+          specUrl: endpoint.specUrl,
+          error: String(e)
+        });
+      }
+    }
+
+    // ==========================================================
+    // 3. Legacy session-era traffic (2026-only servers, SHOULD).
+    // ==========================================================
+
+    // Era probe: a server that also serves the legacy `initialize` handshake
+    // is dual-era; the backward-compatibility SHOULDs below are scoped to
+    // servers that support *only* the draft revision, so they are SKIPPED
+    // for dual-era servers. The probe mimics a legacy client: no
+    // MCP-Protocol-Version header, no per-request _meta.
+    let dualEra = false;
+    try {
+      const probeId = 90001;
+      const res = await fetch(serverUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream'
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: probeId,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-11-25',
+            capabilities: {},
+            clientInfo: { name: 'conformance-era-probe', version: '1.0.0' }
+          }
+        })
+      });
+      const contentType = getHeader(res, 'content-type') ?? '';
+      let body: unknown;
+      if (contentType.includes('text/event-stream')) {
+        body = (await readSseJsonRpcResponse(res, probeId)).body;
+      } else {
+        try {
+          body = await res.json();
+        } catch {
+          body = undefined;
+        }
+      }
+      dualEra =
+        res.status === 200 &&
+        (body as { result?: { protocolVersion?: string } } | undefined)?.result
+          ?.protocolVersion !== undefined;
+    } catch {
+      // Probe failure means we cannot prove the server is dual-era; treat it
+      // as draft-only and let the checks below speak for themselves.
+    }
+
+    const dualEraSkip = {
+      skipped: true,
+      details: {
+        note:
+          'Server also serves the legacy initialize handshake (dual-era). ' +
+          'The backward-compatibility SHOULDs apply only to servers that ' +
+          'support the draft revision exclusively.'
+      }
+    };
+
+    // --- GET / DELETE respond 405 Method Not Allowed ---
+    {
+      const checkArgs = {
+        id: 'sep-2567-server-rejects-get-and-delete',
+        name: 'ServerRejectsGetAndDelete',
+        description:
+          'A draft-only server responds 405 Method Not Allowed to HTTP GET ' +
+          'and DELETE on the MCP endpoint (SHOULD)',
+        specUrl: TRANSPORT_BACKCOMPAT_URL
+      };
+      if (dualEra) {
+        pushCheck({ ...checkArgs, ...dualEraSkip });
+      } else {
+        try {
+          const getRes = await fetch(serverUrl, {
+            method: 'GET',
+            headers: { Accept: 'text/event-stream' }
+          });
+          const deleteRes = await fetch(serverUrl, { method: 'DELETE' });
+          const wrong: string[] = [];
+          if (getRes.status !== 405) {
+            wrong.push(`GET returned ${getRes.status}`);
+          }
+          if (deleteRes.status !== 405) {
+            wrong.push(`DELETE returned ${deleteRes.status}`);
+          }
+          pushCheck({
+            ...checkArgs,
+            warning: true,
+            error:
+              wrong.length > 0
+                ? `Expected 405 Method Not Allowed: ${wrong.join('; ')}`
+                : undefined,
+            details: { get: getRes.status, delete: deleteRes.status }
+          });
+        } catch (e) {
+          pushCheck({ ...checkArgs, warning: true, error: String(e) });
+        }
+      }
+    }
+
+    // --- Mcp-Session-Id on a request is ignored; no minting/echoing ---
+    {
+      const checkArgs = {
+        id: 'sep-2567-server-ignores-session-id',
+        name: 'ServerIgnoresSessionId',
+        description:
+          `A draft-only server ignores an ${SESSION_HEADER} request header ` +
+          'and does not mint or echo session IDs (SHOULD)',
+        specUrl: TRANSPORT_BACKCOMPAT_URL
+      };
+      if (dualEra) {
+        pushCheck({ ...checkArgs, ...dualEraSkip });
+      } else {
+        try {
+          const staleSessionId = 'conformance-stale-session-id';
+          const res = await send('server/discover', undefined, {
+            [SESSION_HEADER]: staleSessionId
+          });
+          const result = (res.body as { result?: unknown } | undefined)?.result;
+          const problems: string[] = [];
+          if (res.status !== 200 || !result) {
+            problems.push(
+              `request carrying a stale ${SESSION_HEADER} header was not ` +
+                `served normally (HTTP ${res.status})`
+            );
+          }
+          const echoed = getHeader(res, SESSION_HEADER);
+          if (echoed !== null) {
+            problems.push(
+              echoed === staleSessionId
+                ? `response echoed the ${SESSION_HEADER} header`
+                : `response minted an ${SESSION_HEADER} header (${echoed})`
+            );
+          }
+          // The session-less baseline response must not mint one either.
+          if (
+            noSessionResponse &&
+            getHeader(noSessionResponse, SESSION_HEADER) !== null
+          ) {
+            problems.push(
+              `response to a request without ${SESSION_HEADER} minted one ` +
+                `(${getHeader(noSessionResponse, SESSION_HEADER)})`
+            );
+          }
+          pushCheck({
+            ...checkArgs,
+            warning: true,
+            error: problems.length > 0 ? problems.join('; ') : undefined,
+            details: { httpStatus: res.status }
+          });
+        } catch (e) {
+          pushCheck({ ...checkArgs, warning: true, error: String(e) });
+        }
+      }
+    }
+
+    // --- Last-Event-ID on a request is ignored ---
+    {
+      const checkArgs = {
+        id: 'sep-2567-server-ignores-last-event-id',
+        name: 'ServerIgnoresLastEventId',
+        description:
+          'A draft-only server ignores a Last-Event-ID request header; ' +
+          'streams are not resumable (SHOULD)',
+        specUrl: TRANSPORT_BACKCOMPAT_URL
+      };
+      if (dualEra) {
+        pushCheck({ ...checkArgs, ...dualEraSkip });
+      } else {
+        try {
+          const res = await send('server/discover', undefined, {
+            'Last-Event-ID': '42'
+          });
+          const result = (res.body as { result?: unknown } | undefined)?.result;
+          pushCheck({
+            ...checkArgs,
+            warning: true,
+            error:
+              res.status === 200 && result
+                ? undefined
+                : `request carrying a Last-Event-ID header was not served ` +
+                  `normally (HTTP ${res.status})`,
+            details: { httpStatus: res.status }
+          });
+        } catch (e) {
+          pushCheck({ ...checkArgs, warning: true, error: String(e) });
+        }
+      }
+    }
+
+    return checks;
+  }
+}

--- a/src/seps/sep-2567.yaml
+++ b/src/seps/sep-2567.yaml
@@ -1,0 +1,33 @@
+sep: 2567
+spec_url: https://modelcontextprotocol.io/specification/draft/basic/transports/streamable-http
+requirements:
+  - check: sep-2567-server-accepts-requests-without-session-id
+    text: 'Remove protocol-level sessions and the `Mcp-Session-Id` header from the Streamable HTTP transport. [A server speaking this revision processes requests that carry no session header; there is no session mechanism left to require.]'
+    url: https://modelcontextprotocol.io/specification/draft/changelog
+  - check: sep-2567-tools-list-connection-invariant
+    text: 'Servers that declare the `tools` capability MUST respond to `tools/list` requests with the set of tools currently available to the requesting client. This set MAY be empty and MAY change over time (see List Changed Notification), but MUST NOT vary per-connection or as a side effect of other requests on the connection.'
+    url: https://modelcontextprotocol.io/specification/draft/server/tools#capabilities
+  - check: sep-2567-resources-list-connection-invariant
+    text: 'Servers that declare the `resources` capability MUST respond to `resources/list` requests with the set of resources currently available to the requesting client. This set MAY be empty and MAY change over time (see List Changed Notification), but MUST NOT vary per-connection or as a side effect of other requests on the connection.'
+    url: https://modelcontextprotocol.io/specification/draft/server/resources#capabilities
+  - check: sep-2567-prompts-list-connection-invariant
+    text: 'Servers that declare the `prompts` capability MUST respond to `prompts/list` requests with the set of prompts currently available to the requesting client. This set MAY be empty and MAY change over time (see List Changed Notification), but MUST NOT vary per-connection or as a side effect of other requests on the connection.'
+    url: https://modelcontextprotocol.io/specification/draft/server/prompts#capabilities
+  - check: sep-2567-server-ignores-session-id
+    text: 'A server that supports only this revision and receives such traffic from an older client SHOULD respond as follows: An `Mcp-Session-Id` header on a request: ignore it, and do not mint or echo session IDs.'
+    url: https://modelcontextprotocol.io/specification/draft/basic/transports/streamable-http#earlier-streamable-http-revisions
+  - check: sep-2567-server-rejects-get-and-delete
+    text: 'A server that supports only this revision and receives such traffic from an older client SHOULD respond as follows: HTTP GET or DELETE to the MCP endpoint: respond with 405 Method Not Allowed.'
+    url: https://modelcontextprotocol.io/specification/draft/basic/transports/streamable-http#earlier-streamable-http-revisions
+  - check: sep-2567-server-ignores-last-event-id
+    text: 'A server that supports only this revision and receives such traffic from an older client SHOULD respond as follows: A `Last-Event-ID` header: ignore it; streams are not resumable.'
+    url: https://modelcontextprotocol.io/specification/draft/basic/transports/streamable-http#earlier-streamable-http-revisions
+
+  - text: 'The request ID MUST NOT match the ID of any other request the sender has issued and not yet received a response for.'
+    excluded: 'not observable from a black-box harness: the harness cannot compel the implementation under test to issue two concurrent requests with colliding IDs; on HTTP, draft servers never issue independent JSON-RPC requests at all (covered by sep-2575-http-server-no-independent-requests-on-stream)'
+    url: https://modelcontextprotocol.io/specification/draft/basic/index#requests
+  - text: 'Note that authorization MUST be included in every HTTP request from client to server.'
+    excluded: 'editorial rewording (SEP-2567 drops the trailing "even if they are part of the same logical session" clause); the obligation itself predates the SEP and is exercised by the authorization scenarios'
+    url: https://modelcontextprotocol.io/specification/draft/basic/authorization
+  - text: 'If present, the [SSE event] ID MUST be globally unique across all streams.'
+    excluded: 'superseded before publication: the draft subsequently removed SSE resumability entirely (event-id replay and Last-Event-ID are not supported), so this re-scoped uniqueness rule no longer appears in the draft spec; legacy Last-Event-ID traffic is covered by sep-2567-server-ignores-last-event-id'


### PR DESCRIPTION
Adds requirement traceability and a draft-suite server scenario for
SEP-2567 (sessionless Streamable HTTP), following the sep-2575 pattern.

## Motivation and Context

Closes #332.

SEP-2567 is merged into the draft spec: it removes protocol-level sessions
and the `Mcp-Session-Id` header from the Streamable HTTP transport, and
makes the list endpoints (`tools/list`, `resources/list`, `prompts/list`)
connection-invariant (see the [draft changelog](https://modelcontextprotocol.io/specification/draft/changelog)).
The conformance suite has no coverage for it yet — there is no
`src/seps/sep-2567.yaml` and no scenario exercises the sessionless
invariants at the draft spec version.

This PR adds both, mirroring how SEP-2575 is covered (`sep-2575.yaml` +
`ServerStatelessScenario`).

### `src/seps/sep-2567.yaml` — 7 check rows, 3 excluded rows

Checks:

- `sep-2567-server-accepts-requests-without-session-id` — sessions are
  removed at the draft revision; a request without `Mcp-Session-Id` is
  served normally. (Anchored to the changelog entry — the removal has no
  keyworded sentence by construction.)
- `sep-2567-{tools,resources,prompts}-list-connection-invariant` — the
  list "MUST NOT vary per-connection or as a side effect of other requests
  on the connection" (server/tools, server/resources, server/prompts
  `#capabilities`).
- `sep-2567-server-rejects-get-and-delete`,
  `sep-2567-server-ignores-session-id`,
  `sep-2567-server-ignores-last-event-id` — the SHOULDs from
  [Earlier Streamable HTTP Revisions](https://modelcontextprotocol.io/specification/draft/basic/transports/streamable-http#earlier-streamable-http-revisions)
  for servers that support only the draft revision.

Excluded (with reasons in the yaml):

- request-ID reuse scoping (`basic/index#requests`) — not observable from
  a black-box harness; the harness cannot compel the implementation under
  test to issue two concurrent requests with colliding IDs.
- the reworded authorization sentence — editorial (SEP-2567 only drops the
  "same logical session" clause); the obligation predates the SEP and is
  exercised by the authorization scenarios.
- the SEP's re-scoped SSE event-id uniqueness rule — superseded before
  publication; the draft later removed SSE resumability entirely, so the
  sentence no longer appears in the spec.

### `ServerSessionlessScenario` (`--suite draft`, `server-sessionless`)

One scenario, seven checks, registered like the other draft scenarios via
`source.introducedIn = DRAFT_PROTOCOL_VERSION`. Built on the existing
`sendStatelessRequest()` connection helper.

The three backward-compatibility SHOULDs are scoped by the spec to "a
server that supports only this revision". The scenario probes with a
legacy-shaped `initialize` request first; dual-era servers (the
everything-server is one) report SKIPPED for those three checks, per the
spec's instruction that dual-era servers implement the legacy revision's
behavior instead.

List invariance is checked by taking two paginated snapshots of each
declared list endpoint on independent connections, with unrelated requests
interleaved, and comparing the identifier sets. (Per-connection state is
not directly addressable from a black-box harness; every harness request
already arrives on an independent connection — same model as the
sep-2575.yaml exclusions.)

## How Has This Been Tested?

- `npm test` — 278/278 passing, including `all-scenarios.test.ts`, which
  runs `server-sessionless` against the everything-server (4 SUCCESS,
  3 SKIPPED via the dual-era probe; no FAILURE).
- 9 new vitest cases in `src/scenarios/server/sessionless.test.ts` drive
  the scenario against mocked non-conformant servers and assert each check
  fires with the right severity (FAILURE for MUST rows, WARNING for SHOULD
  rows), plus the SKIPPED paths (undeclared capabilities, dual-era).
- `npm run build`, `npm run typecheck`, `npm run lint` all pass.

`src/seps/traceability.json` is not regenerated here; the traceability
workflow refreshes it via PR.

## Breaking Changes

None. The scenario is draft-suite only (`--suite draft` / `--suite all`);
the default `active` suite is unchanged.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Severity follows the spec keyword per AGENTS.md (MUST → FAILURE, SHOULD →
WARNING). Requirement texts were verified against SEP-2567's spec diff
(`modelcontextprotocol/modelcontextprotocol#2567`) and the current draft
pages; the three backcompat SHOULDs come from the draft's
"Earlier Streamable HTTP Revisions" section, which is the live normative
expression of the sessionless model for legacy traffic.

Related prior art: #222 covers the 2025-11-25 "server MAY omit
Mcp-Session-Id" path at the dated spec versions; this PR covers the draft
revision where sessions are removed outright, so the two are complementary.
