### PR TITLE
feat: add swift-sdk to the built-in SDK matrix

### DIFF
--- a/src/sdk-runner/known-sdks.ts
+++ b/src/sdk-runner/known-sdks.ts
@@ -127,6 +127,24 @@ export const KNOWN_SDKS: Record<string, SdkConfig> = {
       }
     }
   },
+  // Fixtures live in Sources/MCPConformance/{Client,Server} — the
+  // mcp-everything-client and mcp-everything-server products, mirroring
+  // scripts/run-conformance.sh. SwiftPM writes binaries to a per-triple
+  // directory but also maintains a `.build/debug` symlink pointing at it, so
+  // the paths below stay portable across host architectures. The server
+  // defaults to port 3001; `--port` pins it to the 3000 convention used above.
+  'swift-sdk': {
+    build:
+      'swift build --product mcp-everything-client && swift build --product mcp-everything-server',
+    client: {
+      command: './.build/debug/mcp-everything-client'
+    },
+    server: {
+      command: './.build/debug/mcp-everything-server --port 3000',
+      url: 'http://localhost:3000/mcp'
+    },
+    expectedFailures: 'conformance-baseline.yml'
+  },
   // Fixtures live in tests/ModelContextProtocol.ConformanceClient and
   // tests/ModelContextProtocol.ConformanceServer (requires the .NET 10 SDK,
   // per global.json); build output goes to the repo-level artifacts/ tree

--- a/src/sdk-runner/sdk-runner.test.ts
+++ b/src/sdk-runner/sdk-runner.test.ts
@@ -74,7 +74,7 @@ describe('lookupBuiltinConfig', () => {
   });
 
   it('returns null for unknown SDKs', () => {
-    expect(lookupBuiltinConfig('swift-sdk')).toBeNull();
+    expect(lookupBuiltinConfig('kotlin-sdk')).toBeNull();
   });
 
   it('exposes python-sdk-v1 with repo + defaultRef + specVersion and both commands', () => {
@@ -139,6 +139,18 @@ describe('lookupBuiltinConfig', () => {
     expect(rs?.client?.command).toBe('./target/debug/conformance-client');
     expect(rs?.server?.command).toContain('conformance-server');
     expect(rs?.server?.url).toBe('http://localhost:3000/mcp');
+  });
+
+  it('exposes swift-sdk with the SwiftPM everything fixtures', () => {
+    const sw = lookupBuiltinConfig('swift-sdk');
+    expect(sw?.build).toContain('mcp-everything-client');
+    expect(sw?.build).toContain('mcp-everything-server');
+    // SwiftPM writes to a per-triple dir but keeps a .build/debug symlink to
+    // it, so these paths stay portable across host architectures.
+    expect(sw?.client?.command).toBe('./.build/debug/mcp-everything-client');
+    // The server defaults to 3001; --port pins it to the 3000 convention.
+    expect(sw?.server?.command).toContain('--port 3000');
+    expect(sw?.server?.url).toBe('http://localhost:3000/mcp');
   });
 
   it('every built-in entry validates against SdkConfigSchema', () => {


### PR DESCRIPTION
Register `swift-sdk` in the built-in SDK matrix using its existing `mcp-everything-client` and `mcp-everything-server` SwiftPM products. Build both fixtures, use `.build/debug` paths and start the server with `--port 3000` to match the runner URL. Change the unknown-SDK test fixture to `kotlin-sdk`.

The September 17 rebase onto `7169291ec0b6` preserves both the upstream Ruby registration test and this PR's Swift test. The Swift configuration is unchanged from the original patch.

Current validation: `npm run check`, `npm run build` and all 623 tests pass.

Live Swift fixture conformance was not rerun for this mechanical rebase. The original submission reported 216 core client passes and 67 server passes with two server failures; it also reported 22 failures in the wider client suite that were absent from the SDK baseline. Those are historical results, not current pass counts. No expected failures were added here to hide them. The related fixture fix remains modelcontextprotocol/swift-sdk#269.

AI assistance: this maintenance update, conflict resolution and verification were performed with Codex. The commands above were executed locally; no human review of this update is claimed.
