### PR TITLE
fix: gate SEP-2350 scope-union check to 2026-07-28+

### DIFF
--- a/src/scenarios/client/auth/index.test.ts
+++ b/src/scenarios/client/auth/index.test.ts
@@ -130,8 +130,12 @@ describe('Negative tests', () => {
   });
 
   test('client only responds to 401, not 403', async () => {
+    // Run at draft so the SEP-2350 union check is also emitted: a client that
+    // never makes the second authorization request fails both the escalation
+    // check and the union check.
     const runner = new InlineClientRunner(ignore403Client);
     await runClientAgainstScenario(runner, 'auth/scope-step-up', {
+      specVersion: DRAFT_PROTOCOL_VERSION,
       expectedFailureSlugs: [
         'scope-step-up-escalation',
         'sep-2350-scope-union-on-reauth'
@@ -139,10 +143,23 @@ describe('Negative tests', () => {
     });
   });
 
-  test('client echoes challenge scope without accumulating prior grant (SEP-2350)', async () => {
+  test('client echoes challenge scope without accumulating prior grant (SEP-2350) at draft', async () => {
+    // The set-wise union requirement (SEP-2350) was added in the draft spec
+    // (2026-07-28); a client that echoes only the challenged scope fails it.
     const runner = new InlineClientRunner(echoScopeClient);
     await runClientAgainstScenario(runner, 'auth/scope-step-up', {
+      specVersion: DRAFT_PROTOCOL_VERSION,
       expectedFailureSlugs: ['sep-2350-scope-union-on-reauth']
+    });
+  });
+
+  test('client echoes challenge scope without accumulating prior grant (SEP-2350) at 2025-11-25', async () => {
+    // At dated spec versions that predate SEP-2350, the union check is not
+    // emitted at all, so a client that drops the previously-granted scope on
+    // re-auth passes cleanly.
+    const runner = new InlineClientRunner(echoScopeClient);
+    await runClientAgainstScenario(runner, 'auth/scope-step-up', {
+      specVersion: '2025-11-25'
     });
   });
 

--- a/src/scenarios/client/auth/scope-handling.ts
+++ b/src/scenarios/client/auth/scope-handling.ts
@@ -6,6 +6,7 @@ import { createServer } from './helpers/createServer';
 import { ServerLifecycle } from './helpers/serverLifecycle';
 import { SpecReferences } from './spec-references';
 import { MockTokenVerifier } from './helpers/mockTokenVerifier';
+import { DRAFT_PROTOCOL_VERSION, specVersionAtLeast } from '../../../types';
 import type { Request, Response, NextFunction } from 'express';
 
 /**
@@ -294,9 +295,17 @@ export class ScopeStepUpAuthScenario implements Scenario {
   private authServer = new ServerLifecycle();
   private server = new ServerLifecycle();
   private checks: ConformanceCheck[] = [];
+  // SEP-2350's set-wise union requirement was introduced in 2026-07-28 (the
+  // current draft); it was not a requirement at 2025-11-25, where
+  // non-accumulating re-auth is conformant. Gate the union check accordingly.
+  private unionRequired = false;
 
   async start(ctx: ScenarioContext): Promise<ScenarioUrls> {
     this.checks = [];
+    this.unionRequired = specVersionAtLeast(
+      ctx.specVersion,
+      DRAFT_PROTOCOL_VERSION
+    );
 
     const initialScope = 'mcp:basic';
     // tools/call gates on mcp:write only (not the union) so the scenario can
@@ -352,22 +361,24 @@ export class ScopeStepUpAuthScenario implements Scenario {
             }
           });
 
-          const retainedPrior = requestedScopes.includes(initialScope);
-          this.checks.push({
-            id: 'sep-2350-scope-union-on-reauth',
-            name: 'Client accumulates previously-granted scopes on re-authorization',
-            description: retainedPrior
-              ? 'Client included previously-granted scopes alongside the newly challenged scope when re-authorizing'
-              : 'Client SHOULD compute the union of previously requested scopes and newly challenged scopes when initiating re-authorization (SEP-2350); previously-granted scope was dropped',
-            status: retainedPrior ? 'SUCCESS' : 'WARNING',
-            timestamp: data.timestamp,
-            specReferences: [SpecReferences.MCP_SCOPE_CHALLENGE_HANDLING],
-            details: {
-              previouslyGranted: initialScope,
-              challengedScope: stepUpScope,
-              requestedScope: data.scope || 'none'
-            }
-          });
+          if (this.unionRequired) {
+            const retainedPrior = requestedScopes.includes(initialScope);
+            this.checks.push({
+              id: 'sep-2350-scope-union-on-reauth',
+              name: 'Client accumulates previously-granted scopes on re-authorization',
+              description: retainedPrior
+                ? 'Client included previously-granted scopes alongside the newly challenged scope when re-authorizing'
+                : 'Client SHOULD compute the union of previously requested scopes and newly challenged scopes when initiating re-authorization (SEP-2350); previously-granted scope was dropped',
+              status: retainedPrior ? 'SUCCESS' : 'WARNING',
+              timestamp: data.timestamp,
+              specReferences: [SpecReferences.MCP_SCOPE_CHALLENGE_HANDLING],
+              details: {
+                previouslyGranted: initialScope,
+                challengedScope: stepUpScope,
+                requestedScope: data.scope || 'none'
+              }
+            });
+          }
         }
       }
     });
@@ -500,15 +511,17 @@ export class ScopeStepUpAuthScenario implements Scenario {
         timestamp: new Date().toISOString(),
         specReferences: [SpecReferences.MCP_SCOPE_SELECTION_STRATEGY]
       });
-      this.checks.push({
-        id: 'sep-2350-scope-union-on-reauth',
-        name: 'Client accumulates previously-granted scopes on re-authorization',
-        description:
-          'Client did not make a second authorization request - scope union check could not be performed',
-        status: 'FAILURE',
-        timestamp: new Date().toISOString(),
-        specReferences: [SpecReferences.MCP_SCOPE_CHALLENGE_HANDLING]
-      });
+      if (this.unionRequired) {
+        this.checks.push({
+          id: 'sep-2350-scope-union-on-reauth',
+          name: 'Client accumulates previously-granted scopes on re-authorization',
+          description:
+            'Client did not make a second authorization request - scope union check could not be performed',
+          status: 'FAILURE',
+          timestamp: new Date().toISOString(),
+          specReferences: [SpecReferences.MCP_SCOPE_CHALLENGE_HANDLING]
+        });
+      }
     }
 
     return this.checks;

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,26 @@ export const NEGOTIABLE_PROTOCOL_VERSIONS: readonly string[] = [
  */
 export type SpecVersion = DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
 
+/** Spec versions in timeline order, dated revisions followed by the draft. */
+const SPEC_VERSION_TIMELINE: readonly SpecVersion[] = [
+  ...DATED_SPEC_VERSIONS,
+  DRAFT_PROTOCOL_VERSION
+];
+
+/**
+ * True when `v` is at or after `threshold` on the spec timeline. Lets a check
+ * gate itself to the version that introduced its requirement (e.g. a draft-only
+ * requirement passes `DRAFT_PROTOCOL_VERSION` as the threshold).
+ */
+export function specVersionAtLeast(
+  v: SpecVersion,
+  threshold: SpecVersion
+): boolean {
+  return (
+    SPEC_VERSION_TIMELINE.indexOf(v) >= SPEC_VERSION_TIMELINE.indexOf(threshold)
+  );
+}
+
 // Scenarios may also be tagged 'extension' to mark them as off-timeline
 // (selectable via --suite extensions, never via --spec-version). See #256.
 export type ScenarioSpecTag = SpecVersion | 'extension';


### PR DESCRIPTION
## What

The `auth/scope-step-up` scenario emitted the `sep-2350-scope-union-on-reauth` check at **every** spec version. But the set-wise union requirement (SEP-2350) was only introduced in **2026-07-28** — at **2025-11-25** a client that re-requests *only* the challenged scope (dropping its previously-granted scope) is conformant.

So the harness wrongly WARNed conformant 2025-11-25 clients. This surfaced on **python-sdk v1** (pinned to 2025-11-25) while wiring up its runner in #329 — see [Paul's review comment there](https://github.com/modelcontextprotocol/conformance/pull/329):

> we should probably add a spec version branch in the step-up behavior so we don't fail on the "non accumulating" behavior from 2025-11-25 (we added "set-wise union" as a requirement in 2026-07-28).

## How

- Add `specVersionAtLeast(v, threshold)` to `types.ts` — a small timeline-ordering helper (same `indexOf`-over-the-ordered-timeline approach scenario applicability already uses for `introducedIn`/`removedIn`).
- Gate both the live check and its `getChecks()` fallback in `ScopeStepUpAuthScenario` behind `specVersionAtLeast(ctx.specVersion, DRAFT_PROTOCOL_VERSION)` (i.e. 2026-07-28+).
- Tests pin **both sides** of the branch:
  - **enforced at draft** — the echo-scope client (drops prior grant) fails `sep-2350-scope-union-on-reauth`;
  - **silent at 2025-11-25** — the same client passes cleanly (check not emitted).
  - The existing "responds to 401, not 403" negative test moves to draft so its expected `sep-2350` failure is still emitted.

Mirrors the existing draft-gating pattern used for SEP-837 (`application_type`).

## Verification

- `npm test`, `npm run typecheck`, `npm run lint` all green.
- `conformance sdk python-sdk-v1 --mode client` no longer WARNs on `auth/scope-step-up`.

Follow-up to #329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)