### PR TITLE
fix(server-stateless): requiredCapabilities is a ClientCapabilities object, not an array

### DIFF
--- a/examples/servers/typescript/everything-server.ts
+++ b/examples/servers/typescript/everything-server.ts
@@ -1663,7 +1663,9 @@ app.post('/mcp', async (req, res) => {
             error: {
               code: -32021,
               message: 'MissingRequiredClientCapabilityError',
-              data: { requiredCapabilities: ['sampling'] }
+              // Per the schema, requiredCapabilities is a ClientCapabilities
+              // object keyed by the missing capability, not an array of names.
+              data: { requiredCapabilities: { sampling: {} } }
             }
           });
         }

--- a/src/scenarios/server/stateless.test.ts
+++ b/src/scenarios/server/stateless.test.ts
@@ -186,13 +186,16 @@ describe('Stateless Server Scenario Negative Tests', () => {
     expect(statusCheck?.errorMessage).toContain('Not testable:');
   });
 
-  test('Fails the capability check when the listed diagnostic tool executes without -32021', async () => {
-    // This server lists test_missing_capability but happily executes it even
-    // though the client never declared the sampling capability — a genuine
-    // violation of the MUST, not an untestable gap.
-    const mockUrl = mockFetchTarget((reqBody) => {
+  // A server that lists test_missing_capability and answers its probe call
+  // with the given response; shared by the capability-shape tests below so
+  // the fixture contract lives in one place.
+  function capabilityProbeMock(
+    label: string,
+    callResponse: { status: number; body: object }
+  ) {
+    return mockFetchTarget((reqBody) => {
       if (reqBody.method === 'server/discover') {
-        return discoverResponse(reqBody, { tools: {} }, 'no-enforcement');
+        return discoverResponse(reqBody, { tools: {} }, label);
       }
       if (reqBody.method === 'tools/list') {
         return {
@@ -209,14 +212,28 @@ describe('Stateless Server Scenario Negative Tests', () => {
         reqBody.params?.name === 'test_missing_capability'
       ) {
         return {
-          status: 200,
-          body: {
-            jsonrpc: '2.0',
-            id: reqBody.id,
-            result: { resultType: 'complete', content: [] }
-          }
+          status: callResponse.status,
+          body: { jsonrpc: '2.0', id: reqBody.id, ...callResponse.body }
         };
       }
+    });
+  }
+
+  const spec32021 = (requiredCapabilities: unknown) => ({
+    error: {
+      code: -32021,
+      message: 'MissingRequiredClientCapabilityError',
+      data: { requiredCapabilities }
+    }
+  });
+
+  test('Fails the capability check when the listed diagnostic tool executes without -32021', async () => {
+    // This server lists test_missing_capability but happily executes it even
+    // though the client never declared the sampling capability — a genuine
+    // violation of the MUST, not an untestable gap.
+    const mockUrl = capabilityProbeMock('no-enforcement', {
+      status: 200,
+      body: { result: { resultType: 'complete', content: [] } }
     });
 
     const scenario = new ServerStatelessScenario();
@@ -228,6 +245,62 @@ describe('Stateless Server Scenario Negative Tests', () => {
     );
     expect(rejectCheck?.status).toBe('FAILURE');
     expect(rejectCheck?.errorMessage).toContain('MUST reject with -32021');
+  });
+
+  test('Passes the capability checks on a spec-shaped -32021: requiredCapabilities is a ClientCapabilities object', async () => {
+    // The schema's MissingRequiredClientCapabilityError carries
+    // `data.requiredCapabilities` as a ClientCapabilities OBJECT keyed by the
+    // missing capability (e.g. `{ "sampling": {} }`), not an array of names.
+    const mockUrl = capabilityProbeMock('spec-shaped-32021', {
+      status: 400,
+      body: spec32021({ sampling: {} })
+    });
+
+    const scenario = new ServerStatelessScenario();
+    const checks = await scenario.run(testContext(mockUrl));
+
+    expect(
+      findCheck(checks, 'sep-2575-server-rejects-undeclared-capability')?.status
+    ).toBe('SUCCESS');
+    expect(
+      findCheck(checks, 'sep-2575-missing-capability-http-400')?.status
+    ).toBe('SUCCESS');
+  });
+
+  test('Fails the capability check when requiredCapabilities is an array of names instead of the schema object', async () => {
+    const mockUrl = capabilityProbeMock('array-shaped-32021', {
+      status: 400,
+      body: spec32021(['sampling'])
+    });
+
+    const scenario = new ServerStatelessScenario();
+    const checks = await scenario.run(testContext(mockUrl));
+
+    const rejectCheck = findCheck(
+      checks,
+      'sep-2575-server-rejects-undeclared-capability'
+    );
+    expect(rejectCheck?.status).toBe('FAILURE');
+    expect(rejectCheck?.errorMessage).toContain('ClientCapabilities object');
+  });
+
+  test('Fails the capability check when the sampling capability value is not an object (e.g. null)', async () => {
+    // ClientCapabilities values are themselves objects; `{ sampling: null }`
+    // is schema-invalid and must not be certified.
+    const mockUrl = capabilityProbeMock('null-valued-32021', {
+      status: 400,
+      body: spec32021({ sampling: null })
+    });
+
+    const scenario = new ServerStatelessScenario();
+    const checks = await scenario.run(testContext(mockUrl));
+
+    const rejectCheck = findCheck(
+      checks,
+      'sep-2575-server-rejects-undeclared-capability'
+    );
+    expect(rejectCheck?.status).toBe('FAILURE');
+    expect(rejectCheck?.errorMessage).toContain('ClientCapabilities object');
   });
 
   test('Fails the subscription checks when listChanged is advertised but listen is rejected', async () => {

--- a/src/scenarios/server/stateless.ts
+++ b/src/scenarios/server/stateless.ts
@@ -43,7 +43,7 @@ export class ServerStatelessScenario implements ClientScenario {
    - Mismatched or unknown protocol versions must return an \`UnsupportedProtocolVersionError\` (HTTP status code \`400 Bad Request\`) carrying precise version tracking arrays.
    - Absent or altered protocol version header metadata must trigger a \`-32020 Header Mismatch\` error with an HTTP 400 boundary state.
 4. **Client Capability Constraints (2 Checks)**
-   - Accessing platform capabilities without explicit declaration drops requests with a \`-32021 MissingRequiredClientCapabilityError\` containing needed capabilities, returning an HTTP status code \`400 Bad Request\`.
+   - Accessing platform capabilities without explicit declaration drops requests with a \`-32021 MissingRequiredClientCapabilityError\` returning an HTTP status code \`400 Bad Request\`. Its \`error.data.requiredCapabilities\` is a \`ClientCapabilities\` object keyed by the missing capability (e.g. \`{ "sampling": {} }\`), not an array of names.
 5. **Methods & Routing Mechanics (5 Checks)**
    - Removed legacy endpoints (\`initialize\`, \`ping\`, \`logging/setLevel\`, etc.) or generic unknown methods must cleanly yield an HTTP status code \`404 Not Found\` alongside a JSON-RPC \`-32601 Method not found\` payload. All error returns must preserve original request ID mappings.
    - Validates response streams contain only \`IncompleteResult\` chunks and never independent top-level JSON-RPC requests, while enforcing that no log messages are emitted when \`_meta.../logLevel\` is omitted.
@@ -693,11 +693,17 @@ export class ServerStatelessScenario implements ClientScenario {
           };
         }
 
-        // If it DOES return -32021, strictly validate the requirement payload structure
+        // If it DOES return -32021, strictly validate the requirement payload
+        // structure. Per the schema's `MissingRequiredClientCapabilityError`,
+        // `error.data.requiredCapabilities` is a `ClientCapabilities` OBJECT
+        // keyed by the missing capability — not an array of capability names —
+        // and each capability value is itself an object.
         const reqCaps = data401?.error?.data?.requiredCapabilities;
-        if (!Array.isArray(reqCaps) || !reqCaps.includes('sampling')) {
+        const isPlainObject = (value: unknown): boolean =>
+          typeof value === 'object' && value !== null && !Array.isArray(value);
+        if (!isPlainObject(reqCaps) || !isPlainObject(reqCaps.sampling)) {
           return {
-            error: `Server responded with error code -32021 but failed to provide an array containing the expected 'sampling' capability in error.data.requiredCapabilities`,
+            error: `Server responded with error code -32021 but error.data.requiredCapabilities is not a ClientCapabilities object naming 'sampling' (the schema defines it as an object of capability objects, e.g. { "sampling": {} }, not an array)`,
             details: { response: data401 }
           };
         }


### PR DESCRIPTION
`sep-2575-server-rejects-undeclared-capability` requires `error.data.requiredCapabilities` to be an array containing `'sampling'`. The schema defines it as a `ClientCapabilities` object, so a spec-correct server cannot pass the check.

## Motivation and Context

**Spec** — [`schema/draft/schema.ts#L482`](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/c87328cceac49aa2c95b5b948891cedebb74f96f/schema/draft/schema.ts#L482) ([rendered](https://modelcontextprotocol.io/specification/draft/schema#missingrequiredclientcapabilityerror)):

```ts
export interface MissingRequiredClientCapabilityError extends Omit<JSONRPCErrorResponse, "error"> {
  error: Error & {
    code: typeof MISSING_REQUIRED_CLIENT_CAPABILITY;
    data: {
      requiredCapabilities: ClientCapabilities;
    };
  };
}
```

and the spec's own example, [`missing-elicitation-capability.json`](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/c87328cceac49aa2c95b5b948891cedebb74f96f/schema/draft/examples/MissingRequiredClientCapabilityError/missing-elicitation-capability.json):

```json
"data": { "requiredCapabilities": { "elicitation": {} } }
```

Both have carried the object shape since the commit that introduced SEP-2575 ([`8e192a22`](https://github.com/modelcontextprotocol/modelcontextprotocol/commit/8e192a2277251483768fb254fee4fc3b8da3944f), May 11) — it was never an array at any point. The array assertion arrived a week later in the initial scenario scaffold (#271, May 19) without a spec citation, plausibly from the prose "whose `data.requiredCapabilities` *lists* the missing capabilities" ([basic/index](https://modelcontextprotocol.io/specification/draft/basic#meta)), which reads array-ish in isolation; the schema and example are unambiguous.

This repo already uses the object everywhere else — [`src/spec-types/draft.ts#L499`](https://github.com/modelcontextprotocol/conformance/blob/4944b268062f3c9cbde876e50845e974f59b6a72/src/spec-types/draft.ts#L499) types it as `ClientCapabilities`, and [`tasks/required-task-error.ts#L192`](https://github.com/modelcontextprotocol/conformance/blob/4944b268062f3c9cbde876e50845e974f59b6a72/src/scenarios/server/tasks/required-task-error.ts#L192) asserts `data.requiredCapabilities.extensions[...]` as an object. The array assertion went unnoticed because it is only reachable once a server actually returns `-32021`, and that positive branch had no self-test.

**Before / after**, against a real server (typescript-sdk's conformance everythingServer) answering the probe with the spec shape:

```
HTTP/1.1 400 Bad Request
{"jsonrpc":"2.0","id":401,"error":{"code":-32021,
  "message":"Cannot request input 'llm_answer' (sampling/createMessage): the request's client capabilities do not declare the required capability",
  "data":{"requiredCapabilities":{"sampling":{}}}}}
```

before (`0.2.0-alpha.8`):

```
[sep-2575-server-rejects-undeclared-capability] FAILURE
  Server responded with error code -32021 but failed to provide an array containing
  the expected 'sampling' capability in error.data.requiredCapabilities
```

after (this branch, same server):

```
[sep-2575-server-rejects-undeclared-capability] SUCCESS
Passed: 30/30, 0 failed, 0 warnings
```

## How Has This Been Tested?

- `npx vitest run src/scenarios/server/stateless.test.ts` — 18/18, including three new self-tests: object passes, array fails, `{ "sampling": null }` fails (capability values must themselves be objects).
- From-source run of `server-stateless` against typescript-sdk's everythingServer (with its `test_missing_capability` fixture armed): 30/30 — the same server the shipped alpha.8 fails, as captured above.

## Breaking Changes

For servers, no — the object shape is what the schema has always required. For fixture servers written against the old assertion: python-sdk's reference everything-server emits the array (and pins it in two tests), and `server-stateless` is in neither of its baselines, so its conformance CI will flag this scenario on its next referee bump. The fix there is the same one-line shape change — happy to send it.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

- The scenario's implementer-facing description now states the required shape, so the next fixture author doesn't have to discover it from the runtime error string.
- A one-word prose clarification upstream ("lists" → "names", or matching the schema's phrasing) would prevent a recurrence.
