### PR TITLE
chore: bump version to 0.2.0-alpha.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/conformance",
-  "version": "0.2.0-alpha.2",
+  "version": "0.2.0-alpha.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/conformance",
-      "version": "0.2.0-alpha.2",
+      "version": "0.2.0-alpha.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/conformance",
-  "version": "0.2.0-alpha.2",
+  "version": "0.2.0-alpha.3",
   "type": "module",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",


### PR DESCRIPTION
Bumps the package version from 0.2.0-alpha.2 to 0.2.0-alpha.3 ahead of the next alpha release.

Includes changes since the alpha.2 release, notably the version-aware Connection/MockServer abstractions (#318, #321) and the draft wire version update to 2026-07-28 (#331).