### PR TITLE
fix(input-required-result): report the capability check as untestable when nothing is requested

### DIFF
--- a/examples/servers/typescript/sep-2322-mrtr-broken-server.ts
+++ b/examples/servers/typescript/sep-2322-mrtr-broken-server.ts
@@ -8,6 +8,11 @@
  * 2. Returns InputRequiredResult on `tools/list` (unsupported method)
  * 3. Accepts tampered requestState without integrity verification
  *
+ * Plus one case that is not a violation at all:
+ *
+ * 4. Answers with a conformant input_required result that names no input
+ *    request, leaving the capability check with nothing to verify.
+ *
  * The conformance scenarios should emit FAILURE against this server.
  */
 
@@ -54,6 +59,11 @@ handlers['tools/list'] = () => ({
       name: 'test_input_required_result_tampered_state',
       description: 'Test tool for tampered state',
       inputSchema: { type: 'object' as const, properties: {} }
+    },
+    {
+      name: 'test_input_required_result_capabilities',
+      description: 'Test tool for client capability handling',
+      inputSchema: { type: 'object' as const, properties: {} }
     }
   ]
 });
@@ -91,6 +101,16 @@ handlers['tools/call'] = (params) => {
             }
           }
         }
+      };
+    }
+
+    case 'test_input_required_result_capabilities': {
+      // BUG 4: Conformant on its face — `requestState` satisfies "at least one
+      // of inputRequests or requestState" — but it names no input request, so
+      // the capability restriction under test is never exercised.
+      return {
+        resultType: 'input_required',
+        requestState: 'no-input-requested'
       };
     }
 

--- a/src/scenarios/server/input-required-result.ts
+++ b/src/scenarios/server/input-required-result.ts
@@ -22,6 +22,7 @@ import {
   mockListRootsResponse,
   MRTR_SPEC_REFERENCES
 } from './input-required-result-helpers';
+import { notTestable } from '../untestable';
 
 // ─── A1: Basic Elicitation ────────────────────────────────────────────────────
 
@@ -1424,14 +1425,28 @@ Only include inputRequests for methods the client supports. For example, if the 
 
       const result = resp.result;
       const errors: string[] = [];
+      let untestable = false;
 
       if (resp.error) {
         errors.push(`JSON-RPC error: ${resp.error.message}`);
       } else if (!result) {
         errors.push('No result in response');
-      } else if (isInputRequiredResult(result) && result.inputRequests) {
+      } else if (isInputRequiredResult(result)) {
+        const inputRequests = Object.entries(result.inputRequests ?? {});
+        // `inputRequests` is optional (a result carrying only `requestState` is
+        // still valid), so naming none does not violate the MUST NOT this check
+        // scores — but it leaves nothing to scan, and the loop below would then
+        // record no error at all, scoring SUCCESS without having verified it.
+        if (inputRequests.length === 0) {
+          untestable = true;
+          errors.push(
+            notTestable(
+              'server returned no inputRequests, so the capability restriction was never exercised'
+            )
+          );
+        }
         // Check that no elicitation requests are included (client didn't declare it)
-        for (const [key, req] of Object.entries(result.inputRequests)) {
+        for (const [key, req] of inputRequests) {
           if (req.method === 'elicitation/create') {
             errors.push(
               `Server included elicitation/create inputRequest (key: "${key}") ` +
@@ -1454,7 +1469,7 @@ Only include inputRequests for methods the client supports. For example, if the 
         timestamp: new Date().toISOString(),
         errorMessage: errors.length > 0 ? errors.join('; ') : undefined,
         specReferences: MRTR_SPEC_REFERENCES,
-        details: { result }
+        details: untestable ? { result, untestable: true } : { result }
       });
     } catch (error) {
       checks.push({

--- a/src/scenarios/server/negative-mrtr.test.ts
+++ b/src/scenarios/server/negative-mrtr.test.ts
@@ -13,7 +13,8 @@ import path from 'path';
 import {
   InputRequiredResultResultTypeScenario,
   InputRequiredResultUnsupportedMethodsScenario,
-  InputRequiredResultTamperedStateScenario
+  InputRequiredResultTamperedStateScenario,
+  InputRequiredResultCapabilityCheckScenario
 } from './input-required-result';
 import {
   formatWireViolation,
@@ -141,5 +142,19 @@ describe('SEP-2322 MRTR negative tests', () => {
     );
     expect(tamperedCheck).toBeDefined();
     expect(tamperedCheck?.status).toBe('FAILURE');
+  }, 10000);
+
+  it('reports sep-2322-respect-client-capabilities as untestable against a server whose input_required result requests nothing', async () => {
+    const scenario = new InputRequiredResultCapabilityCheckScenario();
+    const checks = await scenario.run(testContext(SERVER_URL));
+
+    const capabilityCheck = checks.find(
+      (c) => c.id === 'sep-2322-respect-client-capabilities'
+    );
+    expect(capabilityCheck).toBeDefined();
+    expect(capabilityCheck?.status).toBe('FAILURE');
+    // The requirement was not violated, it could not be exercised (#248).
+    expect(capabilityCheck?.errorMessage).toContain('Not testable:');
+    expect(capabilityCheck?.details?.untestable).toBe(true);
   }, 10000);
 });


### PR DESCRIPTION
Narrows #439 item 3. The round-2 consequence of the same case is #440; this PR
does not touch it.

## The bug

`input-required-result-capability-check` guarded its elicitation scan with:

```ts
} else if (isInputRequiredResult(result) && result.inputRequests) {
```

With `inputRequests` absent, that arm is skipped and the following
`isCompleteResult` arm is false by construction for an `input_required` result, so
nothing is recorded and the check passes. `inputRequests: {}` passes by a different
path — the arm *is* taken (`{}` is truthy), the loop just has nothing to scan.

Either way the check reports SUCCESS without having exercised the requirement it
scores.

## Why `notTestable()` rather than a plain assertion

`inputRequests` is optional — a result carrying only `requestState` still satisfies
"at least one of `inputRequests` or `requestState`" — so a server that names none
has not violated `sep-2322-respect-client-capabilities`
(_"Servers MUST NOT send an inputRequests that the client has not declared support
for in its capabilities"_). It has not exercised it either.

That is the #248 / #372 case, so the check now reports through `notTestable()` with
`details.untestable`, per AGENTS.md and the existing call sites in `stateless.ts`.
Status stays FAILURE — the severity follows the underlying MUST NOT — but the
message says the requirement could not be verified rather than claiming a violation
the server did not commit.

## Does this fail a compliant implementation?

No. The scenario's description is an explicit fixture contract: implement
`test_input_required_result_capabilities`, read
`_meta['io.modelcontextprotocol/clientCapabilities']`, and return inputRequests for
the declared capabilities. The probe declares `sampling: {}`, so a server following
that contract returns a `sampling/createMessage` request and still scores SUCCESS
(verified below).

What now goes red is a server that implements the tool but returns no input
request — i.e. the fixture prerequisite is missing, which is exactly what #248
says should be red, with the expected-failures baseline as the escape hatch. It is
still a behaviour change for anyone currently green on that basis.

## Fixture

Adds the case to `sep-2322-mrtr-broken-server`. The fixture returns a *conformant*
envelope — `requestState` present, no input requests — rather than a bare
`{"resultType":"input_required"}`, so it isolates this check instead of also
tripping `sep-2322-request-state-incomplete`.

## Verified

Against `--spec-version 2026-07-28`:

```
everything-server              Passed: 2/2, 0 failed, 0 warnings

sep-2322-mrtr-broken-server    FAILURE  RespectClientCapabilities
                               Not testable: server returned no inputRequests,
                               so the capability restriction was never exercised
```

The negative test pins the slug, the `Not testable:` prefix and
`details.untestable` rather than just asserting a failure count.

`npm run lint`, `npm run typecheck` and the full `vitest run` (43 files / 505
tests) pass.
