### PR TITLE
chore: bump version to 0.2.0-alpha.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/conformance",
-  "version": "0.2.0-alpha.3",
+  "version": "0.2.0-alpha.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/conformance",
-      "version": "0.2.0-alpha.3",
+      "version": "0.2.0-alpha.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/conformance",
-  "version": "0.2.0-alpha.3",
+  "version": "0.2.0-alpha.4",
   "type": "module",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",


### PR DESCRIPTION
Bumps the package version from `0.2.0-alpha.3` to `0.2.0-alpha.4` in preparation for the next alpha release to npm (`alpha` dist-tag).

After merge, the release is published by running the `ci.yml` workflow via `workflow_dispatch` on `main` with `publish_alpha=true`.