### PR TITLE
chore: bump version to 0.2.0-alpha.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/conformance",
-  "version": "0.2.0-alpha.4",
+  "version": "0.2.0-alpha.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/conformance",
-      "version": "0.2.0-alpha.4",
+      "version": "0.2.0-alpha.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/conformance",
-  "version": "0.2.0-alpha.4",
+  "version": "0.2.0-alpha.5",
   "type": "module",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",


### PR DESCRIPTION
Carries the changes since alpha.4:

- #337 — gate SEP-2350 scope-union check to 2026-07-28+
- #347 — serve `server/discover` from the hand-rolled client-scenario mocks
- #348 / #353 — re-sync vendored `spec-types/draft.ts` and renumber draft error codes per modelcontextprotocol/modelcontextprotocol#2907 (HeaderMismatch `-32020`, MissingRequiredClientCapability `-32021`, UnsupportedProtocolVersion `-32022`)
- #262 — SEP-2663 tasks server-direction scenarios

After merge: dispatch `ci.yml` on `main` with `publish_alpha` checked.