### PR TITLE
chore: bump version to 0.2.0-alpha.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/conformance",
-  "version": "0.2.0-alpha.5",
+  "version": "0.2.0-alpha.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/conformance",
-      "version": "0.2.0-alpha.5",
+      "version": "0.2.0-alpha.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/conformance",
-  "version": "0.2.0-alpha.5",
+  "version": "0.2.0-alpha.6",
   "type": "module",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",


### PR DESCRIPTION
Bump to `0.2.0-alpha.6` to publish #361.

## Motivation and Context
Ships the auth callback `iss` / `metadataIssuer` fix (#361) to npm under the `alpha` tag so downstream SDK CI can pick it up.

## How Has This Been Tested?
Version bump only; CI runs the full suite on this PR.

## Breaking Changes
None.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Checklist
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
After merge: dispatch `.github/workflows/ci.yml` on `main` with `publish_alpha=true` to publish to npm.