### PR TITLE
fix: enforce HTTP 400 and data.requested for per-request _meta and version errors

### DIFF
--- a/examples/servers/typescript/everything-server.ts
+++ b/examples/servers/typescript/everything-server.ts
@@ -1225,6 +1225,16 @@ app.use(
   })
 );
 
+// Protocol revisions that use the initialize/session lifecycle. The
+// per-request `_meta` and header/body validation requirements apply to
+// 2026-07-28 and later, not to traffic from these revisions.
+const LEGACY_SESSION_PROTOCOL_VERSIONS = [
+  '2024-11-05',
+  '2025-03-26',
+  '2025-06-18',
+  '2025-11-25'
+];
+
 // Handle POST requests - stateful mode
 app.post('/mcp', async (req, res) => {
   const sessionId = req.headers['mcp-session-id'] as string | undefined;
@@ -1236,7 +1246,15 @@ app.post('/mcp', async (req, res) => {
   const meta = params._meta;
   const metaVersion = meta?.['io.modelcontextprotocol/protocolVersion'];
 
-  if (!sessionId && (reqVersion || meta)) {
+  // A request that carries no `_meta` and names a legacy session-era revision
+  // in the header is legacy traffic; it is served by the session path below
+  // instead of being rejected for missing per-request metadata.
+  const isLegacySessionEraRequest =
+    meta === undefined &&
+    reqVersion !== undefined &&
+    LEGACY_SESSION_PROTOCOL_VERSIONS.includes(reqVersion);
+
+  if (!sessionId && (reqVersion || meta) && !isLegacySessionEraRequest) {
     // Missing Transport Header Validation Check
     if (!reqVersion) {
       return res.status(400).json({
@@ -1246,14 +1264,16 @@ app.post('/mcp', async (req, res) => {
       });
     }
 
-    // Per-Request Metadata Integrity Checks (Fields verification)
+    // Per-Request Metadata Integrity Checks (Fields verification).
+    // A request missing any required `_meta` field is malformed: -32602 and,
+    // on HTTP, status 400 Bad Request.
     if (
       !meta ||
       !meta['io.modelcontextprotocol/protocolVersion'] ||
       !meta['io.modelcontextprotocol/clientInfo'] ||
       !meta['io.modelcontextprotocol/clientCapabilities']
     ) {
-      return res.status(200).json({
+      return res.status(400).json({
         jsonrpc: '2.0',
         id,
         error: {

--- a/src/scenarios/server/stateless.test.ts
+++ b/src/scenarios/server/stateless.test.ts
@@ -127,6 +127,93 @@ describe('Stateless Server Scenario Negative Tests', () => {
     expect(missingVersionCheck?.status).toBe('FAILURE');
   });
 
+  test('Fails validation when missing-_meta rejections are returned with HTTP 200', async () => {
+    // This bad server picks the right JSON-RPC error code but the wrong HTTP
+    // status: the spec requires 400 Bad Request for malformed requests.
+    const mockUrl = mockFetchTarget((reqBody) => {
+      const meta = reqBody.params?._meta;
+      const missingRequired =
+        !meta ||
+        !meta['io.modelcontextprotocol/protocolVersion'] ||
+        !meta['io.modelcontextprotocol/clientInfo'] ||
+        !meta['io.modelcontextprotocol/clientCapabilities'];
+      if (missingRequired) {
+        return {
+          status: 200, // Spec Violation: must be HTTP 400
+          body: {
+            jsonrpc: '2.0',
+            id: reqBody.id,
+            error: {
+              code: -32602,
+              message: 'Invalid params: missing _meta or required fields'
+            }
+          }
+        };
+      }
+    });
+
+    const scenario = new ServerStatelessScenario();
+    const checks = await scenario.run(testContext(mockUrl));
+
+    // The JSON-RPC code is correct, so the per-field checks pass; the wrong
+    // HTTP status is caught by the companion status check.
+    const missingMetaCheck = findCheck(
+      checks,
+      'sep-2575-request-meta-invalid-missing-meta'
+    );
+    const httpStatusCheck = findCheck(
+      checks,
+      'sep-2575-http-server-meta-invalid-400'
+    );
+
+    expect(missingMetaCheck?.status).toBe('SUCCESS');
+    expect(httpStatusCheck?.status).toBe('FAILURE');
+  });
+
+  test('Fails validation when the unsupported-version error omits data.requested', async () => {
+    const mockUrl = mockFetchTarget((reqBody) => {
+      const meta = reqBody.params?._meta;
+      if (meta?.['io.modelcontextprotocol/protocolVersion'] === 'v999.0.0') {
+        return {
+          status: 400,
+          body: {
+            jsonrpc: '2.0',
+            id: reqBody.id,
+            error: {
+              code: -32004,
+              message: 'Unsupported protocol version',
+              // Spec Violation: data.requested is a required member
+              data: { supported: ['2026-07-28'] }
+            }
+          }
+        };
+      }
+      if (reqBody.method === 'server/discover') {
+        return {
+          status: 200,
+          body: {
+            jsonrpc: '2.0',
+            id: reqBody.id,
+            result: {
+              supportedVersions: ['2026-07-28'],
+              capabilities: {},
+              serverInfo: { name: 'no-requested-server', version: '1.0.0' }
+            }
+          }
+        };
+      }
+    });
+
+    const scenario = new ServerStatelessScenario();
+    const checks = await scenario.run(testContext(mockUrl));
+
+    const negotiationCheck = findCheck(
+      checks,
+      'sep-2575-server-unsupported-version-error'
+    );
+    expect(negotiationCheck?.status).toBe('FAILURE');
+  });
+
   test('Fails validation if removed legacy RPCs do not return HTTP 404 Not Found', async () => {
     // This bad server intercepts the removed 'ping' or 'initialize' methods but incorrectly returns HTTP 200
     const mockUrl = mockFetchTarget((reqBody) => {

--- a/src/scenarios/server/stateless.ts
+++ b/src/scenarios/server/stateless.ts
@@ -33,8 +33,8 @@ export class ServerStatelessScenario implements ClientScenario {
 
 **Grouped Specification Requirements**:
 
-1. **Per-Request _meta Validation (4 Checks)**
-   - Rejects requests missing \`_meta\` or lacking structural required internal subfields (\`protocolVersion\`, \`clientInfo\`, \`clientCapabilities\`) with a JSON-RPC \`-32602 Invalid params\` error signature.
+1. **Per-Request _meta Validation (5 Checks)**
+   - Rejects requests missing \`_meta\` or lacking structural required internal subfields (\`protocolVersion\`, \`clientInfo\`, \`clientCapabilities\`) with a JSON-RPC \`-32602 Invalid params\` error signature and an HTTP status code \`400 Bad Request\`.
 2. **Discovery & Capabilities (3 Checks)**
    - Implements \`server/discover\` mapping exact mandatory protocol elements.
    - Dynamically checks prompt capability declaration constraints, validates that active RPC handlers match advertised discovery capacities.
@@ -356,26 +356,50 @@ export class ServerStatelessScenario implements ClientScenario {
       }
     ];
     for (const testCase of metaValidationTestCases) {
+      const metaProbe = await sendRpc(
+        'server/discover',
+        testCase.params,
+        undefined,
+        testCase.rpcId
+      ).catch(() => null);
+      const metaRes: any = metaProbe?.res ?? null;
+      const metaData: any = metaProbe?.data ?? null;
+      if (metaData) checkErrorId(metaData, testCase.rpcId);
+
       await runCheck(
         `sep-2575-request-meta-invalid-${testCase.slug}`,
         'RequestMetaInvalid',
         testCase.description,
-        async () => {
-          const { data } = await sendRpc(
-            'server/discover',
-            testCase.params,
-            undefined,
-            testCase.rpcId
-          );
-          checkErrorId(data, testCase.rpcId);
-
-          if (data?.error?.code !== -32602) {
+        () => {
+          if (!metaProbe)
+            return { error: '_meta validation probe failed completely' };
+          if (metaData?.error?.code !== -32602) {
             return {
-              error: `Expected error code -32602, got ${data?.error?.code}`,
-              details: { fieldIssue: testCase.slug, response: data }
+              error: `Expected error code -32602, got ${metaData?.error?.code}`,
+              details: { fieldIssue: testCase.slug, response: metaData }
             };
           }
-          return { details: { fieldIssue: testCase.slug, response: data } };
+          return { details: { fieldIssue: testCase.slug, response: metaData } };
+        },
+        { fieldIssue: testCase.slug }
+      );
+
+      // Companion HTTP-status check: a request missing a required _meta field
+      // is malformed and, on HTTP, the rejection MUST use 400 Bad Request.
+      await runCheck(
+        'sep-2575-http-server-meta-invalid-400',
+        'HttpServerMetaInvalid400',
+        'Rejections of requests missing required _meta fields use HTTP 400 Bad Request.',
+        () => {
+          if (!metaRes)
+            return { error: '_meta validation probe failed completely' };
+          if (metaRes.status !== 400) {
+            return {
+              error: `Expected HTTP 400 Bad Request, got status code ${metaRes.status}`,
+              details: { fieldIssue: testCase.slug, response: metaData }
+            };
+          }
+          return { details: { fieldIssue: testCase.slug, response: metaData } };
         },
         { fieldIssue: testCase.slug }
       );
@@ -498,14 +522,15 @@ export class ServerStatelessScenario implements ClientScenario {
     // ==========================================
     // 3. Version Negotiation & Headers (3 Checks)
     // ==========================================
+    const requestedUnsupportedVersion = 'v999.0.0';
     const unsupportedMeta = {
       ...validMeta,
-      'io.modelcontextprotocol/protocolVersion': 'v999.0.0'
+      'io.modelcontextprotocol/protocolVersion': requestedUnsupportedVersion
     };
     const response301 = await sendRpc(
       'server/discover',
       { _meta: unsupportedMeta },
-      { 'MCP-Protocol-Version': 'v999.0.0' },
+      { 'MCP-Protocol-Version': requestedUnsupportedVersion },
       301
     ).catch(() => null);
     const res301: any = response301?.res ?? null;
@@ -515,7 +540,7 @@ export class ServerStatelessScenario implements ClientScenario {
     await runCheck(
       'sep-2575-server-unsupported-version-error',
       'ServerUnsupportedVersionError',
-      'If the server does not implement the requested version (whether the version is unknown to the server, or is a known version the server has chosen not to support), it MUST respond with an UnsupportedProtocolVersionError listing the versions it does support.',
+      'If the server does not implement the requested version (whether the version is unknown to the server, or is a known version the server has chosen not to support), it MUST respond with an UnsupportedProtocolVersionError listing the versions it does support; the error data carries the supported versions and echoes the requested version.',
       () => {
         if (!data301)
           return { error: 'Unsupported version invocation failed completely' };
@@ -533,6 +558,17 @@ export class ServerStatelessScenario implements ClientScenario {
           return {
             error: `Returned supported versions data layout does not correlate to active server metrics: ${JSON.stringify(errSupportedVersions)}`
           };
+
+        // UnsupportedProtocolVersionError data carries both required members:
+        // `supported` (asserted above) and `requested`, which echoes the
+        // version the request asked for.
+        const requestedEcho = data301?.error?.data?.requested;
+        if (requestedEcho !== requestedUnsupportedVersion) {
+          return {
+            error: `error.data.requested must echo the requested version '${requestedUnsupportedVersion}', got ${JSON.stringify(requestedEcho)}`,
+            details: { response: data301 }
+          };
+        }
         return { details: { response: data301 } };
       }
     );


### PR DESCRIPTION
Three small, strictly spec-backed fixes around per-request `_meta` handling: the everything-server fixture returned its missing-`_meta` rejection with the wrong HTTP status and applied draft-only validation to legacy traffic, and the `server-stateless` scenario was not checking two members the spec requires. No error-code expectations change in this PR (those are tied to the open renumbering discussion in modelcontextprotocol/modelcontextprotocol#2907 and stay with #336).

## Motivation and Context

Each change maps to a normative sentence in the current draft (2026-07-28) revision (quotes from [`98c49d9`](https://github.com/modelcontextprotocol/modelcontextprotocol/commit/98c49d9310697a105af8ba57fe3fdc23b833d7d2)):

1. **Missing required `_meta` fields ⇒ HTTP 400.** [`basic/index.mdx#L313-L315`](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/98c49d9310697a105af8ba57fe3fdc23b833d7d2/docs/specification/draft/basic/index.mdx#L313-L315):
   > "A request missing any required field is malformed; the server **MUST** reject it with JSON-RPC error code `-32602` (Invalid params). On HTTP, the response status **MUST** be `400 Bad Request`."

   The everything-server returned this `-32602` error with HTTP **200**, and the `sep-2575-request-meta-invalid-*` checks only looked at the JSON-RPC code, so the suite could not catch the wrong status.

2. **Per-request `_meta` is a modern-revision requirement.** [`basic/versioning.mdx#L34-L37`](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/98c49d9310697a105af8ba57fe3fdc23b833d7d2/docs/specification/draft/basic/versioning.mdx#L34-L37):
   > "**Modern**: protocol versions that convey version, identity, and capabilities as per-request metadata (revision `2026-07-28` and later). **Legacy**: protocol versions that establish a session with an `initialize` handshake (`2025-11-25` and earlier)."

   The dual-era everything-server applied the per-request `_meta` validation to any sessionless request that carried an `MCP-Protocol-Version` header — including legacy-revision values — so a legacy client that sends the header before it has a session would be rejected with "missing `_meta`" for metadata its revision does not define.

3. **`UnsupportedProtocolVersionError.data` requires `requested` (and `supported`).** [`schema/draft/schema.ts#L387-L402`](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/98c49d9310697a105af8ba57fe3fdc23b833d7d2/schema/draft/schema.ts#L387-L402) defines `data: { supported: string[]; requested: string }` (both non-optional), and [`basic/versioning.mdx#L48-L52`](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/98c49d9310697a105af8ba57fe3fdc23b833d7d2/docs/specification/draft/basic/versioning.mdx#L48-L52):
   > "If the server does not implement the requested version (whether the version is unknown to the server, or is a known version the server has chosen not to support), it **MUST** respond with an `UnsupportedProtocolVersionError` listing the versions it does support"

   `sep-2575-server-unsupported-version-error` already validated `data.supported`, but never checked that `data.requested` is present and echoes the version the request asked for.

## What changed

- `examples/servers/typescript/everything-server.ts`
  - The missing-`_meta`-fields rejection now returns HTTP **400** (code stays `-32602`).
  - Sessionless requests that carry **no `_meta`** and a **legacy session-era version** in `MCP-Protocol-Version` (2024-11-05 … 2025-11-25) skip the per-request validation block and fall through to the existing session/initialize handling. Requests that carry `_meta`, the draft version, or an unknown version are validated exactly as before.
- `src/scenarios/server/stateless.ts`
  - New companion check `sep-2575-http-server-meta-invalid-400` (FAILURE severity), emitted once per `_meta` probe: rejections of requests missing required `_meta` fields must use HTTP 400. The existing `sep-2575-request-meta-invalid-*` checks keep their code-only meaning, mirroring how the scenario already splits error-shape vs HTTP-status checks elsewhere (e.g. `sep-2575-server-unsupported-version-error` / `sep-2575-http-server-unsupported-version-400`).
  - `sep-2575-server-unsupported-version-error` now also requires `error.data.requested` to echo the requested version.
- `src/scenarios/server/stateless.test.ts`: two new negative tests — a server that returns the `-32602` rejection with HTTP 200 keeps the per-field checks green but FAILs the new status check, and a server that omits `data.requested` from its unsupported-version error FAILs the negotiation check.

Deliberately **not** in this PR: any change to which JSON-RPC error codes the scenario expects. The `-32602`/`-32001`/`-32004` questions interact with the error-code renumbering in modelcontextprotocol/modelcontextprotocol#2907 and remain with #336.

## How Has This Been Tested?

- `npm run check`, `npm run build`, `npm test` — all green (287 tests). `all-scenarios.test.ts` runs the draft and active suites against the modified everything-server in-process, which exercises the strengthened checks against the fixed fixture; the active (2025) scenarios are unaffected by the legacy-traffic gate because the SDK client never sends the version header before it has a session.
- The two new negative tests prove the strengthened checks fail non-conformant servers (wrong HTTP status; missing `data.requested`).

## Breaking Changes

None for conformant servers. Servers that return the missing-`_meta` rejection with a non-400 status, or an unsupported-version error without `data.requested`, will newly fail the corresponding checks — both are MUST/required-member violations of the draft revision — and may need an `expected-failures` entry until fixed.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

- This is the uncontroversial subset of what #336 touches. The remaining parts of #336 (which error code applies to a missing `_meta`/`protocolVersion` when a valid header is present, and `HeaderMismatch` vs `UnsupportedProtocolVersion` precedence when both rules trigger) depend on the error-code allocation/renumbering in modelcontextprotocol/modelcontextprotocol#2907 and on a precedence clarification, and are untouched here.
- Side effect of the legacy-traffic gate worth knowing: the `server-initialize` scenario's raw probe (which sends a `2025-11-25` header with no session and no `_meta`) previously hit the `_meta` rejection on the everything-server and reported its session-id check as INFO; it now reaches the real initialize/session path, so that check reports SUCCESS against the fixture.
- The fixture keeps its own `LEGACY_SESSION_PROTOCOL_VERSIONS` list rather than importing the suite's `STATEFUL_VERSIONS` because the example servers intentionally don't import from `src/`.
- `sep-2575-http-server-meta-invalid-400` is not added to `sep-2575.yaml`, matching the existing `sep-2575-request-meta-invalid-*` checks which aren't mapped there either; a follow-up could add rows for both halves of the missing-field requirement if we want them traced.
