### PR TITLE
fix(server-stateless): declare the elicitation capability on the streaming-probe request

### DIFF
--- a/src/scenarios/server/stateless.test.ts
+++ b/src/scenarios/server/stateless.test.ts
@@ -628,6 +628,135 @@ describe('Stateless Server Scenario Negative Tests', () => {
     expect(independentRequestCheck?.status).toBe('FAILURE');
   });
 
+  // A spec-correct server that enforces per-request capability declaration:
+  // test_missing_capability requires sampling and test_streaming_elicitation
+  // requires elicitation; each is rejected with a spec-shaped -32021 unless
+  // the request's _meta declares the capability. A rejection reaches
+  // listenToStream as the parsed JSON error body — a single error frame.
+  function capabilityEnforcingMock(
+    streamingCallFrames: (reqBody: any) => any[]
+  ) {
+    return mockFetchTarget((reqBody) => {
+      if (reqBody.method === 'server/discover') {
+        return discoverResponse(reqBody, { tools: {} }, 'capability-enforcer');
+      }
+      if (reqBody.method === 'tools/list') {
+        return {
+          status: 200,
+          body: {
+            jsonrpc: '2.0',
+            id: reqBody.id,
+            result: {
+              tools: [
+                { name: 'test_missing_capability' },
+                { name: 'test_streaming_elicitation' }
+              ]
+            }
+          }
+        };
+      }
+      if (reqBody.method === 'tools/call') {
+        const declaredCaps =
+          reqBody.params?._meta?.[
+            'io.modelcontextprotocol/clientCapabilities'
+          ] ?? {};
+        if (reqBody.params?.name === 'test_missing_capability') {
+          if (!declaredCaps.sampling) {
+            return {
+              status: 400,
+              body: {
+                jsonrpc: '2.0',
+                id: reqBody.id,
+                ...spec32021({ sampling: {} })
+              }
+            };
+          }
+          return {
+            status: 200,
+            body: {
+              jsonrpc: '2.0',
+              id: reqBody.id,
+              result: { content: [{ type: 'text', text: 'ok' }] }
+            }
+          };
+        }
+        if (reqBody.params?.name === 'test_streaming_elicitation') {
+          if (!declaredCaps.elicitation) {
+            return {
+              isStream: true,
+              status: 400,
+              frames: [
+                {
+                  jsonrpc: '2.0',
+                  id: reqBody.id,
+                  ...spec32021({ elicitation: {} })
+                }
+              ]
+            };
+          }
+          return {
+            isStream: true,
+            status: 200,
+            frames: streamingCallFrames(reqBody)
+          };
+        }
+      }
+    });
+  }
+
+  test('Passes both capability checks against a capability-enforcing server: the streaming probe declares the elicitation capability its fixture requires', async () => {
+    // sep-2575-server-rejects-undeclared-capability REQUIRES the -32021
+    // rejection of an undeclared capability; before the streaming probe
+    // declared elicitation, that same rejection made
+    // sep-2575-http-server-no-independent-requests-on-stream untestable —
+    // one scenario demanded and punished the identical server behavior.
+    const mockUrl = capabilityEnforcingMock((reqBody) => [
+      {
+        jsonrpc: '2.0',
+        method: 'notifications/progress',
+        params: { progressToken: 'token-abc', total: 100, value: 50 }
+      },
+      {
+        jsonrpc: '2.0',
+        id: reqBody.id,
+        result: { content: [{ type: 'text', text: 'Streaming complete' }] }
+      }
+    ]);
+
+    const scenario = new ServerStatelessScenario();
+    const checks = await scenario.run(testContext(mockUrl));
+
+    expect(
+      findCheck(checks, 'sep-2575-server-rejects-undeclared-capability')?.status
+    ).toBe('SUCCESS');
+    expect(
+      findCheck(
+        checks,
+        'sep-2575-http-server-no-independent-requests-on-stream'
+      )?.status
+    ).toBe('SUCCESS');
+  });
+
+  test('Fails (untestable) the stream check when the server rejects the streaming probe despite the declared elicitation capability', async () => {
+    // Guards the notTestable branch: a server that rejects even a properly
+    // declared capability leaves nothing streamed to inspect, which must
+    // stay a red untestable outcome, not a vacuous SUCCESS.
+    const mockUrl = capabilityEnforcingMock((reqBody) => [
+      { jsonrpc: '2.0', id: reqBody.id, ...spec32021({ elicitation: {} }) }
+    ]);
+
+    const scenario = new ServerStatelessScenario();
+    const checks = await scenario.run(testContext(mockUrl));
+
+    const streamCheck = findCheck(
+      checks,
+      'sep-2575-http-server-no-independent-requests-on-stream'
+    );
+    expect(streamCheck?.status).toBe('FAILURE');
+    expect(streamCheck?.errorMessage).toContain('Not testable:');
+    expect(streamCheck?.errorMessage).toContain('-32021');
+  });
+
   test('Fails validation when logging occurs without an explicit client request logLevel metadata', async () => {
     const mockUrl = mockFetchTarget((reqBody) => {
       if (

--- a/src/scenarios/server/stateless.ts
+++ b/src/scenarios/server/stateless.ts
@@ -827,7 +827,16 @@ export class ServerStatelessScenario implements ClientScenario {
           {
             name: 'test_streaming_elicitation',
             arguments: {},
-            _meta: validMeta
+            // The fixture legitimately needs the elicitation capability, so a
+            // capability-enforcing server rejects the shared empty-capability
+            // envelope with -32021 (the exact behavior
+            // sep-2575-server-rejects-undeclared-capability requires) and the
+            // stream could never be exercised. Declare it at the probe site
+            // only — validMeta must stay empty for that sibling check.
+            _meta: {
+              ...validMeta,
+              'io.modelcontextprotocol/clientCapabilities': { elicitation: {} }
+            }
           },
           3,
           600


### PR DESCRIPTION
Fixes #382

## What

`sep-2575-http-server-no-independent-requests-on-stream` drives its streaming probe by calling
`tools/call` `test_streaming_elicitation` under the scenario's shared `validMeta` envelope, whose
`io.modelcontextprotocol/clientCapabilities` is intentionally empty. The fixture legitimately needs
the elicitation capability, so a capability-enforcing server MUST reject the probe with `-32021
MissingRequiredClientCapability` — the exact behavior `sep-2575-server-rejects-undeclared-capability`
requires and rewards earlier in the same scenario. Since #372 turned missing-prerequisite skips
into hard failures, one check requires the rejection that makes the other untestable.

This PR declares the capability at the probe site only:

```ts
_meta: {
  ...validMeta,
  'io.modelcontextprotocol/clientCapabilities': { elicitation: {} }
}
```

`validMeta` itself stays empty — `sep-2575-server-rejects-undeclared-capability` depends on it.
This matches the intent recorded for this check in #296 ("Call a tool that needs
sampling/elicitation, scan stream frames") and strictly widens coverage: capability-enforcing
servers become testable; servers that ignore capability declarations behave exactly as before.

The sibling probe `sep-2575-server-no-log-without-loglevel` (`test_logging_tool`) was audited for
the same latent problem: its fixture keys off `_meta.../logLevel`, not a client capability, so it
needs no change.

## Self-tests (prove it passes and fails)

Two tests added to `stateless.test.ts`, modeled on the existing mock patterns:

- **Green:** a spec-correct, capability-enforcing mock (rejects `test_missing_capability` without
  `sampling` and `test_streaming_elicitation` without `elicitation`, each with a spec-shaped
  `-32021`) now passes BOTH formerly-contradictory checks. Against `main` without the fix this test
  fails exactly as real servers do: the stream check reads
  `FAILURE — Not testable: the 'test_streaming_elicitation' call was rejected (code -32021)`.
- **Guard:** a server that rejects the streaming probe despite the declared capability still
  produces the red untestable outcome, not a vacuous SUCCESS.

`npm test` 333/333, `npm run check` clean.

## Real-SDK evidence (per CONTRIBUTING)

Run against the PHP SDK (logiscape/mcp-sdk-php v2 `main`), whose everything-server enforces
per-request capability declaration:

- **Before:** 27/28 — `sep-2575-http-server-no-independent-requests-on-stream` fails:
  `Not testable: the 'test_streaming_elicitation' call was rejected (code -32021), so the response
  stream could not be exercised`
- **After:** 28/28.

No regression against this repo's own example server (`examples/servers/typescript`): 30/30
before and after (it does not enforce capabilities on this fixture, so the added declaration is
inert there).

## Note on sequencing

Draft PR #351 hoists/shares this same probe stream between checks; this fix is written against
current `main` and is a one-expression change at the probe site, so whichever lands first, the
other rebases trivially. Happy to coordinate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
