### PR TITLE
chore: bump version to 0.2.0-alpha.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/conformance",
-  "version": "0.2.0-alpha.8",
+  "version": "0.2.0-alpha.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/conformance",
-      "version": "0.2.0-alpha.8",
+      "version": "0.2.0-alpha.9",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/conformance",
-  "version": "0.2.0-alpha.8",
+  "version": "0.2.0-alpha.9",
   "type": "module",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",


### PR DESCRIPTION
Bump to `0.2.0-alpha.9` for release.

Contains exactly one change since `0.2.0-alpha.8`: #376 — the `server-stateless` `requiredCapabilities` assertion now matches the schema's `ClientCapabilities` object shape, so spec-correct servers pass the capability checks.

After merge: dispatch the CI workflow with `publish_alpha` to publish, as with previous alphas.