### PR TITLE
fix: include required result members in 2026-07-28 mock responses

### DIFF
--- a/src/mock-server/index.ts
+++ b/src/mock-server/index.ts
@@ -56,5 +56,10 @@ export interface ScenarioContext {
 }
 
 export { createServerStateful } from './stateful';
-export { createServerStateless, validateStatelessRequest } from './stateless';
+export {
+  createServerStateless,
+  validateStatelessRequest,
+  withRequiredDraftResultFields,
+  CACHEABLE_RESULT_METHODS
+} from './stateless';
 export { createServerFor } from './select';

--- a/src/mock-server/mock-server.test.ts
+++ b/src/mock-server/mock-server.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import { createServerFor } from './select';
 import { createServerStateful } from './stateful';
-import { createServerStateless, validateStatelessRequest } from './stateless';
+import {
+  createServerStateless,
+  validateStatelessRequest,
+  withRequiredDraftResultFields,
+  CACHEABLE_RESULT_METHODS
+} from './stateless';
 import { STATELESS_SPEC_VERSIONS } from '../connection/select';
 import { DRAFT_PROTOCOL_VERSION } from '../types';
 
@@ -73,6 +78,28 @@ describe('validateStatelessRequest', () => {
     expect(v).toMatchObject({ kind: 'route', id: 1, method: 'tools/list' });
   });
 
+  it('includes the draft-required result members on the server/discover result', () => {
+    const v = validateStatelessRequest(
+      {
+        headers,
+        body: {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'server/discover',
+          params: { _meta: meta }
+        }
+      },
+      {},
+      [DRAFT_PROTOCOL_VERSION]
+    );
+    expect(v).toMatchObject({
+      kind: 'handled',
+      body: {
+        result: { resultType: 'complete', ttlMs: 0, cacheScope: 'private' }
+      }
+    });
+  });
+
   it('rejects versions outside the supported list with -32004 and echoes it', () => {
     const v = validateStatelessRequest(
       {
@@ -102,6 +129,53 @@ describe('validateStatelessRequest', () => {
         }
       }
     });
+  });
+});
+
+describe('withRequiredDraftResultFields', () => {
+  it('stamps resultType "complete" when the handler omitted it', () => {
+    expect(
+      withRequiredDraftResultFields('tools/call', { content: [] })
+    ).toEqual({ resultType: 'complete', content: [] });
+  });
+
+  it('adds ttlMs and cacheScope for every cacheable method', () => {
+    for (const method of CACHEABLE_RESULT_METHODS) {
+      expect(withRequiredDraftResultFields(method, {})).toEqual({
+        resultType: 'complete',
+        ttlMs: 0,
+        cacheScope: 'private'
+      });
+    }
+  });
+
+  it('does not add caching hints to non-cacheable results', () => {
+    const result = withRequiredDraftResultFields('tools/call', {
+      content: []
+    });
+    expect(result).not.toHaveProperty('ttlMs');
+    expect(result).not.toHaveProperty('cacheScope');
+  });
+
+  it('preserves members the handler set itself', () => {
+    expect(
+      withRequiredDraftResultFields('tools/call', {
+        resultType: 'input_required',
+        inputRequests: {}
+      })
+    ).toMatchObject({ resultType: 'input_required' });
+    expect(
+      withRequiredDraftResultFields('tools/list', {
+        ttlMs: 5000,
+        cacheScope: 'public',
+        tools: []
+      })
+    ).toMatchObject({ ttlMs: 5000, cacheScope: 'public' });
+  });
+
+  it('passes non-object results through untouched', () => {
+    expect(withRequiredDraftResultFields('tools/call', null)).toBeNull();
+    expect(withRequiredDraftResultFields('tools/call', [1])).toEqual([1]);
   });
 });
 
@@ -281,6 +355,68 @@ describe('createServerStateless', () => {
       );
       expect(status).toBe(200);
       expect(srv.recorded).toHaveLength(0);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('stamps the draft-required result members onto handler results', async () => {
+    const srv = await createServerStateless({
+      'tools/list': () => ({ tools: [{ name: 'x' }] }),
+      'tools/call': () => ({ content: [{ type: 'text', text: 'ok' }] })
+    });
+    try {
+      const list = await post(
+        srv.url,
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/list',
+          params: { _meta: meta }
+        },
+        headers
+      );
+      expect(list.body.result).toMatchObject({
+        resultType: 'complete',
+        ttlMs: 0,
+        cacheScope: 'private',
+        tools: [{ name: 'x' }]
+      });
+
+      const call = await post(
+        srv.url,
+        {
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tools/call',
+          params: { _meta: meta, name: 'x' }
+        },
+        headers
+      );
+      expect(call.body.result).toMatchObject({ resultType: 'complete' });
+      expect(call.body.result).not.toHaveProperty('ttlMs');
+      expect(call.body.result).not.toHaveProperty('cacheScope');
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it('preserves a resultType the handler set itself', async () => {
+    const srv = await createServerStateless({
+      'tools/call': () => ({ resultType: 'input_required', inputRequests: {} })
+    });
+    try {
+      const { body } = await post(
+        srv.url,
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: { _meta: meta }
+        },
+        headers
+      );
+      expect(body.result.resultType).toBe('input_required');
     } finally {
       await srv.close();
     }

--- a/src/mock-server/stateless.ts
+++ b/src/mock-server/stateless.ts
@@ -20,6 +20,45 @@ const META_KEYS = [
   'io.modelcontextprotocol/clientCapabilities'
 ] as const;
 
+/**
+ * Operations whose results the 2026-07-28 revision marks cacheable: servers
+ * MUST include the caching hints `ttlMs` and `cacheScope` on these results
+ * (draft `CacheableResult`, server/utilities/caching).
+ */
+export const CACHEABLE_RESULT_METHODS: ReadonlySet<string> = new Set([
+  'server/discover',
+  'tools/list',
+  'prompts/list',
+  'resources/list',
+  'resources/templates/list',
+  'resources/read'
+]);
+
+/**
+ * Fill in the result members the 2026-07-28 revision requires of servers when
+ * the handler did not set them itself: every result MUST carry `resultType`,
+ * and results of the cacheable operations MUST also carry `ttlMs` and
+ * `cacheScope`. Members the handler set are preserved (e.g. a handler may
+ * return `resultType: 'input_required'`); only absent (or undefined) ones are
+ * filled. A scenario that needs to send a deliberately non-conformant result
+ * must build its own server instead of routing through this mock.
+ */
+export function withRequiredDraftResultFields(
+  method: string,
+  result: unknown
+): unknown {
+  if (result === null || typeof result !== 'object' || Array.isArray(result)) {
+    return result;
+  }
+  const stamped: Record<string, unknown> = { ...result };
+  stamped.resultType ??= 'complete';
+  if (CACHEABLE_RESULT_METHODS.has(method)) {
+    stamped.ttlMs ??= 0;
+    stamped.cacheScope ??= 'private';
+  }
+  return stamped;
+}
+
 type IncomingHeaders = Record<string, string | string[] | undefined>;
 
 export type StatelessValidation =
@@ -114,11 +153,11 @@ export function validateStatelessRequest(
       body: {
         jsonrpc: '2.0',
         id,
-        result: {
+        result: withRequiredDraftResultFields(method, {
           supportedVersions,
           capabilities,
           serverInfo: { name: 'conformance-mock-server', version: '1.0.0' }
-        }
+        })
       }
     };
   }
@@ -166,7 +205,11 @@ export async function createServerStateless(
     }
     try {
       const result = await handler(params, req.body as JSONRPCRequest);
-      return res.json({ jsonrpc: '2.0', id, result });
+      return res.json({
+        jsonrpc: '2.0',
+        id,
+        result: withRequiredDraftResultFields(method, result)
+      });
     } catch (e) {
       return error(500, -32603, e instanceof Error ? e.message : String(e));
     }

--- a/src/scenarios/client/auth/helpers/createServer.ts
+++ b/src/scenarios/client/auth/helpers/createServer.ts
@@ -12,6 +12,7 @@ import express, { Request, Response, NextFunction } from 'express';
 import type { ConformanceCheck } from '../../../../types';
 import {
   validateStatelessRequest,
+  withRequiredDraftResultFields,
   type ScenarioContext
 } from '../../../../mock-server';
 import { isStatefulVersion } from '../../../../connection/select';
@@ -210,16 +211,18 @@ export function createServer(
       return res.json({
         jsonrpc: '2.0',
         id,
-        result: {
+        result: withRequiredDraftResultFields(method, {
           tools: [{ name: 'test-tool', inputSchema: { type: 'object' } }]
-        }
+        })
       });
     }
     if (method === 'tools/call') {
       return res.json({
         jsonrpc: '2.0',
         id,
-        result: { content: [{ type: 'text', text: 'test' }] }
+        result: withRequiredDraftResultFields(method, {
+          content: [{ type: 'text', text: 'test' }]
+        })
       });
     }
     return res.status(404).json({

--- a/src/scenarios/client/draft-result-fields.test.ts
+++ b/src/scenarios/client/draft-result-fields.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect } from 'vitest';
+import { testScenarioContext } from '../../mock-server/testing';
+import { DRAFT_PROTOCOL_VERSION } from '../../types';
+import { HttpStandardHeadersScenario } from './http-standard-headers';
+import {
+  HttpCustomHeadersScenario,
+  HttpInvalidToolHeadersScenario
+} from './http-custom-headers';
+import { RequestMetadataScenario } from './request-metadata';
+import { MRTRClientScenario } from './mrtr-client';
+
+/**
+ * Pins that the hand-rolled mock servers used by client-direction scenarios
+ * at 2026-07-28 return spec-valid results: every result carries `resultType`,
+ * and the cacheable list/read/discover results also carry `ttlMs` and
+ * `cacheScope`. Without these, a strictly-conforming client is failed by the
+ * suite's own non-conformant mock. The shared stateless mock is covered in
+ * src/mock-server/mock-server.test.ts.
+ */
+
+const meta = {
+  'io.modelcontextprotocol/protocolVersion': DRAFT_PROTOCOL_VERSION,
+  'io.modelcontextprotocol/clientInfo': { name: 'test', version: '1.0' },
+  'io.modelcontextprotocol/clientCapabilities': {}
+};
+
+async function post(
+  url: string,
+  body: object,
+  headers: Record<string, string> = {}
+) {
+  const r = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body)
+  });
+  return { status: r.status, body: await r.json() };
+}
+
+const CACHEABLE_FIELDS = {
+  resultType: 'complete',
+  ttlMs: 0,
+  cacheScope: 'private'
+};
+
+describe('http-standard-headers mock results (2026-07-28)', () => {
+  it('carries the draft-required result members on every handled method', async () => {
+    const scenario = new HttpStandardHeadersScenario();
+    const { serverUrl } = await scenario.start(
+      testScenarioContext(DRAFT_PROTOCOL_VERSION)
+    );
+    try {
+      const cases: Array<{
+        method: string;
+        params?: object;
+        cacheable: boolean;
+      }> = [
+        { method: 'initialize', cacheable: false },
+        { method: 'tools/list', cacheable: true },
+        {
+          method: 'tools/call',
+          params: { name: 'test_headers', arguments: {} },
+          cacheable: false
+        },
+        { method: 'resources/list', cacheable: true },
+        {
+          method: 'resources/read',
+          params: { uri: 'file:///path/to/file%20name.txt' },
+          cacheable: true
+        },
+        // Not explicitly handled by the scenario — exercises the method-aware
+        // generic fallback, which must still add the caching hints.
+        { method: 'resources/templates/list', cacheable: true },
+        { method: 'prompts/list', cacheable: true },
+        {
+          method: 'prompts/get',
+          params: { name: 'test_prompt' },
+          cacheable: false
+        },
+        { method: 'unknown/method', cacheable: false }
+      ];
+      let id = 1;
+      for (const c of cases) {
+        const { status, body } = await post(
+          serverUrl,
+          {
+            jsonrpc: '2.0',
+            id: id++,
+            method: c.method,
+            params: c.params ?? {}
+          },
+          { 'Mcp-Method': c.method }
+        );
+        expect(status, c.method).toBe(200);
+        expect(body.result.resultType, c.method).toBe('complete');
+        if (c.cacheable) {
+          expect(body.result, c.method).toMatchObject({
+            ttlMs: 0,
+            cacheScope: 'private'
+          });
+        }
+      }
+    } finally {
+      await scenario.stop();
+    }
+  });
+});
+
+describe('http-custom-headers mock results (2026-07-28)', () => {
+  it('carries the draft-required result members', async () => {
+    const scenario = new HttpCustomHeadersScenario();
+    const { serverUrl } = await scenario.start(
+      testScenarioContext(DRAFT_PROTOCOL_VERSION)
+    );
+    try {
+      const list = await post(serverUrl, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list',
+        params: {}
+      });
+      expect(list.body.result).toMatchObject(CACHEABLE_FIELDS);
+
+      const call = await post(serverUrl, {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'test_custom_headers',
+          arguments: { region: 'us-east', priority: 1, query: 'q' }
+        }
+      });
+      expect(call.body.result.resultType).toBe('complete');
+    } finally {
+      await scenario.stop();
+    }
+  });
+});
+
+describe('http-invalid-tool-headers mock results (2026-07-28)', () => {
+  it('carries the draft-required result members', async () => {
+    const scenario = new HttpInvalidToolHeadersScenario();
+    const { serverUrl } = await scenario.start(
+      testScenarioContext(DRAFT_PROTOCOL_VERSION)
+    );
+    try {
+      const list = await post(serverUrl, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list',
+        params: {}
+      });
+      expect(list.body.result).toMatchObject(CACHEABLE_FIELDS);
+
+      const call = await post(serverUrl, {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'valid_tool', arguments: { region: 'us-east' } }
+      });
+      expect(call.body.result.resultType).toBe('complete');
+    } finally {
+      await scenario.stop();
+    }
+  });
+});
+
+describe('request-metadata mock results (2026-07-28)', () => {
+  it('carries the draft-required result members after the simulated rejection', async () => {
+    const scenario = new RequestMetadataScenario();
+    const { serverUrl } = await scenario.start(
+      testScenarioContext(DRAFT_PROTOCOL_VERSION)
+    );
+    const headers = { 'MCP-Protocol-Version': DRAFT_PROTOCOL_VERSION };
+    try {
+      // The first request is always answered with the simulated -32004
+      // rejection (retry probe); results are served from the second on.
+      const first = await post(
+        serverUrl,
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/list',
+          params: { _meta: meta }
+        },
+        headers
+      );
+      expect(first.status).toBe(400);
+
+      const discover = await post(
+        serverUrl,
+        {
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'server/discover',
+          params: { _meta: meta }
+        },
+        headers
+      );
+      expect(discover.body.result).toMatchObject(CACHEABLE_FIELDS);
+
+      const list = await post(
+        serverUrl,
+        {
+          jsonrpc: '2.0',
+          id: 3,
+          method: 'tools/list',
+          params: { _meta: meta }
+        },
+        headers
+      );
+      expect(list.body.result).toMatchObject(CACHEABLE_FIELDS);
+
+      const call = await post(
+        serverUrl,
+        {
+          jsonrpc: '2.0',
+          id: 4,
+          method: 'tools/call',
+          params: { _meta: meta, name: 'x' }
+        },
+        headers
+      );
+      expect(call.body.result.resultType).toBe('complete');
+
+      const other = await post(
+        serverUrl,
+        { jsonrpc: '2.0', id: 5, method: 'ping', params: { _meta: meta } },
+        headers
+      );
+      expect(other.body.result.resultType).toBe('complete');
+    } finally {
+      await scenario.stop();
+    }
+  });
+});
+
+describe('sep-2322-client-request-state mock results (2026-07-28)', () => {
+  it('carries the draft-required result members on conformant results and keeps the deliberate omission', async () => {
+    const scenario = new MRTRClientScenario();
+    const { serverUrl } = await scenario.start(
+      testScenarioContext(DRAFT_PROTOCOL_VERSION)
+    );
+    try {
+      const list = await post(serverUrl, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list',
+        params: {}
+      });
+      expect(list.body.result).toMatchObject(CACHEABLE_FIELDS);
+
+      const initial = await post(serverUrl, {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'test_mrtr_echo_state', arguments: {} }
+      });
+      expect(initial.body.result.resultType).toBe('input_required');
+
+      const retry = await post(serverUrl, {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'test_mrtr_echo_state',
+          arguments: {},
+          inputResponses: { confirm: { action: 'accept' } },
+          requestState: initial.body.result.requestState
+        }
+      });
+      expect(retry.body.result.resultType).toBe('complete');
+
+      const unrelated = await post(serverUrl, {
+        jsonrpc: '2.0',
+        id: 4,
+        method: 'tools/call',
+        params: { name: 'test_mrtr_unrelated', arguments: {} }
+      });
+      expect(unrelated.body.result.resultType).toBe('complete');
+
+      // The default-resultType probe deliberately omits resultType — that is
+      // the check's stimulus and must not be "fixed".
+      const noResultType = await post(serverUrl, {
+        jsonrpc: '2.0',
+        id: 5,
+        method: 'tools/call',
+        params: { name: 'test_mrtr_no_result_type', arguments: {} }
+      });
+      expect(noResultType.body.result.content).toBeDefined();
+      expect(noResultType.body.result).not.toHaveProperty('resultType');
+    } finally {
+      await scenario.stop();
+    }
+  });
+});

--- a/src/scenarios/client/http-base.ts
+++ b/src/scenarios/client/http-base.ts
@@ -1,4 +1,7 @@
-import type { ScenarioContext } from '../../mock-server';
+import {
+  withRequiredDraftResultFields,
+  type ScenarioContext
+} from '../../mock-server';
 /**
  * Shared HTTP test-server scaffold for client-under-test SEP-2243 scenarios.
  *
@@ -135,6 +138,7 @@ export abstract class BaseHttpScenario implements Scenario {
       jsonrpc: '2.0',
       id: request.id,
       result: {
+        resultType: 'complete',
         protocolVersion: DRAFT_PROTOCOL_VERSION,
         serverInfo: { name: this.name + '-server', version: '1.0.0' },
         capabilities
@@ -151,7 +155,9 @@ export abstract class BaseHttpScenario implements Scenario {
     this.sendJson(res, {
       jsonrpc: '2.0',
       id: request.id,
-      result: {}
+      // Method-aware so cacheable methods that fall through to the generic
+      // reply still carry the ttlMs/cacheScope the draft revision requires.
+      result: withRequiredDraftResultFields(request.method, {})
     });
   }
 }

--- a/src/scenarios/client/http-custom-headers.ts
+++ b/src/scenarios/client/http-custom-headers.ts
@@ -276,6 +276,9 @@ export class HttpCustomHeadersScenario extends BaseHttpScenario {
       jsonrpc: '2.0',
       id: request.id,
       result: {
+        resultType: 'complete',
+        ttlMs: 0,
+        cacheScope: 'private',
         tools: [
           {
             name: 'test_custom_headers',
@@ -591,6 +594,7 @@ export class HttpCustomHeadersScenario extends BaseHttpScenario {
       jsonrpc: '2.0',
       id: request.id,
       result: {
+        resultType: 'complete',
         content: [{ type: 'text', text: 'Custom headers test completed' }]
       }
     });
@@ -760,6 +764,9 @@ export class HttpInvalidToolHeadersScenario extends BaseHttpScenario {
       jsonrpc: '2.0',
       id: request.id,
       result: {
+        resultType: 'complete',
+        ttlMs: 0,
+        cacheScope: 'private',
         tools: [
           // ── Valid tool (should be kept by client) ──
           {
@@ -938,6 +945,7 @@ export class HttpInvalidToolHeadersScenario extends BaseHttpScenario {
       jsonrpc: '2.0',
       id: request.id,
       result: {
+        resultType: 'complete',
         content: [{ type: 'text', text: 'Tool call received' }]
       }
     });

--- a/src/scenarios/client/http-standard-headers.ts
+++ b/src/scenarios/client/http-standard-headers.ts
@@ -221,6 +221,9 @@ export class HttpStandardHeadersScenario extends BaseHttpScenario {
         jsonrpc: '2.0',
         id: request.id,
         result: {
+          resultType: 'complete',
+          ttlMs: 0,
+          cacheScope: 'private',
           tools: [
             {
               name: 'test_headers',
@@ -259,6 +262,7 @@ export class HttpStandardHeadersScenario extends BaseHttpScenario {
         jsonrpc: '2.0',
         id: request.id,
         result: {
+          resultType: 'complete',
           content: [
             {
               type: 'text',
@@ -281,6 +285,9 @@ export class HttpStandardHeadersScenario extends BaseHttpScenario {
         jsonrpc: '2.0',
         id: request.id,
         result: {
+          resultType: 'complete',
+          ttlMs: 0,
+          cacheScope: 'private',
           resources: [
             {
               uri: 'file:///path/to/file%20name.txt',
@@ -309,6 +316,9 @@ export class HttpStandardHeadersScenario extends BaseHttpScenario {
         jsonrpc: '2.0',
         id: request.id,
         result: {
+          resultType: 'complete',
+          ttlMs: 0,
+          cacheScope: 'private',
           contents: []
         }
       })
@@ -326,6 +336,9 @@ export class HttpStandardHeadersScenario extends BaseHttpScenario {
         jsonrpc: '2.0',
         id: request.id,
         result: {
+          resultType: 'complete',
+          ttlMs: 0,
+          cacheScope: 'private',
           prompts: [
             {
               name: 'test_prompt',
@@ -348,6 +361,7 @@ export class HttpStandardHeadersScenario extends BaseHttpScenario {
         jsonrpc: '2.0',
         id: request.id,
         result: {
+          resultType: 'complete',
           messages: []
         }
       })

--- a/src/scenarios/client/json-schema-ref-deref.ts
+++ b/src/scenarios/client/json-schema-ref-deref.ts
@@ -44,6 +44,9 @@ function createMcpServer(canaryUrl: string, onToolsListed: () => void): Server {
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     onToolsListed();
     return {
+      resultType: 'complete',
+      ttlMs: 0,
+      cacheScope: 'private',
       tools: [
         {
           name: TOOL_NAME,

--- a/src/scenarios/client/mrtr-client.ts
+++ b/src/scenarios/client/mrtr-client.ts
@@ -96,7 +96,12 @@ function createMRTRServer(checks: ConformanceCheck[]): express.Application {
         res.json({
           jsonrpc: '2.0',
           id,
-          result: { tools: TOOLS }
+          result: {
+            resultType: 'complete',
+            ttlMs: 0,
+            cacheScope: 'private',
+            tools: TOOLS
+          }
         });
         return;
       }
@@ -141,7 +146,11 @@ function createMRTRServer(checks: ConformanceCheck[]): express.Application {
         res.json({
           jsonrpc: '2.0',
           id,
-          result: { action: 'accept', content: { confirmed: true } }
+          result: {
+            resultType: 'complete',
+            action: 'accept',
+            content: { confirmed: true }
+          }
         });
         return;
       }
@@ -258,6 +267,7 @@ function createMRTRServer(checks: ConformanceCheck[]): express.Application {
       jsonrpc: '2.0',
       id,
       result: {
+        resultType: 'complete',
         content: [{ type: 'text', text: 'echo-state-ok' }]
       }
     });
@@ -324,6 +334,7 @@ function createMRTRServer(checks: ConformanceCheck[]): express.Application {
       jsonrpc: '2.0',
       id,
       result: {
+        resultType: 'complete',
         content: [{ type: 'text', text: 'no-state-ok' }]
       }
     });
@@ -370,6 +381,7 @@ function createMRTRServer(checks: ConformanceCheck[]): express.Application {
       jsonrpc: '2.0',
       id,
       result: {
+        resultType: 'complete',
         content: [{ type: 'text', text: 'unrelated-ok' }]
       }
     });
@@ -403,7 +415,10 @@ function createMRTRServer(checks: ConformanceCheck[]): express.Application {
       res.json({
         jsonrpc: '2.0',
         id,
-        result: { content: [{ type: 'text', text: 'unexpected-retry' }] }
+        result: {
+          resultType: 'complete',
+          content: [{ type: 'text', text: 'unexpected-retry' }]
+        }
       });
       return;
     }

--- a/src/scenarios/client/request-metadata.ts
+++ b/src/scenarios/client/request-metadata.ts
@@ -1,4 +1,7 @@
-import type { ScenarioContext } from '../../mock-server';
+import {
+  withRequiredDraftResultFields,
+  type ScenarioContext
+} from '../../mock-server';
 import http from 'http';
 import {
   Scenario,
@@ -319,11 +322,11 @@ export class RequestMetadataScenario implements Scenario {
           JSON.stringify({
             jsonrpc: '2.0',
             id: request.id,
-            result: {
+            result: withRequiredDraftResultFields(request.method, {
               supportedVersions: [DRAFT_PROTOCOL_VERSION],
               capabilities: {},
               serverInfo: { name: 'test', version: '1.0' }
-            }
+            })
           })
         );
         return;
@@ -337,7 +340,13 @@ export class RequestMetadataScenario implements Scenario {
         result = { content: [] };
       }
       res.writeHead(200, { 'Content-Type': 'application/json' });
-      res.end(JSON.stringify({ jsonrpc: '2.0', id: request.id, result }));
+      res.end(
+        JSON.stringify({
+          jsonrpc: '2.0',
+          id: request.id,
+          result: withRequiredDraftResultFields(request.method, result)
+        })
+      );
     });
   }
 }

--- a/src/scenarios/client/tools_call.test.ts
+++ b/src/scenarios/client/tools_call.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { ToolsCallScenario } from './tools_call';
+import { DRAFT_PROTOCOL_VERSION } from '../../types';
 
 describe('tools_call scenario', () => {
   it('emits a single FAILURE check when the tool was never called', async () => {
@@ -15,6 +16,62 @@ describe('tools_call scenario', () => {
         id: 'tool-add-numbers',
         status: 'FAILURE'
       });
+    } finally {
+      await scenario.stop();
+    }
+  });
+
+  it('serves spec-valid results at the draft (2026-07-28) version', async () => {
+    const meta = {
+      'io.modelcontextprotocol/protocolVersion': DRAFT_PROTOCOL_VERSION,
+      'io.modelcontextprotocol/clientInfo': {
+        name: 'test-client',
+        version: '1.0.0'
+      },
+      'io.modelcontextprotocol/clientCapabilities': {}
+    };
+    async function post(url: string, body: object) {
+      const r = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'mcp-protocol-version': DRAFT_PROTOCOL_VERSION
+        },
+        body: JSON.stringify(body)
+      });
+      return { status: r.status, body: await r.json() };
+    }
+
+    const scenario = new ToolsCallScenario();
+    const { serverUrl } = await scenario.start(
+      testScenarioContext(DRAFT_PROTOCOL_VERSION)
+    );
+    try {
+      const list = await post(serverUrl, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list',
+        params: { _meta: meta }
+      });
+      expect(list.status).toBe(200);
+      expect(list.body.result).toMatchObject({
+        resultType: 'complete',
+        ttlMs: 0,
+        cacheScope: 'private'
+      });
+
+      const call = await post(serverUrl, {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { _meta: meta, name: 'add_numbers', arguments: { a: 2, b: 3 } }
+      });
+      expect(call.status).toBe(200);
+      expect(call.body.result.resultType).toBe('complete');
+
+      const checks = scenario.getChecks();
+      expect(checks).toHaveLength(1);
+      expect(checks[0].status).toBe('SUCCESS');
     } finally {
       await scenario.stop();
     }


### PR DESCRIPTION
The mock servers used for client-direction scenarios return results that are not valid for the 2026-07-28 revision: they omit `resultType`, and the cacheable results also omit `ttlMs`/`cacheScope`. This makes those results spec-valid so the suite can no longer fail a strictly-conforming client because of its own mock.

## Motivation and Context

At 2026-07-28, results from servers must include `resultType` ("The `result` MUST include a `resultType` field", basic/index §Result responses; `Result.resultType` in `schema/draft/schema.ts`: "Servers implementing this protocol version MUST include this field"), and the six cacheable operations (`server/discover`, `tools/list`, `prompts/list`, `resources/list`, `resources/templates/list`, `resources/read`) must also include `ttlMs` and `cacheScope` (`CacheableResult`, server/utilities/caching). The suite's own server-direction check `sep-2322-result-type-included` already enforces the `resultType` MUST against servers under test.

The client-direction mocks don't follow it themselves: the stateless mock wraps scenario handler results verbatim and its built-in `server/discover` result has none of these members, and the hand-rolled per-scenario servers (SEP-2243/2575/2322 scenarios, the auth helper) build results without them. The absent⇒complete bridge in the spec is explicitly scoped to *earlier-revision* servers, so a client that validates 2026-07-28 results strictly is correct to reject these — and then can't pass `tools_call` (or other carry-forward scenarios) at `--spec-version 2026-07-28` even though the non-conformant party is the mock.

## What changed

- `src/mock-server/stateless.ts`: new `withRequiredDraftResultFields(method, result)` helper (exported via `src/mock-server/index.ts`) fills `resultType: "complete"` on every result and `ttlMs: 0` / `cacheScope: "private"` on cacheable-method results, preserving anything the handler set itself. Applied to the handler wrap point and the built-in `server/discover` result, so every `ctx.createServer`-based scenario is covered.
- Hand-rolled scenario servers: the SEP-2243 scenarios (`http-standard-headers`, `http-custom-headers`, `http-invalid-tool-headers`), `request-metadata`, `sep-2322-client-request-state`, the auth helper's stateless path, and `json-schema-ref-no-deref`'s tools/list now return the required members. Method-dispatched fallbacks (`sendGenericResult`, the request-metadata generic reply, the auth helper) route through the shared helper so cacheable methods that fall through still get the caching hints; fixed per-method literals carry the members explicitly so the wire shape stays visible at the emission site.
- Deliberate exception: the `sep-2322-default-result-type-complete` probe in `sep-2322-client-request-state` still omits `resultType` — that omission is the check's stimulus.
- Tests: `mock-server.test.ts` pins the helper and the stateless wrap point; `tools_call.test.ts` gains a draft-mode case asserting the scenario serves spec-valid 2026-07-28 results; new `draft-result-fields.test.ts` pins the hand-rolled scenario servers (including the fallback path and the preserved deliberate omission).

## How Has This Been Tested?

- `npm run check`, `npm run build`, `npm test`: all green (285 tests, including the new response-shape pins).
- `node dist/index.js client --command "npx tsx examples/clients/typescript/everything-client.ts" --suite draft` before and after the change: identical results (115 passed / 9 failed — the 9 are pre-existing gaps in the bundled example client, unrelated to result shapes), so existing clients see no behavior change beyond the added members.

## Breaking Changes

None for clients: the added members are required by the 2026-07-28 schema and ignored by earlier-revision clients. Note for SDK consumers: SDKs pin published releases, so a strict 2026 client can only pass the affected client-direction scenarios once a release containing this change is published (next alpha).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

- The `sep-2322-default-result-type-complete` check exercises the absent⇒complete bridge against a mock that claims 2026-07-28; per the spec the bridge is scoped to earlier-revision servers, so that check may want re-scoping or rewording — left out of this PR as a follow-up question.
- `json-schema-ref-no-deref` serves everything except tools/list through the bundled 1.x SDK transport (initialize handshake, no `server/discover`), so the scenario as a whole is still not a conformant 2026-07-28 server; making it one needs a separate rework coordinated with the example client.
- An all-checks-SKIPPED scenario currently reports as passed (e.g. `http-custom-header-server-validation` against a server with no `x-mcp-header` tool); deliberately not touched here, will be raised separately.
