### PR TITLE
fix(sep-2575): report a schema-valid serverInfo accurately, and count warnings in the server summary

### DIFF
--- a/src/checks/checks.test.ts
+++ b/src/checks/checks.test.ts
@@ -53,7 +53,7 @@ describe('createClientInitializationCheck', () => {
 
     const check = createClientInitializationCheck(invalidRequest);
     expect(check.status).toBe('FAILURE');
-    expect(check.errorMessage).toContain('Client name missing');
+    expect(check.errorMessage).toContain("clientInfo needs a string 'name'");
   });
 
   it('should return FAILURE when client version is missing', () => {
@@ -66,7 +66,7 @@ describe('createClientInitializationCheck', () => {
 
     const check = createClientInitializationCheck(invalidRequest);
     expect(check.status).toBe('FAILURE');
-    expect(check.errorMessage).toContain('Client version missing');
+    expect(check.errorMessage).toContain("clientInfo needs a string 'version'");
   });
 
   it('should accept the current draft protocol version', () => {
@@ -93,6 +93,39 @@ describe('createClientInitializationCheck', () => {
       expect(check.errorMessage).toContain('Version mismatch');
     }
   );
+
+  // `Implementation` constrains `name` and `version` to be present strings and
+  // says nothing about their content, so '' is a supplied field. Failing here
+  // rejected a client the spec allows — and at FAILURE severity.
+  it.each([
+    ['version', { name: 'TestClient', version: '' }],
+    ['name', { name: '', version: '1.0.0' }]
+  ])('should accept an empty %s', (_field, clientInfo) => {
+    const check = createClientInitializationCheck({
+      protocolVersion: '2025-06-18',
+      clientInfo
+    });
+    expect(check.status).toBe('SUCCESS');
+    expect(check.errorMessage).toBeUndefined();
+  });
+
+  it('should return FAILURE when a clientInfo field is not a string', () => {
+    const check = createClientInitializationCheck({
+      protocolVersion: '2025-06-18',
+      clientInfo: { name: 'TestClient', version: 1 }
+    });
+    expect(check.status).toBe('FAILURE');
+    expect(check.errorMessage).toContain("clientInfo needs a string 'version'");
+  });
+
+  it('should report both fields when clientInfo is absent', () => {
+    const check = createClientInitializationCheck({
+      protocolVersion: '2025-06-18'
+    });
+    expect(check.status).toBe('FAILURE');
+    expect(check.errorMessage).toContain("clientInfo needs a string 'name'");
+    expect(check.errorMessage).toContain("clientInfo needs a string 'version'");
+  });
 
   it('should support custom expected spec version', () => {
     const request = {

--- a/src/checks/client.ts
+++ b/src/checks/client.ts
@@ -48,9 +48,15 @@ export function createClientInitializationCheck(
     errors.push(
       `Version mismatch: expected ${expectedSpecVersion}, got ${protocolVersionSent}`
     );
-  if (!initializeRequest?.clientInfo?.name) errors.push('Client name missing');
-  if (!initializeRequest?.clientInfo?.version)
-    errors.push('Client version missing');
+  // Presence and type, not truthiness. `Implementation` is
+  // `"required": ["name", "version"]` with both a bare `{"type": "string"}`,
+  // so a client sending `version: ''` has supplied the field; a falsy test
+  // reports it as missing, and at FAILURE severity.
+  const clientInfo = initializeRequest?.clientInfo;
+  if (typeof clientInfo?.name !== 'string')
+    errors.push("clientInfo needs a string 'name'");
+  if (typeof clientInfo?.version !== 'string')
+    errors.push("clientInfo needs a string 'version'");
 
   const status: CheckStatus = errors.length === 0 ? 'SUCCESS' : 'FAILURE';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -478,7 +478,7 @@ program
           }
         }
 
-        const { totalFailed } = printServerSummary(allResults);
+        const { totalFailed, totalWarnings } = printServerSummary(allResults);
 
         if (options.expectedFailures) {
           const expectedFailuresConfig = await loadExpectedFailures(
@@ -493,7 +493,7 @@ program
           process.exit(baselineResult.exitCode);
         }
 
-        process.exit(totalFailed > 0 ? 1 : 0);
+        process.exit(totalFailed > 0 || totalWarnings > 0 ? 1 : 0);
       }
     } catch (error) {
       if (error instanceof ZodError) {

--- a/src/runner/server.test.ts
+++ b/src/runner/server.test.ts
@@ -5,8 +5,9 @@
  */
 import http from 'http';
 import type { AddressInfo } from 'net';
-import { afterEach, beforeEach, describe, test, expect } from 'vitest';
-import { runServerConformanceTest } from './server';
+import { afterEach, beforeEach, describe, test, expect, vi } from 'vitest';
+import { printServerSummary, runServerConformanceTest } from './server';
+import { evaluateBaseline } from '../expected-failures';
 import { DRAFT_PROTOCOL_VERSION, LATEST_SPEC_VERSION } from '../types';
 
 // The skip decision happens before any network request, so an unreachable
@@ -140,4 +141,66 @@ describe('runServerConformanceTest wire selection for draft-only scenarios', () 
       'io.modelcontextprotocol/tasks': {}
     });
   }, 30000);
+});
+
+describe('printServerSummary', () => {
+  const check = (status: 'SUCCESS' | 'FAILURE' | 'WARNING', id: string) => ({
+    id,
+    name: id,
+    description: `a ${status} check`,
+    status,
+    timestamp: '2026-07-22T00:00:00.000Z'
+  });
+
+  function capture(allResults: Parameters<typeof printServerSummary>[0]): {
+    totals: ReturnType<typeof printServerSummary>;
+    output: string;
+  } {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const totals = printServerSummary(allResults);
+      return { totals, output: spy.mock.calls.map((c) => c[0]).join('\n') };
+    } finally {
+      spy.mockRestore();
+    }
+  }
+
+  test('ticks a scenario whose checks all pass', () => {
+    const { output } = capture([
+      { scenario: 'server-stateless', checks: [check('SUCCESS', 'a')] }
+    ]);
+    expect(output).toContain('✓ server-stateless: 1 passed, 0 failed');
+  });
+
+  // The reported defect: a warning-only scenario printed `✓ ... 0 failed` and
+  // then failed the baseline gate, which counts WARNING.
+  test('crosses a scenario whose only failing check is a warning', () => {
+    const { totals, output } = capture([
+      {
+        scenario: 'server-stateless',
+        checks: [check('SUCCESS', 'a'), check('WARNING', 'b')]
+      }
+    ]);
+    expect(output).toContain(
+      '✗ server-stateless: 1 passed, 0 failed, 1 warnings'
+    );
+    expect(totals.totalWarnings).toBe(1);
+  });
+
+  // The invariant that was violated: the summary's verdict and the gate's
+  // exit code are the same verdict, for every status.
+  test.each(['SUCCESS', 'FAILURE', 'WARNING', 'SKIPPED', 'INFO'] as const)(
+    'agrees with the baseline gate on a %s check',
+    (status) => {
+      const results = [
+        { scenario: 's', checks: [check(status as never, 'a')] }
+      ];
+      const { totals } = capture(results);
+      const summarySaysFailing =
+        totals.totalFailed > 0 || totals.totalWarnings > 0;
+      expect(summarySaysFailing).toBe(
+        evaluateBaseline(results, []).exitCode === 1
+      );
+    }
+  );
 });

--- a/src/runner/server.ts
+++ b/src/runner/server.ts
@@ -157,24 +157,33 @@ export function printServerResults(
 
 export function printServerSummary(
   allResults: { scenario: string; checks: ConformanceCheck[] }[]
-): { totalPassed: number; totalFailed: number } {
+): { totalPassed: number; totalFailed: number; totalWarnings: number } {
   console.log('\n\n=== SUMMARY ===');
   let totalPassed = 0;
   let totalFailed = 0;
+  let totalWarnings = 0;
 
   for (const result of allResults) {
     const passed = result.checks.filter((c) => c.status === 'SUCCESS').length;
     const failed = result.checks.filter((c) => c.status === 'FAILURE').length;
+    const warnings = result.checks.filter((c) => c.status === 'WARNING').length;
     totalPassed += passed;
     totalFailed += failed;
+    totalWarnings += warnings;
 
-    const status = failed === 0 ? '✓' : '✗';
+    // A WARNING fails the expected-failures gate, so it has to fail the tick
+    // too: counting only FAILURE here printed `✓ ... 0 failed` for a run that
+    // then exited 1. The client suite summary already does this.
+    const status = failed === 0 && warnings === 0 ? '✓' : '✗';
+    const warningStr = warnings > 0 ? `, ${warnings} warnings` : '';
     console.log(
-      `${status} ${result.scenario}: ${passed} passed, ${failed} failed`
+      `${status} ${result.scenario}: ${passed} passed, ${failed} failed${warningStr}`
     );
   }
 
-  console.log(`\nTotal: ${totalPassed} passed, ${totalFailed} failed`);
+  console.log(
+    `\nTotal: ${totalPassed} passed, ${totalFailed} failed, ${totalWarnings} warnings`
+  );
 
-  return { totalPassed, totalFailed };
+  return { totalPassed, totalFailed, totalWarnings };
 }

--- a/src/scenarios/server/stateless.test.ts
+++ b/src/scenarios/server/stateless.test.ts
@@ -777,4 +777,59 @@ describe('Stateless Server Scenario Negative Tests', () => {
     expect(promptsCheck?.status).toBe('WARNING');
     expect(toolsCheck?.status).toBe('WARNING');
   });
+
+  describe('sep-2575-server-identifies-in-result-meta', () => {
+    // Runs the scenario against a server whose discover result carries the
+    // given _meta serverInfo, and returns the identity check.
+    async function identityCheckFor(serverInfo: unknown) {
+      const mockUrl = mockFetchTarget((reqBody) => {
+        if (reqBody.method === 'server/discover') {
+          return {
+            status: 200,
+            body: {
+              jsonrpc: '2.0',
+              id: reqBody.id,
+              result: {
+                supportedVersions: ['2026-07-28'],
+                capabilities: {},
+                _meta: { 'io.modelcontextprotocol/serverInfo': serverInfo }
+              }
+            }
+          };
+        }
+      });
+      const checks = await new ServerStatelessScenario().run(
+        testContext(mockUrl)
+      );
+      return findCheck(checks, 'sep-2575-server-identifies-in-result-meta');
+    }
+
+    // `Implementation` requires `name` and `version` to be present strings and
+    // constrains nothing about their content, so an empty version identifies
+    // the server. Warning about it fails CI over a conformant payload.
+    it.each([
+      ['a full identity', { name: 'srv', version: '1.0.0' }],
+      ['an empty version', { name: 'srv', version: '' }],
+      ['an empty name', { name: '', version: '1.0.0' }]
+    ])('passes a server reporting %s', async (_label, serverInfo) => {
+      const check = await identityCheckFor(serverInfo);
+      expect(check?.status).toBe('SUCCESS');
+      expect(check?.errorMessage).toBeUndefined();
+    });
+
+    it.each([
+      ['no version', { name: 'srv' }],
+      ['neither field', {}],
+      ['non-string fields', { name: 1, version: 2 }]
+    ])(
+      'warns, without claiming absence, when the stamp has %s',
+      async (_label, serverInfo) => {
+        const check = await identityCheckFor(serverInfo);
+        expect(check?.status).toBe('WARNING');
+        expect(check?.errorMessage).toBe(
+          "serverInfo in the discover result _meta needs a string 'name' and 'version'"
+        );
+      }
+    );
+  });
 });

--- a/src/scenarios/server/stateless.ts
+++ b/src/scenarios/server/stateless.ts
@@ -509,14 +509,23 @@ export class ServerStatelessScenario implements ClientScenario {
           };
         const metaServerInfo =
           discoverResult?._meta?.['io.modelcontextprotocol/serverInfo'];
-        if (!metaServerInfo?.name || !metaServerInfo?.version) {
+        // Presence and type, not truthiness. `Implementation` is
+        // `"required": ["name", "version"]` with both a bare
+        // `{"type": "string"}`, so `version: ''` identifies the server just as
+        // `'1.0.0'` does; a falsy test reports a present identity as absent.
+        if (
+          typeof metaServerInfo?.name !== 'string' ||
+          typeof metaServerInfo?.version !== 'string'
+        ) {
           const bodyServerInfo = discoverResult?.serverInfo;
           return {
             // SHOULD-level: WARNING, never FAILURE.
             warning: true,
-            error: bodyServerInfo
-              ? 'serverInfo found only in the pre-#3002 result body, not in _meta'
-              : 'No serverInfo in the discover result _meta',
+            error: metaServerInfo
+              ? "serverInfo in the discover result _meta needs a string 'name' and 'version'"
+              : bodyServerInfo
+                ? 'serverInfo found only in the pre-#3002 result body, not in _meta'
+                : 'No serverInfo in the discover result _meta',
             details: { result: discoverResult }
           };
         }


### PR DESCRIPTION
Three small defects in how the suite reports SEP-2575 results. Independently they're minor; together a run prints all ticks and then exits 1, which is how I hit them.

## 1. A schema-valid `serverInfo` is reported as missing

`sep-2575-server-identifies-in-result-meta` tests `!metaServerInfo?.name || !metaServerInfo?.version`. A server that stamps `{"name": "srv", "version": ""}` takes the falsy branch and is told `No serverInfo in the discover result _meta` — while the same check's `details` shows the stamp sitting right there.

The spec constrains presence, not content. `schema/draft/schema.json`:

```json
"Implementation": {
  "properties": { "name": { "type": "string" }, "version": { "type": "string" }, ... },
  "required": [ "name", "version" ]
}
```

No `minLength`, no `pattern`, and [`basic/index.mdx`](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/docs/specification/draft/basic/index.mdx) calls the value self-reported and unverified, "intended for display, logging, and debugging". An empty version is conformant, so warning about it fails CI (the baseline gate counts WARNING) over something the spec doesn't ask for.

Now a type test rather than a truthiness test, and the message distinguishes present-but-malformed from absent:

| `_meta` serverInfo | before | after |
|---|---|---|
| `{name, version: ''}` | WARNING `No serverInfo…` | **SUCCESS** |
| `{name: 1, version: 2}` | **SUCCESS** | WARNING `…needs a string 'name' and 'version'` |
| `{name}` / `{}` | WARNING `No serverInfo…` | WARNING `…needs a string 'name' and 'version'` |
| body only (pre-#3002) / absent | WARNING | unchanged |

Not just python-sdk: go-sdk's `Implementation.Version` has no `omitempty`, so `&mcp.Implementation{Name: "greeter1"}` — the pattern in its own `examples/server/sse/main.go` — marshals `"version": ""`.

## 2. The same bug in `createClientInitializationCheck`

Identical truthiness test on the client side, at **FAILURE** severity — the initialize `clientInfo` is MUST-level. Driven through `client --scenario initialize` with a raw client, before and after:

| `clientInfo` | before | after |
|---|---|---|
| `{name, version: '1.0.0'}` | SUCCESS | SUCCESS |
| `{name, version: ''}` | FAILURE `Client version missing` | **SUCCESS** |
| `{name, version: 1}` | **SUCCESS** | FAILURE `clientInfo needs a string 'version'` |
| `{name}` / `{}` / `null` | FAILURE `Client version missing` | FAILURE `clientInfo needs a string 'version'` |

The `version: 1` row is a second direction flip — non-empty non-strings are truthy, so the old check accepted a numeric version. Messages now match the serverInfo check's phrasing so both sides of the requirement read alike.

## 3. A gate-failing WARNING doesn't show in the suite summary

`printServerSummary` counted SUCCESS and FAILURE and keyed its tick on `failed === 0`. `evaluateBaseline` counts FAILURE **and** WARNING. So one run said both things:

```
✓ server-stateless: 29 passed, 0 failed              ← 30 checks in, 29 reported
✓ input-required-result-validate-input: 1 passed, 0 failed
Total: 64 passed, 10 failed                           ← no warnings column at all

Unexpected failures (not in baseline):
  ✗ server-stateless
  ✗ input-required-result-validate-input
```

The client suite summary (`index.ts:213-231`) already counts warnings and flips its glyph; the server one never got the same treatment. Copied across, plus the matching exit code — so a non-baselined server run agrees with the gate, and with AGENTS.md's "CI treats WARNING as a failure".

After, same run:

```
✓ server-stateless: 30 passed, 0 failed
✗ http-header-validation: 3 passed, 5 failed, 5 warnings
✗ input-required-result-validate-input: 1 passed, 0 failed, 1 warnings
Total: 65 passed, 10 failed, 6 warnings
```

Every ✗ in the summary is now in the gate's list and vice versa. Those five `http-header-validation` warnings had never been printed anywhere.

**One behaviour change worth a look:** a `server` run with no `--expected-failures` now exits 1 on a warning where it used to exit 0. That's what the gate and the `client` command already do, and `--expected-failures` remains the escape hatch — I checked a per-check baseline entry still takes a warning back to exit 0 — but it can turn a currently-green non-baselined run red.

## Deliberately not here

- **`tier-check`** still scores FAILURE-only, so it disagrees with the gate on exactly this case. That's the open policy question in #245, not something to settle in a bug fix.
- `sep-2575-client-sends-client-info` has the inverse problem — it tests the stamp for truthiness, so `clientInfo: {}` scores SUCCESS while a server stamping `{name, version: ""}` scores WARNING. Happy to fix it; kept out to keep this reviewable.
- The six places that each decide "what counts as a failing check" are still six places. This fixes the one that was demonstrably wrong rather than unifying them.

## Testing

`npm run check`, `npm run build`, `npm test` (454, +17). All 17 confirmed failing on `main` first — including two that fail in the *opposite* direction, since the old check passed `{name: 1, version: 2}`.

Driven, not just unit-tested:

- **go-sdk @ `827f90b`**, full draft server suite: **85 passed, 0 failed, 0 warnings** — a conformant SDK is unaffected.
- Reproduced both defects on `main` against the bundled everything-server with its `_meta` version set to `""` (the transcripts above are from that run), then re-ran the same commands on the fix: `server-stateless` goes 29+1 warning → 30 passed.
- Exit codes: warning-only scenario `1` (was `0`), with the check baselined `0`, clean scenario `0`, stale baseline entry `1`.

<sub>[AI Disclaimer](https://gist.github.com/maxisbey/6123d132484e4c533eab519a2800693d)</sub>
