### PR TITLE
fix(auth): callback `iss` must equal metadata `issuer` (honor metadataIssuer override)

### DIFF
--- a/src/scenarios/client/auth/helpers/createAuthServer.ts
+++ b/src/scenarios/client/auth/helpers/createAuthServer.ts
@@ -127,6 +127,14 @@ export function createAuthServer(
     registration_endpoint: `${routePrefix}/register`
   };
 
+  // The issuer identifier this AS publishes — used for both the metadata
+  // `issuer` field and the RFC 9207 callback `iss` parameter, which per
+  // RFC 9207 §2.4 must be identical under simple string comparison.
+  const resolveIssuer = () =>
+    typeof metadataIssuer === 'function'
+      ? metadataIssuer()
+      : (metadataIssuer ?? `${getAuthBaseUrl()}${routePrefix}`);
+
   const app = express();
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));
@@ -158,10 +166,7 @@ export function createAuthServer(
     });
 
     const metadata: any = {
-      issuer:
-        typeof metadataIssuer === 'function'
-          ? metadataIssuer()
-          : (metadataIssuer ?? `${getAuthBaseUrl()}${routePrefix}`),
+      issuer: resolveIssuer(),
       authorization_endpoint: `${getAuthBaseUrl()}${authRoutes.authorization_endpoint}`,
       token_endpoint: `${getAuthBaseUrl()}${authRoutes.token_endpoint}`,
       ...(!disableDynamicRegistration && {
@@ -274,16 +279,19 @@ export function createAuthServer(
       redirectUrl.searchParams.set('state', state);
     }
 
-    // ISS: Include iss parameter in redirect if configured
+    // ISS: Include iss parameter in redirect if configured. The 'correct'
+    // value must equal the metadata `issuer` exactly (RFC 9207 §2.4 simple
+    // string comparison), so honor the same metadataIssuer override the
+    // metadata document does.
     if (issInRedirect === 'correct') {
-      redirectUrl.searchParams.set('iss', `${getAuthBaseUrl()}${routePrefix}`);
+      redirectUrl.searchParams.set('iss', resolveIssuer());
     } else if (issInRedirect === 'wrong') {
       redirectUrl.searchParams.set('iss', 'https://evil.example.com');
     } else if (issInRedirect === 'normalized') {
       // Normalization-equivalent variant of the correct issuer: identical
       // after RFC 3986 scheme-based normalization (trailing slash on an
       // empty path) but different under simple string comparison.
-      redirectUrl.searchParams.set('iss', `${getAuthBaseUrl()}${routePrefix}/`);
+      redirectUrl.searchParams.set('iss', `${resolveIssuer()}/`);
     }
 
     res.redirect(redirectUrl.toString());


### PR DESCRIPTION
The mock AS's authorization-response `iss` and its published metadata `issuer` are the same identifier by definition (RFC 9207 §2: "the authorization server's issuer identifier ... MUST be identical to the value in the `issuer` field of the authorization server metadata"). RFC 9207 §2.4 then requires clients to compare the received `iss` against the metadata `issuer` via simple string comparison and reject on any difference.

`createAuthServer` derived these two values independently:
- metadata `issuer` honors `metadataIssuer` (since #359)
- callback `iss='correct'` was still `getAuthBaseUrl() + routePrefix`

So a scenario that sets `metadataIssuer` (to satisfy RFC 8414 §3.3) while keeping a `routePrefix` — exactly what `auth/2025-03-26-oauth-metadata-backcompat` does after #359 — produces a mock whose callback `iss` doesn't match its own metadata. An RFC 9207-conforming client correctly rejects it, and the scenario becomes un-passable for the wrong reason.

This extracts a single `resolveIssuer()` and uses it for both the metadata `issuer` and the `'correct'`/`'normalized'` callback `iss`, so they're identical by construction. Scenarios that want a deliberate mismatch already use `issInRedirect: 'wrong'`, which is unchanged.

## Motivation and Context
Follow-up to #359. Surfaced by typescript-sdk#2344 turning RFC 9207 validation default-on: `IssuerMismatchError: expected "http://localhost:45193", received "http://localhost:45193/oauth"`.

## How Has This Been Tested?
Ran `auth/2025-03-26-oauth-metadata-backcompat` against typescript-sdk at the SEP-2468 head; passes with this change (fails without). Existing `iss-*` scenarios unaffected (they don't set `metadataIssuer`, so `resolveIssuer()` falls through to the original derivation).

## Breaking Changes
None — `resolveIssuer()` returns exactly what each call site computed before when `metadataIssuer` is unset.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
Once this lands in a published release, typescript-sdk can drop the `auth/2025-03-26-oauth-metadata-backcompat` expected-failure entry.