### PR TITLE
fix(sse-retry): gate retry timing only on the early side

### DIFF
--- a/src/scenarios/client/sse-retry.ts
+++ b/src/scenarios/client/sse-retry.ts
@@ -42,10 +42,8 @@ export class SSERetryScenario implements Scenario {
   private pendingToolCallId: number | string | null = null;
   private getResponseStream: http.ServerResponse | null = null;
 
-  // Tolerances for timing validation
+  // Tolerance for timing validation (early side only; lateness is not gated)
   private readonly EARLY_TOLERANCE = 50; // Allow 50ms early for scheduler variance
-  private readonly LATE_TOLERANCE = 200; // Allow 200ms late for network/event loop
-  private readonly VERY_LATE_MULTIPLIER = 2; // If >2x retry value, client is likely ignoring it
 
   async start(_ctx: ScenarioContext): Promise<ScenarioUrls> {
     return new Promise((resolve, reject) => {
@@ -290,7 +288,8 @@ export class SSERetryScenario implements Scenario {
       jsonrpc: '2.0',
       id: request.id,
       result: {
-        protocolVersion: '2025-03-26',
+        // The retry MUST under test was introduced in 2025-11-25 (SEP-1699)
+        protocolVersion: '2025-11-25',
         serverInfo: {
           name: 'sse-retry-test-server',
           version: '1.0.0'
@@ -459,39 +458,22 @@ export class SSERetryScenario implements Scenario {
     ) {
       const actualDelay = this.getReconnectionTime - this.toolStreamCloseTime;
       const minExpected = this.retryValue - this.EARLY_TOLERANCE;
-      const maxExpected = this.retryValue + this.LATE_TOLERANCE;
 
+      // The retry MUST is a lower bound ("waiting the given number of
+      // milliseconds before attempting to reconnect"), so only an early
+      // reconnect fails; lateness is environment latency and is not gated.
       const tooEarly = actualDelay < minExpected;
-      const slightlyLate = actualDelay > maxExpected;
-      const veryLate =
-        actualDelay > this.retryValue * this.VERY_LATE_MULTIPLIER;
-      const withinTolerance = !tooEarly && !slightlyLate;
-
-      let status: 'SUCCESS' | 'FAILURE' | 'WARNING' = 'SUCCESS';
-      let errorMessage: string | undefined;
-
-      if (tooEarly) {
-        // Client reconnected too soon - MUST violation
-        status = 'FAILURE';
-        errorMessage = `Client reconnected too early (${actualDelay.toFixed(0)}ms instead of ${this.retryValue}ms). Client MUST respect the retry field and wait the specified time.`;
-      } else if (veryLate) {
-        // Client reconnected way too late - likely ignoring retry field entirely
-        status = 'FAILURE';
-        errorMessage = `Client reconnected very late (${actualDelay.toFixed(0)}ms instead of ${this.retryValue}ms). Client appears to be ignoring the retry field and using its own backoff strategy.`;
-      } else if (slightlyLate) {
-        // Client reconnected slightly late - not a spec violation but suspicious
-        status = 'WARNING';
-        errorMessage = `Client reconnected slightly late (${actualDelay.toFixed(0)}ms instead of ${this.retryValue}ms). This is acceptable but may indicate network delays.`;
-      }
 
       this.checks.push({
         id: 'client-sse-retry-timing',
         name: 'ClientRespectsRetryField',
         description:
           'Client MUST respect the retry field, waiting the given number of milliseconds before attempting to reconnect',
-        status,
+        status: tooEarly ? 'FAILURE' : 'SUCCESS',
         timestamp: new Date().toISOString(),
-        errorMessage,
+        errorMessage: tooEarly
+          ? `Client reconnected too early (${actualDelay.toFixed(0)}ms instead of ${this.retryValue}ms). Client MUST respect the retry field and wait the specified time.`
+          : undefined,
         specReferences: [
           {
             id: 'SEP-1699',
@@ -502,14 +484,7 @@ export class SSERetryScenario implements Scenario {
           expectedRetryMs: this.retryValue,
           actualDelayMs: Math.round(actualDelay),
           minAcceptableMs: minExpected,
-          maxAcceptableMs: maxExpected,
-          veryLateThresholdMs: this.retryValue * this.VERY_LATE_MULTIPLIER,
           earlyToleranceMs: this.EARLY_TOLERANCE,
-          lateToleranceMs: this.LATE_TOLERANCE,
-          withinTolerance,
-          tooEarly,
-          slightlyLate,
-          veryLate,
           getConnectionCount: this.getConnectionCount
         }
       });
@@ -518,7 +493,7 @@ export class SSERetryScenario implements Scenario {
         id: 'client-sse-retry-timing',
         name: 'ClientRespectsRetryField',
         description: 'Client MUST respect the retry field timing',
-        status: 'WARNING',
+        status: 'INFO',
         timestamp: new Date().toISOString(),
         errorMessage:
           'Could not measure timing - tool stream close time or GET reconnection time not recorded',


### PR DESCRIPTION
## Problem

`sse-retry` flakes in python-sdk CI (~4–5% of runs, including recent failures on every push to main), always with the signature `✗ sse-retry: 2 passed, 0 failed, 1 warnings` — the retry-timing check landing in its (700, 1000]ms "slightly late" WARNING band, which fails the scenario under the WARNING policy (#245). Example run: https://github.com/modelcontextprotocol/python-sdk/actions/runs/28443055485

The 2025-11-25 spec sentence is "The client **MUST** respect the `retry` field, waiting the given number of milliseconds **before** attempting to reconnect" — a lower bound. Neither MCP nor WHATWG SSE bounds reconnect delay from above. The measured delay is the client's sleep (≥ retry) plus EOF detection, GET propagation, and harness dispatch — all inflated by load, and suite mode runs every scenario's client concurrently. Measured locally with the python client: 503ms idle against the 700ms gate, 591–674ms with the suite pinned to 2 cores. The band gates the environment, not the client.

## Change (one file, +11/−36)

- Delete the slightly-late WARNING and >2× FAILURE bands: the timing check is now FAILURE only when the reconnect arrives earlier than `retry − 50ms`, otherwise SUCCESS, with the measured delay kept in `details`. Load can only push a compliant client deeper into the passing region, so the flake is structurally gone.
- Demote the "could not measure timing" path from WARNING to INFO (the other spurious-warning path).
- One-line fix: the initialize response negotiated `protocolVersion: 2025-03-26`, a version whose spec had no retry MUST; now 2025-11-25 (same issue 4686e06 fixed for server-sse-polling).

Strictly relaxing — no SDK that passes today can start failing on a pin bump; retry stays at 500ms so test duration is unchanged.

Trade-off accepted: the >2× band was the only (unsound) detector for clients that ignore the retry field — a client's ~1000ms default backoff sat near that threshold by coincidence, and a loaded runner pushed compliant clients over it. With the band gone, retry-field-ignorance is untested, which seems proportionate for a scenario that is removed in draft.

## Verification

- python-sdk client, real run: 3/3 SUCCESS (`actualDelayMs: 502`).
- python-sdk client patched to ignore the retry hint (reconnects at its 1000ms fallback, previously red): now passes, delay recorded in details.
- `npm run test` 328 passed; typecheck and lint clean.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
