### PR TITLE
fix(auth): make 2025-03-26 backcompat mock RFC 8414 §3.3-compliant

### DIFF
--- a/src/scenarios/client/auth/helpers/createAuthServer.ts
+++ b/src/scenarios/client/auth/helpers/createAuthServer.ts
@@ -59,8 +59,10 @@ export interface AuthServerOptions {
    * Override the `issuer` value served in the AS metadata document. Used to
    * test that clients validate the metadata issuer against the issuer
    * identifier used to construct the well-known URL (RFC 8414 §3.3).
+   * Accepts a lazy getter for callers that don't know the server URL until
+   * after `start()`.
    */
-  metadataIssuer?: string;
+  metadataIssuer?: string | (() => string);
   tokenVerifier?: MockTokenVerifier;
   onTokenRequest?: (requestData: {
     scope?: string;
@@ -156,7 +158,10 @@ export function createAuthServer(
     });
 
     const metadata: any = {
-      issuer: metadataIssuer ?? `${getAuthBaseUrl()}${routePrefix}`,
+      issuer:
+        typeof metadataIssuer === 'function'
+          ? metadataIssuer()
+          : (metadataIssuer ?? `${getAuthBaseUrl()}${routePrefix}`),
       authorization_endpoint: `${getAuthBaseUrl()}${authRoutes.authorization_endpoint}`,
       token_endpoint: `${getAuthBaseUrl()}${authRoutes.token_endpoint}`,
       ...(!disableDynamicRegistration && {

--- a/src/scenarios/client/auth/march-spec-backcompat.ts
+++ b/src/scenarios/client/auth/march-spec-backcompat.ts
@@ -24,9 +24,13 @@ export class Auth20250326OAuthMetadataBackcompatScenario implements Scenario {
     // same URL as the main server (rather than separating AS / RS).
     const authApp = createAuthServer(ctx, this.checks, this.server.getUrl, {
       // Disable logging since the main server will already have logging enabled
-      loggingEnabled: false,
-      // Add a prefix to auth endpoints to avoid being caught by auth fallbacks
-      routePrefix: '/oauth'
+      loggingEnabled: false
+      // No routePrefix: the AS metadata is served at the root well-known path,
+      // so the metadata `issuer` must be the bare origin (RFC 8414 §3.3). A
+      // routePrefix here would make `createAuthServer` report
+      // `issuer: <origin>/oauth`, which an RFC 8414-conforming client correctly
+      // rejects. The MCP server only mounts `/mcp`, so the unprefixed
+      // `/authorize`, `/token`, `/register` routes do not collide.
     });
     const app = createServer(
       ctx,

--- a/src/scenarios/client/auth/march-spec-backcompat.ts
+++ b/src/scenarios/client/auth/march-spec-backcompat.ts
@@ -24,13 +24,13 @@ export class Auth20250326OAuthMetadataBackcompatScenario implements Scenario {
     // same URL as the main server (rather than separating AS / RS).
     const authApp = createAuthServer(ctx, this.checks, this.server.getUrl, {
       // Disable logging since the main server will already have logging enabled
-      loggingEnabled: false
-      // No routePrefix: the AS metadata is served at the root well-known path,
-      // so the metadata `issuer` must be the bare origin (RFC 8414 §3.3). A
-      // routePrefix here would make `createAuthServer` report
-      // `issuer: <origin>/oauth`, which an RFC 8414-conforming client correctly
-      // rejects. The MCP server only mounts `/mcp`, so the unprefixed
-      // `/authorize`, `/token`, `/register` routes do not collide.
+      loggingEnabled: false,
+      // Keep auth endpoints off the 2025-03-26 fallback paths so a client that
+      // fetches metadata but ignores the advertised endpoints still 404s.
+      routePrefix: '/oauth',
+      // Metadata is served at the root well-known path, so per RFC 8414 §3.3
+      // the `issuer` must be the bare origin — not `<origin>/oauth`.
+      metadataIssuer: () => this.server.getUrl()
     });
     const app = createServer(
       ctx,


### PR DESCRIPTION
The `auth/2025-03-26-oauth-metadata-backcompat` scenario tests that an MCP client can still discover and authenticate when the server uses the [March 2025 spec layout](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization): no Protected Resource Metadata, OAuth Authorization Server Metadata served at the root `/.well-known/oauth-authorization-server`. That property is still worth testing in `--suite all`.

The mock's *configuration* has a latent bug unrelated to that property: it passes `routePrefix: '/oauth'`, which makes `createAuthServer` report `issuer: '<origin>/oauth'` in the metadata while serving that metadata at the root well-known path. [RFC 8414 §3.3](https://datatracker.ietf.org/doc/html/rfc8414#section-3.3) requires that *"the `issuer` value returned MUST be identical to the authorization server's issuer identifier value into which the well-known URI string was inserted"* — i.e., metadata served at the root well-known path must have `issuer: '<origin>'` with no path component. A real March-2025-era authorization server following RFC 8414 (published 2018) would have been compliant; the mismatch here is an artifact of how `routePrefix` and the default `metadataPath` interact.

This was invisible until [SEP-2468](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2468) made the §3.3 check a client **MUST** in the 2026-07-28 spec ([authorization-server-discovery.mdx](https://modelcontextprotocol.io/specification/draft/basic/authorization/authorization-server-discovery): *"the `issuer` value in the document **MUST** be identical to the issuer identifier used to construct the well-known URL. If they differ, the client **MUST NOT** use the metadata"*). A client implementing that MUST now correctly rejects the mock's metadata, so the scenario and SEP-2468 cannot both pass as written.

## Motivation and Context

Dropping `routePrefix` makes the mock §3.3-compliant without changing what the scenario tests. The route prefix existed to avoid collisions with the MCP server routes, but `createServer` only mounts `/mcp` (and the PRM path, which is `null` here), so unprefixed `/authorize`, `/token`, `/register` are fine — the sibling `auth/2025-03-26-oauth-endpoint-fallback` scenario in the same file already mounts them at root.

## How Has This Been Tested?

CI will verify; local `npm ci` was blocked by registry access in my environment. The change is a single options-property removal.

## Breaking Changes

None — fixes a mock configuration bug; no API or behavior change for clients that don't enforce §3.3.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Surfaced while landing SEP-2468 in typescript-sdk: with §3.3 default-on, this is the only `auth/*` scenario that regresses, and only because of the mock's `issuer`/well-known mismatch.