### PR TITLE
fix(http-custom-headers): use spec-permitted x-mcp-header types

### DIFF
--- a/src/scenarios/client/http-custom-headers.ts
+++ b/src/scenarios/client/http-custom-headers.ts
@@ -321,7 +321,7 @@ export class HttpCustomHeadersScenario extends BaseHttpScenario {
                 float_val: {
                   type: 'number',
                   description:
-                    'Floating point numeric value — no x-mcp-header annotation: the spec forbids x-mcp-header on `number`-typed properties, so this is sent in the body but never mirrored'
+                    'Floating point value — no x-mcp-header annotation, should not be mirrored'
                 },
                 non_ascii_val: {
                   type: 'string',
@@ -475,9 +475,9 @@ export class HttpCustomHeadersScenario extends BaseHttpScenario {
         this.checkParamHeader(req, 'Method', args.method_val, 'string');
       }
 
-      // float_val is intentionally unannotated (the spec forbids x-mcp-header on
-      // `number`-typed properties), so it MUST NOT be mirrored. Assert the absence,
-      // mirroring the negative check applied to the unannotated `query` parameter.
+      // float_val is intentionally unannotated: SEP-2243 forbids x-mcp-header on
+      // `number`-typed properties, so it is served without one. Assert no header
+      // was sent — same "designated params only" rule as the `query` check below.
       const floatHeader = req.headers['mcp-param-floatval'] as
         | string
         | undefined;
@@ -485,7 +485,7 @@ export class HttpCustomHeadersScenario extends BaseHttpScenario {
         id: 'sep-2243-client-mirrors-designated-params',
         name: 'ClientCustomHeaderNoMirrorNumber',
         description:
-          'Client MUST NOT add an Mcp-Param header for a `number`-typed parameter (x-mcp-header is not permitted on it)',
+          'Client MUST NOT add Mcp-Param headers for parameters without x-mcp-header (number-typed float_val is served unannotated per SEP-2243)',
         status: floatHeader === undefined ? 'SUCCESS' : 'FAILURE',
         timestamp: new Date().toISOString(),
         errorMessage:

--- a/src/scenarios/client/http-custom-headers.ts
+++ b/src/scenarios/client/http-custom-headers.ts
@@ -127,7 +127,7 @@ function validateEncodedHeader(
       return `Value '${bodyValue}' requires Base64 encoding but header was sent as plain: '${rawHeader}'`;
     }
     const decoded = Buffer.from(base64Match[1], 'base64').toString('utf-8');
-    if (valueType === 'number') {
+    if (valueType === 'number' || valueType === 'integer') {
       return compareNumericValues(decoded, bodyValue);
     }
     if (decoded !== bodyValue) {
@@ -137,7 +137,7 @@ function validateEncodedHeader(
   }
   // Plain ASCII - compare directly (after decoding if Base64 was used)
   const decoded = decodeHeaderValue(rawHeader);
-  if (valueType === 'number') {
+  if (valueType === 'number' || valueType === 'integer') {
     return compareNumericValues(decoded, bodyValue);
   }
   if (decoded !== bodyValue) {
@@ -293,7 +293,7 @@ export class HttpCustomHeadersScenario extends BaseHttpScenario {
                   'x-mcp-header': 'Region'
                 },
                 priority: {
-                  type: 'number',
+                  type: 'integer',
                   description: 'Integer numeric value',
                   'x-mcp-header': 'Priority'
                 },
@@ -320,8 +320,8 @@ export class HttpCustomHeadersScenario extends BaseHttpScenario {
                 },
                 float_val: {
                   type: 'number',
-                  description: 'Floating point numeric value',
-                  'x-mcp-header': 'FloatVal'
+                  description:
+                    'Floating point numeric value — no x-mcp-header annotation: the spec forbids x-mcp-header on `number`-typed properties, so this is sent in the body but never mirrored'
                 },
                 non_ascii_val: {
                   type: 'string',
@@ -393,7 +393,7 @@ export class HttpCustomHeadersScenario extends BaseHttpScenario {
                   'x-mcp-header': 'Region'
                 },
                 priority: {
-                  type: 'number',
+                  type: 'integer',
                   description: 'Integer numeric value',
                   'x-mcp-header': 'Priority'
                 },
@@ -449,8 +449,8 @@ export class HttpCustomHeadersScenario extends BaseHttpScenario {
       // Check Mcp-Param-Region header (plain ASCII string)
       this.checkParamHeader(req, 'Region', args.region, 'string');
 
-      // Check Mcp-Param-Priority header (integer number)
-      this.checkParamHeader(req, 'Priority', args.priority, 'number');
+      // Check Mcp-Param-Priority header (integer)
+      this.checkParamHeader(req, 'Priority', args.priority, 'integer');
 
       // Check Mcp-Param-Verbose header (boolean value)
       // checkParamHeader already FAILs on missing header, so this also covers
@@ -475,10 +475,25 @@ export class HttpCustomHeadersScenario extends BaseHttpScenario {
         this.checkParamHeader(req, 'Method', args.method_val, 'string');
       }
 
-      // Check Mcp-Param-FloatVal header (floating point number)
-      if (args.float_val !== undefined && args.float_val !== null) {
-        this.checkParamHeader(req, 'FloatVal', args.float_val, 'number');
-      }
+      // float_val is intentionally unannotated (the spec forbids x-mcp-header on
+      // `number`-typed properties), so it MUST NOT be mirrored. Assert the absence,
+      // mirroring the negative check applied to the unannotated `query` parameter.
+      const floatHeader = req.headers['mcp-param-floatval'] as
+        | string
+        | undefined;
+      this.checks.push({
+        id: 'sep-2243-client-mirrors-designated-params',
+        name: 'ClientCustomHeaderNoMirrorNumber',
+        description:
+          'Client MUST NOT add an Mcp-Param header for a `number`-typed parameter (x-mcp-header is not permitted on it)',
+        status: floatHeader === undefined ? 'SUCCESS' : 'FAILURE',
+        timestamp: new Date().toISOString(),
+        errorMessage:
+          floatHeader !== undefined
+            ? `Found unexpected Mcp-Param-FloatVal header '${floatHeader}' for an unannotated number parameter`
+            : undefined,
+        specReferences: [SPEC_REFERENCE_CUSTOM]
+      });
 
       // Check Mcp-Param-NonAscii header (requires Base64 encoding)
       if (args.non_ascii_val !== undefined && args.non_ascii_val !== null) {
@@ -652,7 +667,9 @@ export class HttpCustomHeadersScenario extends BaseHttpScenario {
       typeof bodyValue === 'string' && needsBase64Encoding(String(bodyValue));
     const checkId = needsBase64
       ? 'sep-2243-client-base64-unsafe'
-      : valueType === 'number' || valueType === 'boolean'
+      : valueType === 'number' ||
+          valueType === 'integer' ||
+          valueType === 'boolean'
         ? 'sep-2243-client-encode-values'
         : 'sep-2243-client-mirrors-designated-params';
 


### PR DESCRIPTION
## Summary

The `http-custom-headers` client scenario annotates three `number`-typed properties with `x-mcp-header` (`priority` and `float_val`, in both `test_custom_headers` and `test_custom_headers_null`). [SEP-2243](https://modelcontextprotocol.io/specification/draft/server/tools#x-mcp-header) forbids this:

> **MUST** only be applied to parameters with primitive types (integer, string, boolean). Parameters with type `number` are not permitted.

The same spec says a conformant client **MUST reject** (exclude from `tools/list`) any tool whose `x-mcp-header` annotations violate the constraints:

> Clients **MUST** reject tool definitions where any `x-mcp-header` value violates these constraints. Rejection means the client **MUST** exclude the invalid tool from the result of `tools/list`.

So a strict, spec-conformant client drops both `test_custom_headers` and `test_custom_headers_null` and never calls them - failing `ClientSupportsCustomHeaders` (and `ClientCustomHeaderOmitNull`) through no fault of its own. The fixture is internally inconsistent: it requires the client both to reject the tool (per the type constraint) and to call it and mirror its params.

This surfaced while implementing SEP-2243 client emission in the Python SDK (modelcontextprotocol/python-sdk#2990): the SDK rejects `number` per the spec text, so the scenario is unpassable as written. The TypeScript SDK works around it by deliberately allow-listing `number` against the spec ([note in `mcpParamHeaders.ts`](https://github.com/modelcontextprotocol/typescript-sdk/blob/v2-2026-07-28/packages/core/src/shared/mcpParamHeaders.ts)). Fixing the fixture lets both SDKs follow the spec text.

## Changes

- `priority`: `number` -> `integer` (both tools). Its value (`42` / `1`) and the resulting `Mcp-Param-Priority` header are unchanged.
- `float_val`: drop the `x-mcp-header` annotation. A floating-point header parameter is exactly what the spec prohibits and has no valid replacement; the property stays in the body and is now asserted **not** to be mirrored, mirroring the existing negative check on the unannotated `query` parameter.
- Treat `'integer'` like `'number'` in `validateEncodedHeader` and the check-id classification, so `Priority` keeps its cross-SDK numeric tolerance (`42` vs `42.0`) and lands under `sep-2243-client-encode-values`.

## Verification

```sh
npm run typecheck
npm run lint
npm run build
npx vitest run src/scenarios/client/http-custom-headers.test.ts   # 5 passed
npm test                                                          # 315 passed
```

All pass.