### PR TITLE
fix: correct server-stateless error-code expectations against the draft spec

### DIFF
--- a/examples/servers/typescript/everything-server.ts
+++ b/examples/servers/typescript/everything-server.ts
@@ -1236,7 +1236,10 @@ app.post('/mcp', async (req, res) => {
   const meta = params._meta;
   const metaVersion = meta?.['io.modelcontextprotocol/protocolVersion'];
 
-  if (!sessionId && (reqVersion || meta)) {
+  // Header-body validation applies to protocol versions that require
+  // per-request metadata; older-version traffic (e.g. a 2025-11-25
+  // initialize carrying only the transport header) is not subject to it.
+  if (!sessionId && (meta !== undefined || reqVersion === '2026-07-28')) {
     // Missing Transport Header Validation Check
     if (!reqVersion) {
       return res.status(400).json({
@@ -1246,14 +1249,28 @@ app.post('/mcp', async (req, res) => {
       });
     }
 
-    // Per-Request Metadata Integrity Checks (Fields verification)
+    // The body's protocolVersion mirrors the MCP-Protocol-Version header; a
+    // body with nothing to match the header against fails header validation
+    // (-32001 HeaderMismatch, HTTP 400).
+    if (!meta || !metaVersion) {
+      return res.status(400).json({
+        jsonrpc: '2.0',
+        id,
+        error: {
+          code: -32001,
+          message:
+            'MCP-Protocol-Version header has no matching _meta.protocolVersion in the request body'
+        }
+      });
+    }
+
+    // Per-Request Metadata Integrity Checks: the remaining _meta fields have
+    // no corresponding header, so their absence is -32602 Invalid params.
     if (
-      !meta ||
-      !meta['io.modelcontextprotocol/protocolVersion'] ||
       !meta['io.modelcontextprotocol/clientInfo'] ||
       !meta['io.modelcontextprotocol/clientCapabilities']
     ) {
-      return res.status(200).json({
+      return res.status(400).json({
         jsonrpc: '2.0',
         id,
         error: {
@@ -1263,20 +1280,14 @@ app.post('/mcp', async (req, res) => {
       });
     }
 
-    // Header Mismatch Verification (-32001, HTTP 400)
-    if (reqVersion !== metaVersion) {
-      return res.status(400).json({
-        jsonrpc: '2.0',
-        id,
-        error: {
-          code: -32001,
-          message: 'Mismatched MCP-Protocol-Version header'
-        }
-      });
-    }
-
-    // Protocol Version Negotiation Matrix (-32004, HTTP 400)
-    if (metaVersion !== '2026-07-28') {
+    // Protocol Version Negotiation Matrix (-32004, HTTP 400): a request
+    // carrying an unimplemented version on either channel gets the
+    // renegotiation-shaped error with the supported list, even when the two
+    // channels also disagree.
+    const unsupportedVersion = [reqVersion, metaVersion].find(
+      (v) => v !== '2026-07-28'
+    );
+    if (unsupportedVersion !== undefined) {
       return res.status(400).json({
         jsonrpc: '2.0',
         id,
@@ -1285,8 +1296,21 @@ app.post('/mcp', async (req, res) => {
           message: 'UnsupportedProtocolVersionError',
           data: {
             supported: ['2026-07-28'],
-            requested: String(metaVersion)
+            requested: String(unsupportedVersion)
           }
+        }
+      });
+    }
+
+    // Header Mismatch Verification (-32001, HTTP 400) — reachable only when
+    // both channels carry implemented versions that disagree.
+    if (reqVersion !== metaVersion) {
+      return res.status(400).json({
+        jsonrpc: '2.0',
+        id,
+        error: {
+          code: -32001,
+          message: 'Mismatched MCP-Protocol-Version header'
         }
       });
     }

--- a/src/mock-server/mock-server.test.ts
+++ b/src/mock-server/mock-server.test.ts
@@ -148,7 +148,7 @@ describe('createServerStateless', () => {
     }
   });
 
-  it('rejects requests missing required _meta keys', async () => {
+  it('rejects requests whose body cannot mirror the version header with -32001', async () => {
     const srv = await createServerStateless({});
     try {
       const { status, body } = await post(
@@ -157,7 +157,58 @@ describe('createServerStateless', () => {
         { 'mcp-protocol-version': DRAFT_PROTOCOL_VERSION }
       );
       expect(status).toBe(400);
+      expect(body.error.code).toBe(-32001);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('rejects requests missing non-header-mirrored _meta keys with -32602', async () => {
+    const srv = await createServerStateless({});
+    try {
+      const { status, body } = await post(
+        srv.url,
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/list',
+          params: {
+            _meta: {
+              'io.modelcontextprotocol/protocolVersion': DRAFT_PROTOCOL_VERSION
+            }
+          }
+        },
+        { 'mcp-protocol-version': DRAFT_PROTOCOL_VERSION }
+      );
+      expect(status).toBe(400);
       expect(body.error.code).toBe(-32602);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('rejects an unimplemented body protocolVersion with -32004 and the supported list', async () => {
+    const srv = await createServerStateless({});
+    try {
+      const { status, body } = await post(
+        srv.url,
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/list',
+          params: {
+            _meta: {
+              ...meta,
+              'io.modelcontextprotocol/protocolVersion': 'v999.0.0'
+            }
+          }
+        },
+        { 'mcp-protocol-version': DRAFT_PROTOCOL_VERSION }
+      );
+      expect(status).toBe(400);
+      expect(body.error.code).toBe(-32004);
+      expect(body.error.data.requested).toBe('v999.0.0');
+      expect(Array.isArray(body.error.data.supported)).toBe(true);
     } finally {
       await srv.close();
     }

--- a/src/mock-server/stateless.ts
+++ b/src/mock-server/stateless.ts
@@ -71,7 +71,19 @@ export function validateStatelessRequest(
   if (!headerVersion) {
     return reject(400, -32001, 'Missing MCP-Protocol-Version header');
   }
-  const missing = META_KEYS.filter((k) => meta?.[k] === undefined);
+  // The body's protocolVersion mirrors the MCP-Protocol-Version header. A
+  // body with no value to match the header against fails header validation
+  // (-32001 HeaderMismatch); the other _meta keys have no corresponding
+  // header, so their absence is plain -32602 Invalid params.
+  const bodyVersion = meta?.[META_KEYS[0]];
+  if (bodyVersion === undefined) {
+    return reject(
+      400,
+      -32001,
+      'MCP-Protocol-Version header has no matching _meta.protocolVersion in the request body'
+    );
+  }
+  const missing = META_KEYS.slice(1).filter((k) => meta?.[k] === undefined);
   if (missing.length > 0) {
     return reject(
       400,
@@ -79,17 +91,21 @@ export function validateStatelessRequest(
       `Invalid params: missing _meta keys: ${missing.join(', ')}`
     );
   }
-  if (meta?.[META_KEYS[0]] !== headerVersion) {
+  // A request carrying a version this endpoint does not implement (on
+  // either channel) gets the renegotiation-shaped error, even when the two
+  // channels also disagree: -32004 carries the supported list the client
+  // needs to retry, -32001 does not.
+  const unsupportedVersion = [headerVersion, bodyVersion].find(
+    (v) => typeof v !== 'string' || !supportedVersions.includes(v)
+  );
+  if (unsupportedVersion === undefined && bodyVersion !== headerVersion) {
     return reject(
       400,
       -32001,
       'MCP-Protocol-Version header does not match _meta.protocolVersion'
     );
   }
-  if (
-    typeof headerVersion !== 'string' ||
-    !supportedVersions.includes(headerVersion)
-  ) {
+  if (unsupportedVersion !== undefined) {
     return {
       kind: 'reject',
       status: 400,
@@ -101,7 +117,7 @@ export function validateStatelessRequest(
           message: 'Unsupported protocol version',
           data: {
             supported: supportedVersions,
-            requested: String(headerVersion)
+            requested: String(unsupportedVersion)
           }
         }
       }

--- a/src/scenarios/server/stateless.ts
+++ b/src/scenarios/server/stateless.ts
@@ -12,6 +12,7 @@ import {
   readSseJsonRpcResponse,
   type RunContext
 } from '../../connection';
+import { STATELESS_SPEC_VERSIONS } from '../../connection/select';
 
 const SPEC_REF = [
   {
@@ -34,13 +35,13 @@ export class ServerStatelessScenario implements ClientScenario {
 **Grouped Specification Requirements**:
 
 1. **Per-Request _meta Validation (4 Checks)**
-   - Rejects requests missing \`_meta\` or lacking structural required internal subfields (\`protocolVersion\`, \`clientInfo\`, \`clientCapabilities\`) with a JSON-RPC \`-32602 Invalid params\` error signature.
+   - Rejects requests whose body cannot mirror the \`MCP-Protocol-Version\` header (missing \`_meta\` or missing \`protocolVersion\`) with \`-32001 HeaderMismatch\`; rejects requests lacking \`clientInfo\`/\`clientCapabilities\` (no corresponding header) with \`-32602 Invalid params\`.
 2. **Discovery & Capabilities (3 Checks)**
    - Implements \`server/discover\` mapping exact mandatory protocol elements.
    - Dynamically checks prompt capability declaration constraints, validates that active RPC handlers match advertised discovery capacities.
-3. **Version Negotiation & Headers (3 Checks)**
-   - Mismatched or unknown protocol versions must return an \`UnsupportedProtocolVersionError\` (HTTP status code \`400 Bad Request\`) carrying precise version tracking arrays.
-   - Absent or altered protocol version header metadata must trigger a \`-32001 Header Mismatch\` error with an HTTP 400 boundary state.
+3. **Version Negotiation & Headers (4 Checks)**
+   - A request carrying a protocol version the server does not implement (header or body channel) must return an \`UnsupportedProtocolVersionError\` (\`-32004\`, HTTP \`400 Bad Request\`) carrying the \`supported\`/\`requested\` version data.
+   - A header/body version mismatch between two implemented versions must trigger \`-32001 HeaderMismatch\` with HTTP 400 (probed only when the server advertises more than one supported version; SKIPPED otherwise).
 4. **Client Capability Constraints (2 Checks)**
    - Accessing platform capabilities without explicit declaration drops requests with a \`-32003 MissingRequiredClientCapabilityError\` containing needed capabilities, returning an HTTP status code \`400 Bad Request\`.
 5. **Methods & Routing Mechanics (5 Checks)**
@@ -304,18 +305,27 @@ export class ServerStatelessScenario implements ClientScenario {
     // ==========================================
     // 1. Per-request _meta Validation (4 Checks)
     // ==========================================
+    // The MCP-Protocol-Version header is mirrored by the request body's
+    // _meta protocolVersion. When the header is present but the body has no
+    // value to match it against (no _meta at all, or no protocolVersion in
+    // it), header validation fails: "The HTTP headers do not match the
+    // corresponding values in the request body, or required headers are
+    // missing/malformed" -> 400 + -32001 HeaderMismatch. clientInfo and
+    // clientCapabilities have no corresponding standard header, so their
+    // absence is a plain -32602 Invalid params.
     const metaValidationTestCases = [
       {
         slug: 'missing-meta',
         description:
-          'Rejects request with missing _meta with -32602 Invalid params',
+          'Rejects request with missing _meta with -32001 HeaderMismatch (MCP-Protocol-Version header has no matching body value)',
         params: {},
+        expectedCode: -32001,
         rpcId: 101
       },
       {
         slug: 'missing-protocol-version',
         description:
-          'Rejects request with _meta missing io.modelcontextprotocol/protocolVersion',
+          'Rejects request with _meta missing io.modelcontextprotocol/protocolVersion with -32001 HeaderMismatch',
         params: {
           _meta: {
             'io.modelcontextprotocol/clientInfo':
@@ -324,12 +334,13 @@ export class ServerStatelessScenario implements ClientScenario {
               validMeta['io.modelcontextprotocol/clientCapabilities']
           }
         },
+        expectedCode: -32001,
         rpcId: 102
       },
       {
         slug: 'missing-client-info',
         description:
-          'Rejects request with _meta missing io.modelcontextprotocol/clientInfo',
+          'Rejects request with _meta missing io.modelcontextprotocol/clientInfo with -32602 Invalid params',
         params: {
           _meta: {
             'io.modelcontextprotocol/protocolVersion':
@@ -338,12 +349,13 @@ export class ServerStatelessScenario implements ClientScenario {
               validMeta['io.modelcontextprotocol/clientCapabilities']
           }
         },
+        expectedCode: -32602,
         rpcId: 103
       },
       {
         slug: 'missing-client-capabilities',
         description:
-          'Rejects request with _meta missing io.modelcontextprotocol/clientCapabilities',
+          'Rejects request with _meta missing io.modelcontextprotocol/clientCapabilities with -32602 Invalid params',
         params: {
           _meta: {
             'io.modelcontextprotocol/protocolVersion':
@@ -352,6 +364,7 @@ export class ServerStatelessScenario implements ClientScenario {
               validMeta['io.modelcontextprotocol/clientInfo']
           }
         },
+        expectedCode: -32602,
         rpcId: 104
       }
     ];
@@ -369,9 +382,9 @@ export class ServerStatelessScenario implements ClientScenario {
           );
           checkErrorId(data, testCase.rpcId);
 
-          if (data?.error?.code !== -32602) {
+          if (data?.error?.code !== testCase.expectedCode) {
             return {
-              error: `Expected error code -32602, got ${data?.error?.code}`,
+              error: `Expected error code ${testCase.expectedCode}, got ${data?.error?.code}`,
               details: { fieldIssue: testCase.slug, response: data }
             };
           }
@@ -552,13 +565,19 @@ export class ServerStatelessScenario implements ClientScenario {
       }
     );
 
-    const headerMismatchMeta = {
+    // The body claims a protocol version the server does not implement
+    // ('v999.0.0'). Per the versioning requirements, a request carrying an
+    // unimplemented version MUST be answered with an
+    // UnsupportedProtocolVersionError (-32004) listing the supported
+    // versions, so the client can renegotiate — not with a bare
+    // HeaderMismatch, which carries no recovery data.
+    const unsupportedBodyMeta = {
       ...validMeta,
       'io.modelcontextprotocol/protocolVersion': 'v999.0.0'
     };
     const responseAbsent = await sendRpc(
       'server/discover',
-      { _meta: headerMismatchMeta },
+      { _meta: unsupportedBodyMeta },
       { 'MCP-Protocol-Version': specVersion },
       302
     ).catch(() => null);
@@ -566,18 +585,81 @@ export class ServerStatelessScenario implements ClientScenario {
     const dataAbsent: any = responseAbsent?.data ?? null;
 
     await runCheck(
+      'sep-2575-http-server-unsupported-version-400-body',
+      'HttpServerUnsupportedVersionBody400',
+      'If the server does not implement the requested protocol version (carried in the body _meta), it MUST respond with 400 Bad Request and an UnsupportedProtocolVersionError listing its supported versions.',
+      () => {
+        if (!resAbsent)
+          return { error: 'Header verification endpoint network hit failed' };
+        if (resAbsent.status !== 400 || dataAbsent?.error?.code !== -32004) {
+          return {
+            error: `Expected HTTP 400 and JSON-RPC error -32004, got status ${resAbsent.status} with code ${dataAbsent?.error?.code}`
+          };
+        }
+        if (!Array.isArray(dataAbsent?.error?.data?.supported)) {
+          return {
+            error:
+              'UnsupportedProtocolVersionError is missing the data.supported version array',
+            details: { response: dataAbsent }
+          };
+        }
+        return { details: { response: dataAbsent } };
+      }
+    );
+
+    // A true HeaderMismatch probe needs header and body to carry two
+    // DIFFERENT versions that both use per-request metadata (header-body
+    // validation does not exist in older versions, and a cross-lifecycle
+    // pair triggers the unsupported-version rule on the per-request leg
+    // instead). Only probeable when the server advertises at least two such
+    // versions — today there is exactly one, so this check reports SKIPPED
+    // until a second per-request-metadata spec version exists.
+    const mismatchCandidates = discoverSupportedVersions.filter((v) =>
+      (STATELESS_SPEC_VERSIONS as readonly string[]).includes(v)
+    );
+    const mismatchPair =
+      mismatchCandidates.length >= 2
+        ? [mismatchCandidates[0], mismatchCandidates[1]]
+        : null;
+    const mismatchResponse = mismatchPair
+      ? await sendRpc(
+          'server/discover',
+          {
+            _meta: {
+              ...validMeta,
+              'io.modelcontextprotocol/protocolVersion': mismatchPair[1]
+            }
+          },
+          { 'MCP-Protocol-Version': mismatchPair[0] },
+          303
+        ).catch(() => null)
+      : null;
+
+    await runCheck(
       'sep-2575-http-server-header-mismatch-400',
       'HttpServerHeaderMismatch400',
       'If the values do not match, the server MUST reject the request with 400 Bad Request and a HeaderMismatch JSON-RPC error.',
       () => {
-        if (!resAbsent)
-          return { error: 'Header verification endpoint network hit failed' };
-        if (resAbsent.status !== 400 || dataAbsent?.error?.code !== -32001) {
+        if (!mismatchPair) {
+          // The requirement was not exercised - report SKIPPED rather than
+          // a vacuous SUCCESS.
           return {
-            error: `Expected HTTP 400 and JSON-RPC error -32001, got status ${resAbsent.status} with code ${dataAbsent?.error?.code}`
+            skipped: true,
+            details: {
+              reason:
+                'Server advertises fewer than two per-request-metadata versions; a header/body mismatch between two implemented versions of the same lifecycle is not constructible.'
+            }
           };
         }
-        return { details: { response: dataAbsent } };
+        const res: any = mismatchResponse?.res ?? null;
+        const data: any = mismatchResponse?.data ?? null;
+        if (!res) return { error: 'Header mismatch probe network hit failed' };
+        if (res.status !== 400 || data?.error?.code !== -32001) {
+          return {
+            error: `Expected HTTP 400 and JSON-RPC error -32001, got status ${res.status} with code ${data?.error?.code}`
+          };
+        }
+        return { details: { response: data } };
       }
     );
 

--- a/src/seps/sep-2575.yaml
+++ b/src/seps/sep-2575.yaml
@@ -37,6 +37,9 @@ requirements:
   - check: sep-2575-http-server-unsupported-version-400
     text: 'If the server does not implement the requested protocol version, it MUST respond with 400 Bad Request and an UnsupportedProtocolVersionError listing its supported versions.'
     url: https://modelcontextprotocol.io/specification/draft/basic/transports#protocol-version-header
+  - check: sep-2575-http-server-unsupported-version-400-body
+    text: 'If the server does not implement the requested protocol version, it MUST respond with 400 Bad Request and an UnsupportedProtocolVersionError listing its supported versions.'
+    url: https://modelcontextprotocol.io/specification/draft/basic/transports#protocol-version-header
   - check: sep-2575-http-server-method-not-found-404
     text: 'If the server does not implement the requested RPC method, it MUST respond with 404 Not Found and a JSON-RPC error with code -32601 (Method not found).'
     url: https://modelcontextprotocol.io/specification/draft/basic/transports#protocol-version-header


### PR DESCRIPTION
Three checks in `server-stateless` expect error codes the draft spec contradicts, so a spec-correct server can't pass the scenario. This fixes the expectations to match the spec text, updates the mock server and the everything-server fixture to the same behavior, and tightens the header-mismatch probe so it actually tests what its requirement sentence says.

## Motivation and Context

**1+2. Missing `_meta` / missing `_meta.protocolVersion` expected `-32602`, spec says `-32001`.**

The probes send a valid `MCP-Protocol-Version` header with a body that has no value to mirror it. That's a header validation failure, not generic invalid params. The transports spec is explicit ([streamable-http, error codes](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/0168c57fc74aba6e6dcf8f0b7191db3caaa5ad65/docs/specification/draft/basic/transports/streamable-http.mdx#L549-L555)):

> When rejecting a request due to header validation failure, servers **MUST** return HTTP status `400 Bad Request` and **MUST** include a JSON-RPC error response using the following error code:
>
> | `-32001` | `HeaderMismatch` | The HTTP headers do not match the corresponding values in the request body, or required headers are missing/malformed. |

and the [validation failure conditions](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/0168c57fc74aba6e6dcf8f0b7191db3caaa5ad65/docs/specification/draft/basic/transports/streamable-http.mdx#L574-L577) include "A header value does not match the corresponding request body value" — a body with no value can't match. `clientInfo`/`clientCapabilities` have no corresponding header, so those two cells correctly stay `-32602`.

**3. A body carrying `protocolVersion: 'v999.0.0'` expected `-32001`, spec says `-32004`.**

The probe's requested version isn't implemented by anyone, and [versioning](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/0168c57fc74aba6e6dcf8f0b7191db3caaa5ad65/docs/specification/draft/basic/versioning.mdx#L48-L55) is unambiguous about that case:

> If the server does not implement the requested version (whether the version is unknown to the server, or is a known version the server has chosen not to support), it **MUST** respond with an `UnsupportedProtocolVersionError` listing the versions it does support

`UnsupportedProtocolVersionError` is `-32004` with `data: { supported, requested }` (see the [schema type](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/0168c57fc74aba6e6dcf8f0b7191db3caaa5ad65/schema/draft/schema.ts)). Expecting a bare `-32001` here also denies the client the `supported` list it needs to renegotiate. The check is re-tagged `sep-2575-http-server-unsupported-version-400-body` since it exercises the unsupported-version requirement (body channel), not the mismatch requirement.

**The mismatch requirement keeps a real probe.** `sep-2575-http-server-header-mismatch-400` now sends two *different implemented per-request-metadata versions* on header vs body — the only construction where the mismatch rule applies without colliding with the unsupported-version rule. Exactly one such version exists today, so the check reports SKIPPED until a second one ships; before this change it was passing/failing on a probe that actually exercised a different requirement.

**Fixture fixes that fall out of this:** the everything-server returned its `-32602` with HTTP **200** (every rejection here must be 400), and applied draft per-request validation to 2025-era traffic — the spec [notes](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/0168c57fc74aba6e6dcf8f0b7191db3caaa5ad65/docs/specification/draft/basic/transports/streamable-http.mdx#L588-L595) header–body validation only applies to versions that require it. Both fixed, and the mock server now uses the same precedence (mirror-missing → `-32001`, other `_meta` fields → `-32602`, unimplemented version on either channel → `-32004`, mismatch of two implemented versions → `-32001`).

## How Has This Been Tested?

- Full suite: 273/273 passing, including new mock-server cells for each corrected code and the `data.supported`/`data.requested` shape.
- The scenario self-tests (`all-scenarios.test.ts`) run against the updated fixture and pass; the dns-rebinding scenario surfaced the fixture's 200-on-error bug during this work (its "accepted" probe was previously matching an HTTP 200 *error* response).

## Breaking Changes

None for spec-correct servers. Servers that were passing these three cells by emitting the old codes will now fail them — that's the correction.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

All spec links pin the schema/prose revision the suite's own `src/spec-types/SOURCE` vendors (`0168c57f`), so the cited text is exactly what the runner's types are generated from. `src/seps/sep-2575.yaml` gains the `-body` check id under the unsupported-version requirement; the requirement sentences themselves are unchanged.
