### PR TITLE
chore: sync spec-types/draft.ts to modelcontextprotocol@2fb207d

### DIFF
--- a/src/scenarios/server/http-standard-headers.ts
+++ b/src/scenarios/server/http-standard-headers.ts
@@ -25,6 +25,7 @@ import {
   sendStatelessRequest,
   type RunContext
 } from '../../connection';
+import { HEADER_MISMATCH } from '../../spec-types/draft';
 
 const SPEC_REFERENCE = {
   id: 'SEP-2243-Server-Validation',
@@ -55,7 +56,7 @@ const SPEC_REFERENCE_CUSTOM = {
   url: 'https://modelcontextprotocol.io/specification/draft/basic/transports#server-behavior-for-custom-headers'
 };
 
-const HEADER_MISMATCH_ERROR_CODE = -32001;
+const HEADER_MISMATCH_ERROR_CODE = HEADER_MISMATCH;
 
 // Coarse, requirement-level check IDs (SEP-2243) for STANDARD-header
 // rejections. Every standard-header rejection case emits this same pair of IDs;

--- a/src/spec-types/SOURCE
+++ b/src/spec-types/SOURCE
@@ -1,1 +1,1 @@
-modelcontextprotocol@0168c57fc74aba6e6dcf8f0b7191db3caaa5ad65
+modelcontextprotocol@2fb207da428f43a4981513ec2aef218b7533c5b3

--- a/src/spec-types/draft.ts
+++ b/src/spec-types/draft.ts
@@ -111,6 +111,29 @@ export interface RequestMetaObject extends MetaObject {
 }
 
 /**
+ * Extends {@link MetaObject} with additional notification-specific fields. All key naming rules from `MetaObject` apply.
+ *
+ * @see {@link MetaObject} for key naming rules and reserved prefixes.
+ * @see [General fields: `_meta`](/specification/draft/basic/index#meta) for more details.
+ * @category Common Types
+ */
+export interface NotificationMetaObject extends MetaObject {
+  /**
+   * Identifies the subscription stream a notification was delivered on. The
+   * server MUST include this key on every notification delivered via a
+   * {@link SubscriptionsListenRequest | subscriptions/listen} stream, so the
+   * client can correlate the notification with the originating subscription.
+   * The key is absent on notifications not delivered via a subscription
+   * stream (e.g. progress notifications for an in-flight request), which is
+   * why it is optional here.
+   *
+   * The value is the JSON-RPC ID of the `subscriptions/listen` request that
+   * opened the stream.
+   */
+  "io.modelcontextprotocol/subscriptionId"?: RequestId;
+}
+
+/**
  * A progress token, used to associate progress notifications with the original request.
  *
  * @category Common Types
@@ -147,7 +170,7 @@ export interface Request {
  * @category Common Types
  */
 export interface NotificationParams {
-  _meta?: MetaObject;
+  _meta?: NotificationMetaObject;
 }
 
 /** @internal */
@@ -358,6 +381,15 @@ export interface InternalError extends Error {
 }
 
 /**
+ * Error code returned when the HTTP headers of a request do not match the
+ * corresponding values in the request body, or required headers are
+ * missing or malformed.
+ *
+ * @category Errors
+ */
+export const HEADER_MISMATCH = -32001;
+
+/**
  * Error code returned when a server requires a client capability that was
  * not declared in the request's `clientCapabilities`.
  *
@@ -372,6 +404,26 @@ export const MISSING_REQUIRED_CLIENT_CAPABILITY = -32003;
  * @category Errors
  */
 export const UNSUPPORTED_PROTOCOL_VERSION = -32004;
+
+/**
+ * Returned when a server rejects a request because the values in the HTTP
+ * headers do not match the corresponding values in the request body, or
+ * because required headers are missing or malformed. For HTTP, the response
+ * status code MUST be `400 Bad Request`.
+ *
+ * @example Header mismatch
+ * {@includeCode ./examples/HeaderMismatchError/header-mismatch.json}
+ *
+ * @category Errors
+ */
+export interface HeaderMismatchError extends Omit<
+  JSONRPCErrorResponse,
+  "error"
+> {
+  error: Error & {
+    code: typeof HEADER_MISMATCH;
+  };
+}
 
 /**
  * Returned when the request's protocol version is unknown to the server or
@@ -529,9 +581,9 @@ export interface CancelledNotificationParams extends NotificationParams {
   /**
    * The ID of the request to cancel.
    *
-   * This MUST correspond to the ID of a request previously issued in the same direction.
+   * This MUST correspond to the ID of a request the client previously issued.
    */
-  requestId?: RequestId;
+  requestId: RequestId;
 
   /**
    * An optional string describing the reason for the cancellation. This MAY be logged or presented to the user.
@@ -540,7 +592,9 @@ export interface CancelledNotificationParams extends NotificationParams {
 }
 
 /**
- * This notification can be sent by either side to indicate that it is cancelling a previously-issued request.
+ * This notification is sent by the client to indicate that it is cancelling a request it previously issued.
+ *
+ * On stdio, the server also sends this notification, solely to terminate a {@link SubscriptionsListenRequest | subscriptions/listen} stream: it references the ID of the `subscriptions/listen` request that opened the stream. Servers MUST NOT use this notification to cancel any other request.
  *
  * The request SHOULD still be in-flight, but due to communication latency, it is always possible that this notification MAY arrive after the request has already finished.
  *
@@ -1007,11 +1061,13 @@ export interface CacheableResult extends Result {
    * Indicates the intended scope of the cached response, analogous to HTTP
    * `Cache-Control: public` vs `Cache-Control: private`.
    *
-   * - `"public"`: Any client or intermediary (e.g., shared gateway, proxy)
-   *   MAY cache the response and serve it to any user.
-   * - `"private"`: Only the requesting user's client MAY cache the response.
-   *   Shared caches (e.g., multi-tenant gateways) MUST NOT serve a cached
-   *   copy to a different user.
+   * - `"public"`: The response does not contain user-specific data. Any
+   *   client or intermediary (e.g., shared gateway, caching proxy) MAY cache
+   *   the response and serve it across authorization contexts.
+   * - `"private"`: The response MAY be cached and reused only within the
+   *   same authorization context. Caches MUST NOT be shared across
+   *   authorization contexts (e.g., a different access token requires a
+   *   different cache).
    *
    */
   cacheScope: "public" | "private";
@@ -1154,7 +1210,7 @@ export interface ReadResourceResultResponse extends JSONRPCResultResponse {
 }
 
 /**
- * An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This may be issued by servers without any previous subscription from the client.
+ * An optional notification from the server to the client, informing it that the list of resources it can read from has changed. This is only delivered on a {@link SubscriptionsListenRequest | subscriptions/listen} stream when the client requested it via the `resourcesListChanged` filter field.
  *
  * @example Resources list changed
  * {@includeCode ./examples/ResourceListChangedNotification/resources-list-changed.json}
@@ -1598,7 +1654,7 @@ export interface EmbeddedResource {
   _meta?: MetaObject;
 }
 /**
- * An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This may be issued by servers without any previous subscription from the client.
+ * An optional notification from the server to the client, informing it that the list of prompts it offers has changed. This is only delivered on a {@link SubscriptionsListenRequest | subscriptions/listen} stream when the client requested it via the `promptsListChanged` filter field.
  *
  * @example Prompts list changed
  * {@includeCode ./examples/PromptListChangedNotification/prompts-list-changed.json}
@@ -1740,7 +1796,7 @@ export interface CallToolRequest extends JSONRPCRequest {
 }
 
 /**
- * An optional notification from the server to the client, informing it that the list of tools it offers has changed. This may be issued by servers without any previous subscription from the client.
+ * An optional notification from the server to the client, informing it that the list of tools it offers has changed. This is only delivered on a {@link SubscriptionsListenRequest | subscriptions/listen} stream when the client requested it via the `toolsListChanged` filter field.
  *
  * @example Tools list changed
  * {@includeCode ./examples/ToolListChangedNotification/tools-list-changed.json}
@@ -1841,6 +1897,11 @@ export interface Tool extends BaseMetadata, Icons {
    * composition keywords (`oneOf`, `anyOf`, `allOf`, `not`), conditional keywords
    * (`if`/`then`/`else`), reference keywords (`$ref`, `$defs`, `$anchor`), and any other
    * standard validation or annotation keywords.
+   *
+   * Property schemas may carry an `x-mcp-header` annotation to mirror the
+   * argument value into an HTTP header on the Streamable HTTP transport. See
+   * the Streamable HTTP transport specification for the validity and
+   * extraction rules.
    *
    * Defaults to JSON Schema 2020-12 when no explicit `$schema` is provided.
    */
@@ -2571,7 +2632,9 @@ export interface PromptReference extends BaseMetadata {
  */
 export interface ListRootsRequest {
   method: "roots/list";
-  params?: RequestParams;
+  params?: {
+    _meta?: MetaObject;
+  };
 }
 
 /**
@@ -2680,12 +2743,6 @@ export interface ElicitRequestURLParams {
    * The message to present to the user explaining why the interaction is needed.
    */
   message: string;
-
-  /**
-   * The ID of the elicitation, which must be unique within the context of the server.
-   * The client MUST treat this ID as an opaque value.
-   */
-  elicitationId: string;
 
   /**
    * The URL that the user should navigate to.
@@ -3014,31 +3071,6 @@ export interface ElicitResult {
   content?: { [key: string]: string | number | boolean | string[] };
 }
 
-/**
- * Parameters for a {@link ElicitationCompleteNotification | notifications/elicitation/complete} notification.
- *
- * @category `notifications/elicitation/complete`
- */
-export interface ElicitationCompleteNotificationParams extends NotificationParams {
-  /**
-   * The ID of the elicitation that completed.
-   */
-  elicitationId: string;
-}
-
-/**
- * An optional notification from the server to the client, informing it of a completion of a out-of-band elicitation request.
- *
- * @example Elicitation complete
- * {@includeCode ./examples/ElicitationCompleteNotification/elicitation-complete.json}
- *
- * @category `notifications/elicitation/complete`
- */
-export interface ElicitationCompleteNotification extends JSONRPCNotification {
-  method: "notifications/elicitation/complete";
-  params: ElicitationCompleteNotificationParams;
-}
-
 /* Client messages */
 /** @internal */
 export type ClientRequest =
@@ -3054,7 +3086,7 @@ export type ClientRequest =
   | ListToolsRequest;
 
 /** @internal */
-export type ClientNotification = CancelledNotification | ProgressNotification;
+export type ClientNotification = CancelledNotification;
 
 /** @internal */
 export type ClientResult = EmptyResult;
@@ -3070,7 +3102,6 @@ export type ServerNotification =
   | ResourceListChangedNotification
   | ToolListChangedNotification
   | PromptListChangedNotification
-  | ElicitationCompleteNotification
   | SubscriptionsAcknowledgedNotification;
 
 /** @internal */


### PR DESCRIPTION
Re-vendors `schema/draft/schema.ts` from the spec repo at the merge commit of [modelcontextprotocol#2891](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2891) (`2fb207da428f43a4981513ec2aef218b7533c5b3`), which also includes [#2889](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2889) and [#2890](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2890).

## Type changes picked up
- Add `NotificationMetaObject` (with `io.modelcontextprotocol/subscriptionId`)
- Add `HEADER_MISMATCH` (-32001) const and `HeaderMismatchError` interface
- `CancelledNotificationParams.requestId` is now required
- `ClientNotification` narrowed to `CancelledNotification` only
- `ListRootsRequest.params` narrowed (drops `progressToken`)
- Remove `ElicitationCompleteNotification` and `elicitationId`

Also replaces the local `-32001` literal in `src/scenarios/server/http-standard-headers.ts` with the new exported `HEADER_MISMATCH` constant.

## Verification
- `tsc --noEmit` ✓
- `npm test` — 288/288 ✓
- `npm run lint` ✓

This unblocks follow-up conformance PRs for the SEP-2243 header changes and SEP-2575 subscription/cancellation changes.

https://claude.ai/code/session_01Gbqx5LodtAghT5fRYFxeja