### PR TITLE
Add client conformance for SEP-2663 task results

### DIFF
--- a/examples/clients/typescript/everything-client.ts
+++ b/examples/clients/typescript/everything-client.ts
@@ -28,8 +28,12 @@ import type {
 import { JWT_BEARER_GRANT_TYPE } from '../../../src/scenarios/client/auth/helpers/createWorkloadJwt.js';
 import { ElicitRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { ClientConformanceContextSchema } from '../../../src/schemas/context.js';
-import { DRAFT_PROTOCOL_VERSION } from '../../../src/types.js';
+import {
+  DRAFT_PROTOCOL_VERSION,
+  type SpecVersion
+} from '../../../src/types.js';
 import { STATELESS_SPEC_VERSIONS } from '../../../src/connection/select.js';
+import { buildStandardHeaders } from '../../../src/connection/stateless.js';
 import {
   auth,
   extractWWWAuthenticateParams
@@ -100,7 +104,8 @@ const USE_STATELESS_LIFECYCLE = PROTOCOL_VERSION
 // Wire protocolVersion for stateless requests: the runner-resolved version
 // when available (so a dated stateless release is exercised under its own
 // identifier), the current draft otherwise.
-const STATELESS_PROTOCOL_VERSION = PROTOCOL_VERSION ?? DRAFT_PROTOCOL_VERSION;
+const STATELESS_PROTOCOL_VERSION = (PROTOCOL_VERSION ??
+  DRAFT_PROTOCOL_VERSION) as SpecVersion;
 
 const STATELESS_META_BASE = {
   'io.modelcontextprotocol/clientInfo': {
@@ -128,13 +133,9 @@ async function statelessRequest(
   };
   const response = await fetch(serverUrl, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      // Servers built on the SDK's StreamableHTTPServerTransport reject
-      // requests that don't accept both JSON and SSE responses.
-      Accept: 'application/json, text/event-stream',
-      'MCP-Protocol-Version': STATELESS_PROTOCOL_VERSION
-    },
+    headers: buildStandardHeaders(method, params, {
+      specVersion: STATELESS_PROTOCOL_VERSION
+    }),
     body: JSON.stringify({
       jsonrpc: '2.0',
       id: _nextStatelessId++,
@@ -350,7 +351,7 @@ async function runRequestMetadataClient(serverUrl: string): Promise<void> {
             serverSupported.includes(v)
           );
           if (mutuallySupported.length > 0) {
-            activeVersion = mutuallySupported[0];
+            activeVersion = mutuallySupported[0] as SpecVersion;
             logger.debug(
               `Mutually supported version found: ${activeVersion}. Retrying...`
             );
@@ -1067,6 +1068,69 @@ async function runMRTRClient(serverUrl: string): Promise<void> {
 }
 
 registerScenario('sep-2322-client-request-state', runMRTRClient);
+
+// ============================================================================
+// Tasks extension client conformance (SEP-2663)
+// ============================================================================
+
+const TASKS_EXTENSION_ID = 'io.modelcontextprotocol/tasks';
+
+async function runTasksClientCreateHandling(serverUrl: string): Promise<void> {
+  const taskCapabilities = {
+    ...STATELESS_META_BASE['io.modelcontextprotocol/clientCapabilities'],
+    extensions: { [TASKS_EXTENSION_ID]: {} }
+  };
+  const request = (method: string, params: Record<string, unknown> = {}) =>
+    statelessRequest(serverUrl, method, {
+      ...params,
+      _meta: {
+        'io.modelcontextprotocol/clientCapabilities': taskCapabilities
+      }
+    });
+
+  const discovery = await request('server/discover');
+  if (!discovery?.capabilities?.extensions?.[TASKS_EXTENSION_ID]) {
+    throw new Error('Server did not advertise the Tasks extension');
+  }
+
+  await request('tools/list');
+  const result = await request('tools/call', {
+    name: 'long_running_echo',
+    arguments: { text: 'hello' }
+  });
+
+  if (result?.resultType !== 'task') {
+    // A standard CallToolResult is also valid after negotiating the extension.
+    return;
+  }
+
+  const taskId = result.taskId;
+  if (typeof taskId !== 'string') {
+    throw new Error('CreateTaskResult did not contain a taskId');
+  }
+
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const task = await request('tasks/get', { taskId });
+    if (task?.status === 'completed') {
+      if (!task.result) {
+        throw new Error('Completed task did not include its result');
+      }
+      return;
+    }
+    if (task?.status === 'failed' || task?.status === 'cancelled') {
+      throw new Error(`Task terminated with status ${task.status}`);
+    }
+    const delay =
+      typeof task?.pollIntervalMs === 'number' ? task.pollIntervalMs : 0;
+    if (delay > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  throw new Error('Task did not reach a terminal status');
+}
+
+registerScenario('tasks-client-create-handling', runTasksClientCreateHandling);
 
 // ============================================================================
 // WIF JWT-bearer scenario

--- a/examples/clients/typescript/tasks-client-missing-get-capability.ts
+++ b/examples/clients/typescript/tasks-client-missing-get-capability.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+/**
+ * Deliberately broken SEP-2663 client: it declares the Tasks extension on the
+ * task-producing tools/call, then omits it from the tasks/get request.
+ */
+
+import { DRAFT_PROTOCOL_VERSION } from '../../../src/types.js';
+import { buildStandardHeaders } from '../../../src/connection/stateless.js';
+import { runAsCli } from './helpers/cliRunner.js';
+
+const TASKS_EXTENSION_ID = 'io.modelcontextprotocol/tasks';
+let nextId = 1;
+
+export async function runClient(serverUrl: string): Promise<void> {
+  const request = async (
+    method: string,
+    params: Record<string, unknown> = {},
+    declareTasks = true
+  ): Promise<Record<string, unknown>> => {
+    const id = nextId++;
+    const extensions = declareTasks ? { [TASKS_EXTENSION_ID]: {} } : {};
+    const meta = {
+      'io.modelcontextprotocol/protocolVersion': DRAFT_PROTOCOL_VERSION,
+      'io.modelcontextprotocol/clientInfo': {
+        name: 'broken-tasks-client',
+        version: '1.0.0'
+      },
+      'io.modelcontextprotocol/clientCapabilities': { extensions }
+    };
+    const response = await fetch(serverUrl, {
+      method: 'POST',
+      headers: buildStandardHeaders(method, params, {
+        specVersion: DRAFT_PROTOCOL_VERSION
+      }),
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id,
+        method,
+        params: { ...params, _meta: meta }
+      })
+    });
+    const body = (await response.json()) as {
+      result?: Record<string, unknown>;
+    };
+    return body.result ?? {};
+  };
+
+  await request('server/discover');
+  await request('tools/list');
+  const result = await request('tools/call', {
+    name: 'long_running_echo',
+    arguments: { text: 'hello' }
+  });
+  const taskId = result.taskId;
+  if (typeof taskId !== 'string') {
+    throw new Error('CreateTaskResult did not contain a taskId');
+  }
+
+  // BUG: tasks/get omits the per-request Tasks extension declaration.
+  await request('tasks/get', { taskId }, false);
+}
+
+runAsCli(
+  runClient,
+  import.meta.url,
+  'tasks-client-missing-get-capability <server-url>'
+);

--- a/examples/clients/typescript/tasks-client-no-poll.ts
+++ b/examples/clients/typescript/tasks-client-no-poll.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+/**
+ * Deliberately broken SEP-2663 client: it negotiates the Tasks extension and
+ * receives CreateTaskResult, but never follows the task with tasks/get.
+ */
+
+import { DRAFT_PROTOCOL_VERSION } from '../../../src/types.js';
+import { buildStandardHeaders } from '../../../src/connection/stateless.js';
+import { runAsCli } from './helpers/cliRunner.js';
+
+const TASKS_EXTENSION_ID = 'io.modelcontextprotocol/tasks';
+let nextId = 1;
+
+export async function runClient(serverUrl: string): Promise<void> {
+  const request = async (
+    method: string,
+    params: Record<string, unknown> = {}
+  ): Promise<Record<string, unknown>> => {
+    const id = nextId++;
+    const meta = {
+      'io.modelcontextprotocol/protocolVersion': DRAFT_PROTOCOL_VERSION,
+      'io.modelcontextprotocol/clientInfo': {
+        name: 'broken-tasks-client',
+        version: '1.0.0'
+      },
+      'io.modelcontextprotocol/clientCapabilities': {
+        extensions: { [TASKS_EXTENSION_ID]: {} }
+      }
+    };
+    const response = await fetch(serverUrl, {
+      method: 'POST',
+      headers: buildStandardHeaders(method, params, {
+        specVersion: DRAFT_PROTOCOL_VERSION
+      }),
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id,
+        method,
+        params: { ...params, _meta: meta }
+      })
+    });
+    const body = (await response.json()) as {
+      result?: Record<string, unknown>;
+      error?: { message: string };
+    };
+    if (body.error) throw new Error(body.error.message);
+    return body.result ?? {};
+  };
+
+  await request('server/discover');
+  await request('tools/list');
+  await request('tools/call', {
+    name: 'long_running_echo',
+    arguments: { text: 'hello' }
+  });
+  // BUG: ignores CreateTaskResult and exits without tasks/get.
+}
+
+runAsCli(runClient, import.meta.url, 'tasks-client-no-poll <server-url>');

--- a/src/runner/client.test.ts
+++ b/src/runner/client.test.ts
@@ -64,4 +64,14 @@ describe('runConformanceTest spec-version applicability', () => {
     expect(result.skipped).toBeUndefined();
     expect(result.clientOutput?.stdout).toContain(LATEST_SPEC_VERSION);
   }, 30000);
+
+  test('uses an extension baseSpecVersion when the scenario declares one', async () => {
+    const result = await runConformanceTest(
+      PRINT_VERSION_COMMAND,
+      'tasks-client-create-handling',
+      10000
+    );
+    expect(result.skipped).toBeUndefined();
+    expect(result.clientOutput?.stdout).toContain(DRAFT_PROTOCOL_VERSION);
+  }, 30000);
 });

--- a/src/runner/client.ts
+++ b/src/runner/client.ts
@@ -140,9 +140,12 @@ function resolveScenarioSpecVersion(
 ): SpecVersion {
   return (
     specVersion ??
-    ('introducedIn' in source && source.introducedIn === DRAFT_PROTOCOL_VERSION
-      ? DRAFT_PROTOCOL_VERSION
-      : LATEST_SPEC_VERSION)
+    ('extensionId' in source && source.baseSpecVersion !== undefined
+      ? source.baseSpecVersion
+      : 'introducedIn' in source &&
+          source.introducedIn === DRAFT_PROTOCOL_VERSION
+        ? DRAFT_PROTOCOL_VERSION
+        : LATEST_SPEC_VERSION)
   );
 }
 

--- a/src/runner/server.ts
+++ b/src/runner/server.ts
@@ -83,10 +83,11 @@ export async function runServerConformanceTest(
   // on draft, so they fall under the same inference.
   const resolvedSpecVersion =
     specVersion ??
-    ('extensionId' in scenario.source ||
-    scenario.source.introducedIn === DRAFT_PROTOCOL_VERSION
-      ? DRAFT_PROTOCOL_VERSION
-      : LATEST_SPEC_VERSION);
+    ('extensionId' in scenario.source
+      ? (scenario.source.baseSpecVersion ?? DRAFT_PROTOCOL_VERSION)
+      : scenario.source.introducedIn === DRAFT_PROTOCOL_VERSION
+        ? DRAFT_PROTOCOL_VERSION
+        : LATEST_SPEC_VERSION);
 
   console.log(
     `Running client scenario '${scenarioName}' against server: ${serverUrl}`

--- a/src/scenarios/client/tasks-create-handling.test.ts
+++ b/src/scenarios/client/tasks-create-handling.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'vitest';
+import { getHandler } from '../../../examples/clients/typescript/everything-client';
+import { runClient as noPollClient } from '../../../examples/clients/typescript/tasks-client-no-poll';
+import { DRAFT_PROTOCOL_VERSION } from '../../types';
+import { listExtensionScenarios } from '../index';
+import { extensionScenariosList } from './auth/index';
+import {
+  InlineClientRunner,
+  runClientAgainstScenario
+} from './auth/test_helpers/testClient';
+
+const SCENARIO = 'tasks-client-create-handling';
+
+describe('SEP-2663 Tasks client handling', () => {
+  test('everything-client handles CreateTaskResult and retrieves the result', async () => {
+    const handler = getHandler(SCENARIO);
+    expect(handler).toBeDefined();
+
+    const checks = await runClientAgainstScenario(
+      new InlineClientRunner(handler!),
+      SCENARIO,
+      { specVersion: DRAFT_PROTOCOL_VERSION }
+    );
+
+    expect(checks).toEqual([
+      expect.objectContaining({
+        id: 'sep-2663-client-handles-polymorphic-result',
+        status: 'SUCCESS'
+      })
+    ]);
+  });
+
+  test('detects a client that ignores CreateTaskResult', async () => {
+    const checks = await runClientAgainstScenario(
+      new InlineClientRunner(noPollClient),
+      SCENARIO,
+      {
+        specVersion: DRAFT_PROTOCOL_VERSION,
+        expectedFailureSlugs: ['sep-2663-client-handles-polymorphic-result']
+      }
+    );
+
+    expect(checks[0]).toMatchObject({
+      status: 'FAILURE',
+      errorMessage:
+        'Client received CreateTaskResult but did not retrieve it with tasks/get.'
+    });
+  });
+
+  test('is selected without dropping existing extension scenarios', () => {
+    const listed = listExtensionScenarios();
+    expect(listed).toContain(SCENARIO);
+    expect(listed).toEqual(
+      expect.arrayContaining(
+        extensionScenariosList.map((scenario) => scenario.name)
+      )
+    );
+  });
+});

--- a/src/scenarios/client/tasks-create-handling.test.ts
+++ b/src/scenarios/client/tasks-create-handling.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { getHandler } from '../../../examples/clients/typescript/everything-client';
+import { runClient as missingGetCapabilityClient } from '../../../examples/clients/typescript/tasks-client-missing-get-capability';
 import { runClient as noPollClient } from '../../../examples/clients/typescript/tasks-client-no-poll';
 import { DRAFT_PROTOCOL_VERSION } from '../../types';
 import { listExtensionScenarios } from '../index';
@@ -44,6 +45,27 @@ describe('SEP-2663 Tasks client handling', () => {
       status: 'FAILURE',
       errorMessage:
         'Client received CreateTaskResult but did not retrieve it with tasks/get.'
+    });
+  });
+
+  test('detects a client that omits the Tasks capability on tasks/get', async () => {
+    const checks = await runClientAgainstScenario(
+      new InlineClientRunner(missingGetCapabilityClient),
+      SCENARIO,
+      {
+        specVersion: DRAFT_PROTOCOL_VERSION,
+        expectedFailureSlugs: ['sep-2663-client-handles-polymorphic-result']
+      }
+    );
+
+    expect(checks[0]).toMatchObject({
+      status: 'FAILURE',
+      errorMessage:
+        'Client did not declare io.modelcontextprotocol/tasks in the tasks/get per-request capabilities.',
+      details: {
+        taskGetSeen: true,
+        taskGetDeclaredExtension: false
+      }
     });
   });
 

--- a/src/scenarios/client/tasks-create-handling.ts
+++ b/src/scenarios/client/tasks-create-handling.ts
@@ -1,0 +1,292 @@
+/**
+ * SEP-2663 Tasks Extension — client polymorphic-result handling.
+ *
+ * The mock server returns a server-directed CreateTaskResult from tools/call.
+ * A conformant client follows the task handle with tasks/get instead of
+ * treating the task envelope as a CallToolResult. This black-box scenario can
+ * observe retrieval, but not application-level use of the completed result.
+ */
+
+import express from 'express';
+import { randomUUID } from 'node:crypto';
+import type { Server as HttpServer } from 'node:http';
+import type { ScenarioContext } from '../../mock-server';
+import {
+  validateStatelessRequest,
+  withRequiredDraftResultFields
+} from '../../mock-server';
+import {
+  DRAFT_PROTOCOL_VERSION,
+  type ConformanceCheck,
+  type Scenario,
+  type ScenarioUrls
+} from '../../types';
+import { MISSING_REQUIRED_CLIENT_CAPABILITY } from '../../spec-types/draft';
+import { validateWireMessage } from '../../validation/wire-schema';
+
+const TASKS_EXTENSION_ID = 'io.modelcontextprotocol/tasks';
+const CREATED_AT = '2026-07-19T00:00:00.000Z';
+const SEP_2663_REF = {
+  id: 'SEP-2663',
+  url: 'https://modelcontextprotocol.io/seps/2663-tasks-extension'
+};
+
+interface Observations {
+  toolCallSeen: boolean;
+  toolCallDeclaredExtension: boolean;
+  taskGetIds: string[];
+}
+
+function clientDeclaredTasks(params: Record<string, unknown>): boolean {
+  const meta = params._meta as Record<string, unknown> | undefined;
+  const capabilities = meta?.['io.modelcontextprotocol/clientCapabilities'] as
+    | Record<string, unknown>
+    | undefined;
+  const extensions = capabilities?.extensions as
+    | Record<string, unknown>
+    | undefined;
+  const declaration = extensions?.[TASKS_EXTENSION_ID];
+  return (
+    typeof declaration === 'object' &&
+    declaration !== null &&
+    !Array.isArray(declaration)
+  );
+}
+
+export class TasksClientCreateHandlingScenario implements Scenario {
+  name = 'tasks-client-create-handling';
+  readonly source = {
+    extensionId: TASKS_EXTENSION_ID,
+    baseSpecVersion: DRAFT_PROTOCOL_VERSION
+  } as const;
+  description =
+    'Tests that a client declaring the SEP-2663 Tasks extension handles a server-directed CreateTaskResult from tools/call and retrieves the completed result with tasks/get.';
+
+  private httpServer: HttpServer | null = null;
+  private taskId = randomUUID();
+  private observations: Observations = this.newObservations();
+
+  async start(ctx: ScenarioContext): Promise<ScenarioUrls> {
+    this.taskId = randomUUID();
+    this.observations = this.newObservations();
+
+    const app = express();
+    app.use(express.json());
+
+    const serverCapabilities = {
+      tools: {},
+      extensions: { [TASKS_EXTENSION_ID]: {} }
+    };
+
+    app.post('/mcp', (req, res) => {
+      const body = req.body as Record<string, unknown> | undefined;
+      const requestMethod =
+        typeof body?.method === 'string' ? body.method : undefined;
+      if (body !== undefined) {
+        validateWireMessage(ctx.specVersion, body, {
+          origin: 'implementation',
+          context: `client request '${requestMethod ?? '(unknown)'}' to Tasks mock`
+        });
+      }
+
+      const sendJson = (status: number, payload: object, method?: string) => {
+        const raw = payload as Record<string, unknown>;
+        const validated =
+          raw.error !== undefined && raw.id === null
+            ? { ...raw, id: 0 }
+            : payload;
+        validateWireMessage(ctx.specVersion, validated, {
+          origin: 'harness',
+          context: `Tasks mock response${method ? ` to '${method}'` : ''}`,
+          requestMethod: method
+        });
+        return res.status(status).json(payload);
+      };
+
+      const validation = validateStatelessRequest(req, serverCapabilities, [
+        ctx.specVersion
+      ]);
+      if (validation.kind !== 'route') {
+        return sendJson(
+          validation.status,
+          validation.body,
+          validation.kind === 'handled' ? requestMethod : undefined
+        );
+      }
+
+      const { id, method, params } = validation;
+      const error = (
+        status: number,
+        code: number,
+        message: string,
+        data?: Record<string, unknown>
+      ) =>
+        sendJson(status, {
+          jsonrpc: '2.0',
+          id,
+          error: { code, message, ...(data ? { data } : {}) }
+        });
+
+      if (method === 'tools/list') {
+        return sendJson(
+          200,
+          {
+            jsonrpc: '2.0',
+            id,
+            result: withRequiredDraftResultFields(method, {
+              tools: [
+                {
+                  name: 'long_running_echo',
+                  description: 'Returns its result through an MCP task.',
+                  inputSchema: {
+                    type: 'object',
+                    properties: { text: { type: 'string' } },
+                    required: ['text']
+                  }
+                }
+              ]
+            })
+          },
+          method
+        );
+      }
+
+      if (method === 'tools/call') {
+        this.observations.toolCallSeen = true;
+        this.observations.toolCallDeclaredExtension =
+          clientDeclaredTasks(params);
+
+        if (!this.observations.toolCallDeclaredExtension) {
+          return error(
+            400,
+            MISSING_REQUIRED_CLIENT_CAPABILITY,
+            `Missing required client capability: ${TASKS_EXTENSION_ID}`,
+            {
+              requiredCapabilities: {
+                extensions: { [TASKS_EXTENSION_ID]: {} }
+              }
+            }
+          );
+        }
+
+        return sendJson(
+          200,
+          {
+            jsonrpc: '2.0',
+            id,
+            result: {
+              resultType: 'task',
+              taskId: this.taskId,
+              status: 'working',
+              createdAt: CREATED_AT,
+              lastUpdatedAt: CREATED_AT,
+              ttlMs: 60_000,
+              pollIntervalMs: 1
+            }
+          },
+          method
+        );
+      }
+
+      if (method === 'tasks/get') {
+        const taskId = params.taskId;
+        if (typeof taskId !== 'string' || taskId !== this.taskId) {
+          return error(400, -32602, 'Unknown taskId');
+        }
+
+        this.observations.taskGetIds.push(taskId);
+        return sendJson(
+          200,
+          {
+            jsonrpc: '2.0',
+            id,
+            result: {
+              resultType: 'complete',
+              taskId: this.taskId,
+              status: 'completed',
+              createdAt: CREATED_AT,
+              lastUpdatedAt: CREATED_AT,
+              ttlMs: 60_000,
+              pollIntervalMs: 1,
+              result: {
+                resultType: 'complete',
+                content: [{ type: 'text', text: 'task-result-ok' }]
+              }
+            }
+          },
+          method
+        );
+      }
+
+      return error(404, -32601, `Method not found: ${method}`);
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      this.httpServer = app.listen(0);
+      this.httpServer.once('error', reject);
+      this.httpServer.once('listening', resolve);
+    });
+
+    const server = this.httpServer;
+    if (!server) throw new Error('Tasks conformance server did not start');
+    const address = server.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+    return { serverUrl: `http://localhost:${port}/mcp` };
+  }
+
+  async stop(): Promise<void> {
+    if (!this.httpServer) return;
+    const server = this.httpServer;
+    this.httpServer = null;
+    await new Promise<void>((resolve) => {
+      server.closeAllConnections?.();
+      server.close(() => resolve());
+    });
+  }
+
+  getChecks(): ConformanceCheck[] {
+    const polledCreatedTask = this.observations.taskGetIds.includes(
+      this.taskId
+    );
+    const passed =
+      this.observations.toolCallSeen &&
+      this.observations.toolCallDeclaredExtension &&
+      polledCreatedTask;
+
+    let errorMessage: string | undefined;
+    if (!this.observations.toolCallSeen) {
+      errorMessage = 'Client did not issue tools/call.';
+    } else if (!this.observations.toolCallDeclaredExtension) {
+      errorMessage = `Client did not declare ${TASKS_EXTENSION_ID} in the tools/call per-request capabilities.`;
+    } else if (!polledCreatedTask) {
+      errorMessage =
+        'Client received CreateTaskResult but did not retrieve it with tasks/get.';
+    }
+
+    return [
+      {
+        id: 'sep-2663-client-handles-polymorphic-result',
+        name: 'TasksClientHandlesPolymorphicResult',
+        description:
+          'Client handles CreateTaskResult from tools/call and retrieves the completed task result with tasks/get. This black-box check observes retrieval, not application-level use of the returned result.',
+        status: passed ? 'SUCCESS' : 'FAILURE',
+        timestamp: new Date().toISOString(),
+        errorMessage,
+        specReferences: [SEP_2663_REF],
+        details: {
+          toolCallSeen: this.observations.toolCallSeen,
+          declaredTasksExtension: this.observations.toolCallDeclaredExtension,
+          taskGetIds: [...this.observations.taskGetIds]
+        }
+      }
+    ];
+  }
+
+  private newObservations(): Observations {
+    return {
+      toolCallSeen: false,
+      toolCallDeclaredExtension: false,
+      taskGetIds: []
+    };
+  }
+}

--- a/src/scenarios/client/tasks-create-handling.ts
+++ b/src/scenarios/client/tasks-create-handling.ts
@@ -32,8 +32,8 @@ const SEP_2663_REF = {
 };
 
 interface Observations {
-  toolCallSeen: boolean;
-  toolCallDeclaredExtension: boolean;
+  toolCallCapabilityDeclarations: boolean[];
+  taskGetCapabilityDeclarations: boolean[];
   taskGetIds: string[];
 }
 
@@ -126,6 +126,17 @@ export class TasksClientCreateHandlingScenario implements Scenario {
           id,
           error: { code, message, ...(data ? { data } : {}) }
         });
+      const missingTasksCapability = () =>
+        error(
+          400,
+          MISSING_REQUIRED_CLIENT_CAPABILITY,
+          `Missing required client capability: ${TASKS_EXTENSION_ID}`,
+          {
+            requiredCapabilities: {
+              extensions: { [TASKS_EXTENSION_ID]: {} }
+            }
+          }
+        );
 
       if (method === 'tools/list') {
         return sendJson(
@@ -152,21 +163,11 @@ export class TasksClientCreateHandlingScenario implements Scenario {
       }
 
       if (method === 'tools/call') {
-        this.observations.toolCallSeen = true;
-        this.observations.toolCallDeclaredExtension =
-          clientDeclaredTasks(params);
+        const declaredTasks = clientDeclaredTasks(params);
+        this.observations.toolCallCapabilityDeclarations.push(declaredTasks);
 
-        if (!this.observations.toolCallDeclaredExtension) {
-          return error(
-            400,
-            MISSING_REQUIRED_CLIENT_CAPABILITY,
-            `Missing required client capability: ${TASKS_EXTENSION_ID}`,
-            {
-              requiredCapabilities: {
-                extensions: { [TASKS_EXTENSION_ID]: {} }
-              }
-            }
-          );
+        if (!declaredTasks) {
+          return missingTasksCapability();
         }
 
         return sendJson(
@@ -189,6 +190,12 @@ export class TasksClientCreateHandlingScenario implements Scenario {
       }
 
       if (method === 'tasks/get') {
+        const declaredTasks = clientDeclaredTasks(params);
+        this.observations.taskGetCapabilityDeclarations.push(declaredTasks);
+        if (!declaredTasks) {
+          return missingTasksCapability();
+        }
+
         const taskId = params.taskId;
         if (typeof taskId !== 'string' || taskId !== this.taskId) {
           return error(400, -32602, 'Unknown taskId');
@@ -245,22 +252,39 @@ export class TasksClientCreateHandlingScenario implements Scenario {
   }
 
   getChecks(): ConformanceCheck[] {
+    const toolCallSeen =
+      this.observations.toolCallCapabilityDeclarations.length > 0;
+    const toolCallDeclaredExtension =
+      toolCallSeen &&
+      this.observations.toolCallCapabilityDeclarations.every(Boolean);
+    const taskGetSeen =
+      this.observations.taskGetCapabilityDeclarations.length > 0;
+    const taskGetDeclaredExtension =
+      taskGetSeen &&
+      this.observations.taskGetCapabilityDeclarations.every(Boolean);
     const polledCreatedTask = this.observations.taskGetIds.includes(
       this.taskId
     );
     const passed =
-      this.observations.toolCallSeen &&
-      this.observations.toolCallDeclaredExtension &&
+      toolCallSeen &&
+      toolCallDeclaredExtension &&
+      taskGetSeen &&
+      taskGetDeclaredExtension &&
       polledCreatedTask;
 
     let errorMessage: string | undefined;
-    if (!this.observations.toolCallSeen) {
+    if (!toolCallSeen) {
       errorMessage = 'Client did not issue tools/call.';
-    } else if (!this.observations.toolCallDeclaredExtension) {
+    } else if (!toolCallDeclaredExtension) {
       errorMessage = `Client did not declare ${TASKS_EXTENSION_ID} in the tools/call per-request capabilities.`;
-    } else if (!polledCreatedTask) {
+    } else if (!taskGetSeen) {
       errorMessage =
         'Client received CreateTaskResult but did not retrieve it with tasks/get.';
+    } else if (!taskGetDeclaredExtension) {
+      errorMessage = `Client did not declare ${TASKS_EXTENSION_ID} in the tasks/get per-request capabilities.`;
+    } else if (!polledCreatedTask) {
+      errorMessage =
+        'Client did not retrieve the returned taskId with tasks/get.';
     }
 
     return [
@@ -274,8 +298,16 @@ export class TasksClientCreateHandlingScenario implements Scenario {
         errorMessage,
         specReferences: [SEP_2663_REF],
         details: {
-          toolCallSeen: this.observations.toolCallSeen,
-          declaredTasksExtension: this.observations.toolCallDeclaredExtension,
+          toolCallSeen,
+          toolCallDeclaredExtension,
+          taskGetSeen,
+          taskGetDeclaredExtension,
+          toolCallCapabilityDeclarations: [
+            ...this.observations.toolCallCapabilityDeclarations
+          ],
+          taskGetCapabilityDeclarations: [
+            ...this.observations.taskGetCapabilityDeclarations
+          ],
           taskGetIds: [...this.observations.taskGetIds]
         }
       }
@@ -284,8 +316,8 @@ export class TasksClientCreateHandlingScenario implements Scenario {
 
   private newObservations(): Observations {
     return {
-      toolCallSeen: false,
-      toolCallDeclaredExtension: false,
+      toolCallCapabilityDeclarations: [],
+      taskGetCapabilityDeclarations: [],
       taskGetIds: []
     };
   }

--- a/src/scenarios/index.ts
+++ b/src/scenarios/index.ts
@@ -15,6 +15,7 @@ import { ElicitationClientDefaultsScenario } from './client/elicitation-defaults
 import { SSERetryScenario } from './client/sse-retry';
 import { RequestMetadataScenario } from './client/request-metadata';
 import { MRTRClientScenario } from './client/mrtr-client';
+import { TasksClientCreateHandlingScenario } from './client/tasks-create-handling';
 
 // Import all new server test scenarios
 import { ServerInitializeScenario } from './server/lifecycle';
@@ -317,7 +318,10 @@ const scenariosList: Scenario[] = [
   new JsonSchemaRefDerefScenario(),
 
   // JSON Schema 2020-12 client-side keyword preservation (SEP-1613, SEP-2106)
-  new JsonSchema2020_12PreservationScenario()
+  new JsonSchema2020_12PreservationScenario(),
+
+  // SEP-2663 Tasks extension client conformance
+  new TasksClientCreateHandlingScenario()
 ];
 
 // Core scenarios (tier 1 requirements)
@@ -377,7 +381,9 @@ export function listCoreScenarios(): string[] {
 }
 
 export function listExtensionScenarios(): string[] {
-  return extensionScenariosList.map((scenario) => scenario.name);
+  return scenariosList
+    .filter((scenario) => 'extensionId' in scenario.source)
+    .map((scenario) => scenario.name);
 }
 
 export function listBackcompatScenarios(): string[] {

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,7 +116,16 @@ export type ScenarioSource =
       introducedIn: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
       removedIn?: DatedSpecVersion | typeof DRAFT_PROTOCOL_VERSION;
     }
-  | { extensionId: ExtensionId };
+  | {
+      extensionId: ExtensionId;
+      /**
+       * Core protocol version the extension is layered on for conformance
+       * runs. When omitted, the client runner uses LATEST_SPEC_VERSION and the
+       * server runner uses DRAFT_PROTOCOL_VERSION, preserving their existing
+       * extension defaults.
+       */
+      baseSpecVersion?: SpecVersion;
+    };
 
 export interface ScenarioUrls {
   serverUrl: string;

--- a/src/validation/wire-schema.test.ts
+++ b/src/validation/wire-schema.test.ts
@@ -117,6 +117,28 @@ describe('wireSchemaErrors', () => {
     ).toEqual([]);
   });
 
+  it('accepts a Tasks extension CreateTaskResult for draft tools/call', () => {
+    expect(
+      wireSchemaErrors(
+        DRAFT_PROTOCOL_VERSION,
+        {
+          jsonrpc: '2.0',
+          id: 4,
+          result: {
+            resultType: 'task',
+            taskId: 'task-1',
+            status: 'working',
+            createdAt: '2026-07-29T00:00:00.000Z',
+            lastUpdatedAt: '2026-07-29T00:00:00.000Z',
+            ttlMs: 60_000,
+            pollIntervalMs: 100
+          }
+        },
+        'tools/call'
+      )
+    ).toEqual([]);
+  });
+
   it('accepts a JSON-RPC batch under 2025-03-26 and reports per-element errors', () => {
     expect(
       wireSchemaErrors('2025-03-26', [

--- a/src/validation/wire-schema.ts
+++ b/src/validation/wire-schema.ts
@@ -262,12 +262,20 @@ export function wireSchemaErrors(
   if (msg.result !== undefined) {
     // SEP-2322 (MRTR): any request may be answered with an InputRequiredResult
     // instead of its method's result type; discriminate on resultType.
+    const resultType = (msg.result as Record<string, unknown> | null)
+      ?.resultType;
     const inputRequired =
-      (msg.result as Record<string, unknown> | null)?.resultType ===
-        'input_required' && 'InputRequiredResult' in spec.defs;
+      resultType === 'input_required' && 'InputRequiredResult' in spec.defs;
+    // Tasks v2 is a protocol extension, so its CreateTaskResult is
+    // intentionally absent from the core draft schema. Validate the base
+    // Result envelope instead of incorrectly requiring CallToolResult.content.
+    const tasksCreateResult =
+      specVersion === DRAFT_PROTOCOL_VERSION &&
+      requestMethod === 'tools/call' &&
+      resultType === 'task';
     const resultDefName = inputRequired
       ? 'InputRequiredResult'
-      : requestMethod !== undefined
+      : !tasksCreateResult && requestMethod !== undefined
         ? spec.resultDefs.get(requestMethod)
         : undefined;
     if (resultDefName) {


### PR DESCRIPTION
## Summary

- add `tasks-client-create-handling`, where the harness returns a server-directed `CreateTaskResult` from `tools/call` and requires the client to retrieve it with `tasks/get`
- register the scenario in the extensions suite by deriving membership from `source.extensionId`, and allow extension scenarios to declare the core protocol version they layer on
- update the TypeScript everything-client fixture to negotiate the Tasks extension and drive the polling flow
- add positive and deliberately broken no-poll coverage
- integrate the Tasks extension flow with the suite's per-version wire-schema validation

## Why

The server suite already covers SEP-2663, but the client suite could not observe the client requirement to handle either a standard result or `CreateTaskResult`. This implements the first client scenario proposed in #374.

The scenario is black-box: it proves that the client recognizes the task envelope and follows the returned handle with `tasks/get`. It does not claim to observe application-level use of the completed result.

## Alignment with current main

Rebased onto `49103de`, incorporating the 11 upstream commits added since the original PR base.

- layer the Tasks extension on `DRAFT_PROTOCOL_VERSION` (`2026-07-28`)
- use the final `MISSING_REQUIRED_CLIENT_CAPABILITY` code, `-32021`
- record requests and responses from the custom Tasks mock in the new wire validator
- validate extension-defined `CreateTaskResult` as a base draft `Result` envelope, since Tasks v2 types intentionally live outside the core draft schema
- keep `wire-schema-valid` green for both the conformant and deliberately broken client paths

## Validation

- `npm run check`
- `npm run build`
- `npm test` — 488 tests passed
- targeted Tasks, runner, and wire-schema tests — 31 tests passed
- end-to-end conformant client run on Node 22.23.1 — 2/2 checks passed, including `wire-schema-valid`
- end-to-end no-poll client run — fails only `sep-2663-client-handles-polymorphic-result` with the expected diagnostic; `wire-schema-valid` passes

Addresses #374.
