### PR TITLE
fix(server-sse-polling): send mcp-protocol-version 2025-11-25 (the version this scenario tests)

### DIFF
--- a/src/scenarios/server/sse-polling.ts
+++ b/src/scenarios/server/sse-polling.ts
@@ -138,7 +138,7 @@ export class ServerSSEPollingScenario implements ClientScenario {
           'Content-Type': 'application/json',
           Accept: 'text/event-stream, application/json',
           ...(sessionId && { 'mcp-session-id': sessionId }),
-          'mcp-protocol-version': '2025-03-26'
+          'mcp-protocol-version': '2025-11-25'
         },
         body: JSON.stringify({
           jsonrpc: '2.0',
@@ -417,7 +417,7 @@ export class ServerSSEPollingScenario implements ClientScenario {
           headers: {
             Accept: 'text/event-stream',
             'mcp-session-id': sessionId,
-            'mcp-protocol-version': '2025-03-26',
+            'mcp-protocol-version': '2025-11-25',
             'last-event-id': lastEventId
           }
         });


### PR DESCRIPTION
The `server-sse-polling` scenario has `introducedIn: '2025-11-25'` and tests SEP-1699 priming events (which require empty-data SSE support, introduced in `2025-11-25`). But the scenario's raw-fetch probes send `mcp-protocol-version: '2025-03-26'`.

A server that correctly version-gates priming events (suppressing them for clients whose declared version predates empty-data SSE support) will never emit a priming event for this scenario, so the scenario emits `WARNING: Server did not send priming event` against a conformant implementation.

## How Has This Been Tested?

Verified against `typescript-sdk@v2-2026-07-28` (which gates priming on `protocolVersion >= '2025-11-25'`): with this fix, `server-sse-polling` goes from `WARNING` to `✓ 3 passed, 0 failed`.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
