### PR TITLE
docs: sync sep-2549 traceability with spec PR #2890

### DIFF
--- a/src/seps/sep-2549.yaml
+++ b/src/seps/sep-2549.yaml
@@ -2,15 +2,15 @@ sep: 2549
 spec_url: https://modelcontextprotocol.io/specification/draft/server/utilities/caching
 requirements:
   - check: sep-2549-tools-list-caching-hints
-    text: 'Servers MUST include caching hints on results returned by tools/list'
+    text: 'Servers MUST include caching hints on results with resultType: "complete" returned by tools/list'
   - check: sep-2549-prompts-list-caching-hints
-    text: 'Servers MUST include caching hints on results returned by prompts/list'
+    text: 'Servers MUST include caching hints on results with resultType: "complete" returned by prompts/list'
   - check: sep-2549-resources-list-caching-hints
-    text: 'Servers MUST include caching hints on results returned by resources/list'
+    text: 'Servers MUST include caching hints on results with resultType: "complete" returned by resources/list'
   - check: sep-2549-resources-templates-list-caching-hints
-    text: 'Servers MUST include caching hints on results returned by resources/templates/list'
+    text: 'Servers MUST include caching hints on results with resultType: "complete" returned by resources/templates/list'
   - check: sep-2549-resources-read-caching-hints
-    text: 'Servers MUST include caching hints on results returned by resources/read'
+    text: 'Servers MUST include caching hints on results with resultType: "complete" returned by resources/read'
   - check: sep-2549-ttl-non-negative
     text: 'Servers MUST provide a ttlMs value that is >= 0'
   - check: sep-2549-cache-scope-valid
@@ -42,3 +42,7 @@ requirements:
     excluded: 'Server-side awareness requirement; implementation guidance not testable via protocol messages'
   - text: 'Server implementors MUST apply appropriate per-primitive access controls, and MUST NOT rely on cacheScope alone to prevent unauthorized access to primitives.'
     excluded: 'Server-side access control; implementation guidance not testable via protocol messages'
+  - text: 'Clients MUST NOT serve a cached response for a request whose method or parameters differ from the request that produced it.'
+    excluded: 'Client-side caching behavior; not observable at the protocol level'
+  - text: 'Results produced by retrying a request through the multi round-trip requests mechanism (requests carrying inputResponses or requestState) MUST NOT be cached.'
+    excluded: 'Client-side caching behavior; not observable at the protocol level'


### PR DESCRIPTION
Syncs `src/seps/sep-2549.yaml` traceability text with the normative caching changes landed in modelcontextprotocol/modelcontextprotocol#2890.

### Changes
- Scope the five `sep-2549-*-caching-hints` requirement texts to results with `resultType: "complete"` — interim `input_required` results carry no caching hints.
- Add two `excluded` rows for the new **Cache Key** section client MUST NOTs:
  - Clients MUST NOT serve a cached response for a request whose method or parameters differ from the request that produced it.
  - Results produced by retrying a request through the multi round-trip requests mechanism (requests carrying `inputResponses` or `requestState`) MUST NOT be cached.

  Both are client-side caching behaviors that are not wire-observable (a conformant client may simply never cache), so they are excluded rather than checked.

No check IDs change. `src/seps/traceability.json` will be refreshed by the scheduled traceability workflow.

https://claude.ai/code/session_01Gbqx5LodtAghT5fRYFxeja