### PR TITLE
fix: serve server/discover from the hand-rolled client-scenario mocks

### DIFF
--- a/src/scenarios/client/draft-result-fields.test.ts
+++ b/src/scenarios/client/draft-result-fields.test.ts
@@ -8,6 +8,7 @@ import {
 } from './http-custom-headers';
 import { RequestMetadataScenario } from './request-metadata';
 import { MRTRClientScenario } from './mrtr-client';
+import { JsonSchemaRefDerefScenario } from './json-schema-ref-deref';
 
 /**
  * Pins that the hand-rolled mock servers used by client-direction scenarios
@@ -42,6 +43,70 @@ const CACHEABLE_FIELDS = {
   ttlMs: 0,
   cacheScope: 'private'
 };
+
+const DISCOVER_FIELDS = {
+  ...CACHEABLE_FIELDS,
+  supportedVersions: [DRAFT_PROTOCOL_VERSION]
+};
+
+describe('hand-rolled mock servers serve server/discover (2026-07-28)', () => {
+  const cases = [
+    {
+      name: 'http-standard-headers',
+      make: () => new HttpStandardHeadersScenario(),
+      capabilities: { tools: {}, resources: {}, prompts: {} }
+    },
+    {
+      name: 'http-custom-headers',
+      make: () => new HttpCustomHeadersScenario(),
+      capabilities: { tools: {} }
+    },
+    {
+      name: 'http-invalid-tool-headers',
+      make: () => new HttpInvalidToolHeadersScenario(),
+      capabilities: { tools: {} }
+    },
+    {
+      name: 'sep-2322-client-request-state',
+      make: () => new MRTRClientScenario(),
+      capabilities: { tools: {} }
+    },
+    {
+      name: 'json-schema-ref-no-deref',
+      make: () => new JsonSchemaRefDerefScenario(),
+      capabilities: { tools: {} }
+    }
+  ];
+
+  for (const c of cases) {
+    it(`${c.name} returns a valid DiscoverResult`, async () => {
+      const scenario = c.make();
+      const { serverUrl } = await scenario.start(
+        testScenarioContext(DRAFT_PROTOCOL_VERSION)
+      );
+      try {
+        const { status, body } = await post(
+          serverUrl,
+          {
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'server/discover',
+            params: { _meta: meta }
+          },
+          { 'mcp-protocol-version': DRAFT_PROTOCOL_VERSION }
+        );
+        expect(status).toBe(200);
+        expect(body.result).toMatchObject({
+          ...DISCOVER_FIELDS,
+          capabilities: c.capabilities
+        });
+        expect(body.result.serverInfo?.name).toBeTypeOf('string');
+      } finally {
+        await scenario.stop();
+      }
+    });
+  }
+});
 
 describe('http-standard-headers mock results (2026-07-28)', () => {
   it('carries the draft-required result members on every handled method', async () => {

--- a/src/scenarios/client/http-base.ts
+++ b/src/scenarios/client/http-base.ts
@@ -102,6 +102,10 @@ export abstract class BaseHttpScenario implements Scenario {
     req.on('end', () => {
       try {
         const request = JSON.parse(body);
+        if (request.method === 'server/discover') {
+          this.sendDiscover(res, request);
+          return;
+        }
         this.handlePost(req, res, request);
       } catch (error) {
         res.writeHead(400, { 'Content-Type': 'application/json' });
@@ -129,10 +133,31 @@ export abstract class BaseHttpScenario implements Scenario {
     res.end(JSON.stringify(body));
   }
 
+  /**
+   * Capabilities advertised to a 2026-07-28 client via `server/discover` (and
+   * defaulted in the legacy `initialize` reply). Subclasses override to match
+   * the methods they actually serve.
+   */
+  protected discoverCapabilities(): object {
+    return { tools: {} };
+  }
+
+  protected sendDiscover(res: http.ServerResponse, request: any): void {
+    this.sendJson(res, {
+      jsonrpc: '2.0',
+      id: request.id,
+      result: withRequiredDraftResultFields('server/discover', {
+        supportedVersions: [DRAFT_PROTOCOL_VERSION],
+        capabilities: this.discoverCapabilities(),
+        serverInfo: { name: this.name + '-server', version: '1.0.0' }
+      })
+    });
+  }
+
   protected sendInitialize(
     res: http.ServerResponse,
     request: any,
-    capabilities: object = { tools: {} }
+    capabilities: object = this.discoverCapabilities()
   ): void {
     this.sendJson(res, {
       jsonrpc: '2.0',

--- a/src/scenarios/client/http-standard-headers.ts
+++ b/src/scenarios/client/http-standard-headers.ts
@@ -202,12 +202,12 @@ export class HttpStandardHeadersScenario extends BaseHttpScenario {
     });
   }
 
+  protected discoverCapabilities(): object {
+    return { tools: {}, resources: {}, prompts: {} };
+  }
+
   private handleInitialize(res: http.ServerResponse, request: any): void {
-    this.sendInitialize(res, request, {
-      tools: {},
-      resources: {},
-      prompts: {}
-    });
+    this.sendInitialize(res, request);
   }
 
   private handleToolsList(res: http.ServerResponse, request: any): void {

--- a/src/scenarios/client/json-schema-ref-deref.ts
+++ b/src/scenarios/client/json-schema-ref-deref.ts
@@ -109,6 +109,29 @@ The scenario advertises a tool whose inputSchema contains a \`$ref\` pointing at
     });
 
     app.post('/mcp', async (req: Request, res: Response) => {
+      // The bundled SDK server below predates the 2026-07-28 lifecycle and
+      // does not implement server/discover; answer it directly so a client
+      // that negotiates first can proceed to tools/list.
+      if (
+        (req.body as Record<string, unknown> | undefined)?.method ===
+        'server/discover'
+      ) {
+        return res.json({
+          jsonrpc: '2.0',
+          id: (req.body as Record<string, unknown>).id ?? null,
+          result: {
+            resultType: 'complete',
+            ttlMs: 0,
+            cacheScope: 'private',
+            supportedVersions: [DRAFT_PROTOCOL_VERSION],
+            capabilities: { tools: {} },
+            serverInfo: {
+              name: 'json-schema-ref-deref-server',
+              version: '1.0.0'
+            }
+          }
+        });
+      }
       try {
         // Stateless: fresh server and transport per request
         const server = createMcpServer(this.canaryUrl(), () => {

--- a/src/scenarios/client/mrtr-client.ts
+++ b/src/scenarios/client/mrtr-client.ts
@@ -87,6 +87,22 @@ function createMRTRServer(checks: ConformanceCheck[]): express.Application {
     const { id, method, params } = body;
 
     switch (method) {
+      case 'server/discover': {
+        res.json({
+          jsonrpc: '2.0',
+          id,
+          result: {
+            resultType: 'complete',
+            ttlMs: 0,
+            cacheScope: 'private',
+            supportedVersions: [DRAFT_PROTOCOL_VERSION],
+            capabilities: { tools: {} },
+            serverInfo: { name: 'mrtr-mock-server', version: '1.0.0' }
+          }
+        });
+        return;
+      }
+
       case 'notifications/initialized': {
         res.status(204).end();
         return;


### PR DESCRIPTION
The hand-rolled mock servers for the SEP-2243/2322/2106 client-direction scenarios now answer `server/discover`, so a 2026-07-28 client that negotiates via discover before its scenario calls can proceed without intercepting the response at the transport layer.

## Motivation and Context

`server/discover` is the recommended negotiation entry point at 2026-07-28 ("Clients MAY call `server/discover`", [server/discover](https://modelcontextprotocol.io/specification/draft/server/discover)); a client that does so against the suite's mocks should get a valid `DiscoverResult`. The shared stateless mock (`createServerStateless` / `validateStatelessRequest`) and the `request-metadata` and auth scenarios already serve it, but the hand-rolled servers used by `http-standard-headers`, `http-custom-headers`, `http-invalid-tool-headers`, `sep-2322-client-request-state`, and `json-schema-ref-no-deref` did not — discover hit their fallbacks (`-32601` for the MRTR mock, the generic empty result for the SEP-2243 scenarios, the bundled 1.x SDK's method-not-found for the SEP-2106 scenario). A client whose fixture negotiates via discover currently has to synthesize the response itself; the typescript-sdk's everythingClient carries exactly that workaround.

Same family as #341: the mocks need to speak enough of the 2026-07-28 surface that a strictly-conforming client can connect and proceed.

## What changed

- `BaseHttpScenario` answers `server/discover` itself (before delegating to `handlePost`) with a valid `DiscoverResult`: `supportedVersions: [DRAFT_PROTOCOL_VERSION]`, `capabilities` from a new overridable `discoverCapabilities()` (default `{ tools: {} }`), `serverInfo`, and the required `resultType`/`ttlMs`/`cacheScope`. `sendInitialize` defaults its capabilities to the same hook so the legacy and modern paths advertise the same set.
- `http-standard-headers` overrides `discoverCapabilities()` to `{ tools: {}, resources: {}, prompts: {} }` (the methods it actually serves).
- `mrtr-client` adds a `server/discover` case to its method switch.
- `json-schema-ref-no-deref` answers `server/discover` directly before handing the request to the bundled SDK transport (which predates the 2026-07-28 lifecycle).
- `draft-result-fields.test.ts` gains a parameterised test asserting each of the five scenarios returns a valid `DiscoverResult` carrying `supportedVersions: [draft]`, the expected capabilities, and the cacheable-result members.

## How Has This Been Tested?

- `npm run check`, `npm run build`, `npm test` — all green (293 tests, including the 5 new discover assertions).
- `node dist/index.js client --command "npx tsx examples/clients/typescript/everything-client.ts" --suite draft` before and after the change: identical results (the bundled example client doesn't call discover on these scenarios, so this confirms no regression for clients that don't).

## Breaking Changes

None. The added `server/discover` handling is purely additive; clients that don't call discover see no change.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

- Once this ships in a release, the typescript-sdk's everythingClient can drop its discover-interception shim and exercise the negotiation step against the mocks for real.
- `json-schema-ref-no-deref` still routes everything *except* discover through the bundled 1.x SDK transport (initialize handshake, no `_meta` validation); fully reworking that scenario to a hand-rolled stateless server is a larger follow-up flagged in #341.
- These mocks deliberately do not enforce per-request `_meta` validation (unlike the shared stateless mock), so clients on either lifecycle can drive them; only the discover response was missing.
- Because `BaseHttpScenario` now answers discover before delegating to `handlePost`, `http-standard-headers` no longer emits its opportunistic `Mcp-Method` check for `server/discover` (it was never in the scenario's `expectedMethods` list, so no backfill or test changes). If we want SEP-2243 header coverage on `server/discover`, the right place is the scenario's expected-methods list — separate question from this PR.
