### PR TITLE
fix(auth): add issuer to pre-registration context

### DIFF
--- a/examples/clients/typescript/everything-client.ts
+++ b/examples/clients/typescript/everything-client.ts
@@ -678,6 +678,10 @@ export async function runPreRegistration(serverUrl: string): Promise<void> {
     redirect_uris: ['http://localhost:3000/callback']
   });
 
+  // Associate the pre-registered credentials with the AS that issued them,
+  // keyed by its issuer (Authorization Server Binding).
+  provider.bindIssuer(ctx.issuer);
+
   // Use the provider-based middleware
   const oauthFetch = withOAuthRetryWithProvider(
     provider,

--- a/src/scenarios/client/auth/index.test.ts
+++ b/src/scenarios/client/auth/index.test.ts
@@ -38,6 +38,8 @@ import { runClient as dpopClient } from '../../../../examples/clients/typescript
 import { getHandler } from '../../../../examples/clients/typescript/everything-client';
 import { setLogLevel } from '../../../../examples/clients/typescript/helpers/logger';
 import { DRAFT_PROTOCOL_VERSION } from '../../../types';
+import { testScenarioContext } from '../../../mock-server/testing';
+import { ClientConformanceContextSchema } from '../../../schemas/context';
 
 beforeAll(() => {
   setLogLevel('error');
@@ -110,6 +112,37 @@ describe('Client Draft Scenarios', () => {
       });
     });
   }
+});
+
+describe('auth/pre-registration context', () => {
+  // Authorization Server Binding: the context issuer is only usable as a
+  // binding key if it equals the issuer the mock AS publishes in its metadata.
+  test('supplies the issuer the mock AS publishes in its metadata', async () => {
+    const scenario = authScenariosList.find(
+      (s) => s.name === 'auth/pre-registration'
+    );
+    if (!scenario) {
+      throw new Error('auth/pre-registration scenario not found');
+    }
+    const urls = await scenario.start(testScenarioContext());
+    try {
+      const context = ClientConformanceContextSchema.parse({
+        name: 'auth/pre-registration',
+        ...urls.context
+      });
+      if (context.name !== 'auth/pre-registration') {
+        throw new Error(`Unexpected context variant: ${context.name}`);
+      }
+      const res = await fetch(
+        `${context.issuer}/.well-known/oauth-authorization-server`
+      );
+      expect(res.ok).toBe(true);
+      const metadata = (await res.json()) as { issuer?: string };
+      expect(metadata.issuer).toBe(context.issuer);
+    } finally {
+      await scenario.stop();
+    }
+  });
 });
 
 describe('Negative tests', () => {

--- a/src/scenarios/client/auth/pre-registration.ts
+++ b/src/scenarios/client/auth/pre-registration.ts
@@ -13,7 +13,12 @@ const PRE_REGISTERED_CLIENT_SECRET = 'pre-registered-secret';
  * Scenario: Pre-registration (static client credentials)
  *
  * Tests OAuth flow where the server does NOT support Dynamic Client Registration.
- * Clients must use pre-registered credentials passed via context.
+ * Clients must use pre-registered credentials passed via context. The context
+ * also carries the mock AS's `issuer` identifier: clients targeting the
+ * 2026-07-28 spec MUST associate pre-registered credentials with the
+ * authorization server that issued them, keyed by that issuer
+ * (Authorization Server Binding):
+ * https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/client-registration#authorization-server-binding
  *
  * This tests the pre-registration approach described in the MCP spec:
  * https://modelcontextprotocol.io/specification/draft/basic/authorization#preregistration
@@ -123,7 +128,11 @@ export class PreRegistrationScenario implements Scenario {
       serverUrl: `${this.server.getUrl()}/mcp`,
       context: {
         client_id: PRE_REGISTERED_CLIENT_ID,
-        client_secret: PRE_REGISTERED_CLIENT_SECRET
+        client_secret: PRE_REGISTERED_CLIENT_SECRET,
+        // The `issuer` the mock AS publishes in its metadata — the scenario
+        // sets neither `metadataIssuer` nor `routePrefix`, so createAuthServer
+        // resolves the published issuer to exactly this URL.
+        issuer: this.authServer.getUrl()
       }
     };
   }

--- a/src/schemas/context.ts
+++ b/src/schemas/context.ts
@@ -21,7 +21,8 @@ export const ClientConformanceContextSchema = z.discriminatedUnion('name', [
   z.object({
     name: z.literal('auth/pre-registration'),
     client_id: z.string(),
-    client_secret: z.string()
+    client_secret: z.string(),
+    issuer: z.string()
   }),
   z.object({
     name: z.literal('auth/enterprise-managed-authorization'),


### PR DESCRIPTION
Fixes #422
## What

`auth/pre-registration` hands the client under test `context: { client_id, client_secret }` with
no indication of which authorization server issued the credentials. The 2026-07-28 spec's
[Authorization Server Binding](https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization/client-registration#authorization-server-binding)
section says clients using pre-registered credentials **MUST** associate them with the issuing
authorization server, keyed by its `issuer` identifier. A client that takes the strict reading of
that MUST — refusing to present credentials it cannot bind — never makes a token request, and the
scenario's `pre-registration-auth` check fails ("Client did not make a token request"). The
scenario predates the rule (#120, Jan 2026, before SEP-2352) and was never updated.

This PR additively supplies the mock AS's issuer in the scenario context:

```ts
context: {
  client_id: PRE_REGISTERED_CLIENT_ID,
  client_secret: PRE_REGISTERED_CLIENT_SECRET,
  issuer: this.authServer.getUrl()
}
```

The emitted value equals the issuer the mock AS publishes in its metadata (the scenario sets
neither `metadataIssuer` nor `routePrefix`, so `createAuthServer` resolves the published issuer to
exactly this URL — pinned by a new self-test). Alongside:

- `src/schemas/context.ts` — the `auth/pre-registration` variant of
  `ClientConformanceContextSchema` gains `issuer: z.string()`.
- `examples/clients/typescript/everything-client.ts` — `runPreRegistration` demonstrates the
  intended use via the provider's existing SEP-2352 helper: `provider.bindIssuer(ctx.issuer)`.

This is the discovery half of what #285/#286 already settled behaviorally: #285 concluded issuer
*keying* isn't protocol-observable and #286 tests the enforcement side via
`auth/authorization-server-migration` — indeed #286 shipped `bindIssuer()` in this repo's own
example client precisely to key credentials by issuer, yet this scenario gave a client nothing to
key by. Real-world pre-registration always tells the operator which AS issued the credentials; the
scenario now does too. Strict clients become testable; warn-and-proceed clients are provably
unaffected (verified against the TypeScript SDK).

## Self-test (prove it passes and fails)

New test in `src/scenarios/client/auth/index.test.ts`: the scenario's emitted context parses
against `ClientConformanceContextSchema` and its `issuer` equals the `issuer` the mock AS serves
at `/.well-known/oauth-authorization-server` — the property a binding client depends on. The
strict-refusal red case is demonstrated with a real SDK below.

`npm test` 484/484, `npm run check` clean.

## Real-SDK evidence (per CONTRIBUTING)

**Strict client (PHP SDK, logiscape/mcp-sdk-php v2 `main`, draft track = mandatory issuer
binding, no legacy opt-out):**

- **Before (unpatched main):** 2/3 — `pre-registration-auth` FAILURE "Client did not make a token
  request"; the client refuses: "Pre-registered client credentials have no issuer binding…"
- **After (one-line change in its conformance client to pass `issuer` from context):** 14/14.

**Warn-path regression (official TypeScript SDK, current `main`, via the sdk-runner):** passes
before and after — its conformance client's non-strict context parsing strips the new key, so
behavior is byte-identical.

**This repo's example client:** `auth/pre-registration` 14/14 before and after; full `--suite
auth` 235/235 before and after (no delta in sibling scenarios).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [X] My code follows the repository's style guidelines
- [X] New and existing tests pass locally
- [X] I have added appropriate error handling
- [X] I have added or updated documentation as needed