### PR TITLE
fix(sep-2243): reject x-mcp-header on number-typed params

### DIFF
--- a/src/scenarios/client/http-custom-headers.test.ts
+++ b/src/scenarios/client/http-custom-headers.test.ts
@@ -30,6 +30,18 @@ async function post(
   });
 }
 
+async function postJson(serverUrl: string, body: object): Promise<any> {
+  const res = await fetch(serverUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream'
+    },
+    body: JSON.stringify(body)
+  });
+  return res.json();
+}
+
 function idsOf(checks: { id: string }[]): Set<string> {
   return new Set(checks.map((c) => c.id));
 }
@@ -193,6 +205,44 @@ describe('HttpInvalidToolHeadersScenario (SEP-2243) check IDs', () => {
       // The other constraints were not violated.
       expect(
         statusesFor(checks, 'sep-2243-x-mcp-header-charset')
+      ).not.toContain('FAILURE');
+    } finally {
+      await scenario.stop();
+    }
+  });
+
+  it('FAILs primitive-only when the client calls the number-typed tool', async () => {
+    const scenario = new HttpInvalidToolHeadersScenario();
+    const { serverUrl } = await scenario.start(testScenarioContext());
+    try {
+      const listed = await postJson(serverUrl, {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/list'
+      });
+      // SEP-2243 permits x-mcp-header only on integer/string/boolean, so the
+      // number-typed tool must be served for the client to reject it.
+      const numberTool = listed.result.tools.find(
+        (t: { name: string }) => t.name === 'invalid_number_header'
+      );
+      expect(numberTool?.inputSchema.properties.score).toEqual({
+        type: 'number',
+        'x-mcp-header': 'Score'
+      });
+
+      await post(serverUrl, {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'invalid_number_header', arguments: { score: 1.5 } }
+      });
+      const checks = scenario.getChecks();
+      expect(
+        statusesFor(checks, 'sep-2243-x-mcp-header-primitive-only')
+      ).toContain('FAILURE');
+      // The other constraints were not violated.
+      expect(
+        statusesFor(checks, 'sep-2243-x-mcp-header-not-empty')
       ).not.toContain('FAILURE');
     } finally {
       await scenario.stop();

--- a/src/scenarios/client/http-custom-headers.ts
+++ b/src/scenarios/client/http-custom-headers.ts
@@ -68,6 +68,7 @@ const INVALID_TOOL_CONSTRAINT_IDS: Record<string, string> = {
   invalid_object_header: 'sep-2243-x-mcp-header-primitive-only',
   invalid_array_header: 'sep-2243-x-mcp-header-primitive-only',
   invalid_null_header: 'sep-2243-x-mcp-header-primitive-only',
+  invalid_number_header: 'sep-2243-x-mcp-header-primitive-only',
   invalid_duplicate_same_case: 'sep-2243-x-mcp-header-unique',
   invalid_duplicate_diff_case: 'sep-2243-x-mcp-header-unique',
   invalid_space_in_name: 'sep-2243-x-mcp-header-charset',
@@ -858,6 +859,23 @@ export class HttpInvalidToolHeadersScenario extends BaseHttpScenario {
                 nil: { type: 'null', 'x-mcp-header': 'Nil' }
               },
               required: ['nil']
+            }
+          },
+
+          // ── Invalid: x-mcp-header on number type ──
+          // `number` is a JSON Schema primitive but SEP-2243 excludes it from
+          // the permitted set: "Parameters with type `number` are not
+          // permitted." Only integer, string and boolean may be annotated.
+          {
+            name: 'invalid_number_header',
+            description:
+              'x-mcp-header MUST NOT be on number type (MUST be rejected)',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                score: { type: 'number', 'x-mcp-header': 'Score' }
+              },
+              required: ['score']
             }
           },
 

--- a/src/seps/sep-2243.yaml
+++ b/src/seps/sep-2243.yaml
@@ -23,13 +23,13 @@ requirements:
     text: 'The x-mcp-header value MUST be case-insensitively unique within a single tool definition.'
     url: https://modelcontextprotocol.io/specification/draft/server/tools#custom-headers
   - check: sep-2243-x-mcp-header-primitive-only
-    text: 'x-mcp-header MUST only be applied to parameters with primitive types (number, string, or boolean).'
+    text: 'x-mcp-header MUST only be applied to parameters with primitive types (integer, string, boolean). Parameters with type `number` are not permitted.'
     url: https://modelcontextprotocol.io/specification/draft/server/tools#custom-headers
   - check: sep-2243-client-reject-invalid-tool
     text: 'Clients MUST reject tool definitions where any x-mcp-header value violates these constraints. Rejection means the client MUST exclude the invalid tool from the set of tools returned by tools/list.'
     url: https://modelcontextprotocol.io/specification/draft/server/tools#custom-headers
   - check: sep-2243-client-encode-values
-    text: 'Clients MUST encode parameter values before including them in HTTP headers: number values MUST be converted to their decimal string representation; boolean values MUST be converted to the lowercase strings "true" or "false".'
+    text: 'Clients MUST encode parameter values before including them in HTTP headers: integer values MUST be converted to their decimal string representation; boolean values MUST be converted to the lowercase strings "true" or "false".'
   - check: sep-2243-client-base64-unsafe
     text: 'When a value cannot be safely represented as plain ASCII (e.g., contains non-ASCII characters, control characters, or leading/trailing whitespace), clients MUST use Base64 encoding of the UTF-8 representation, wrapped as =?base64?{encoded}?=.'
   - check: sep-2243-server-decode-base64

--- a/src/seps/traceability.json
+++ b/src/seps/traceability.json
@@ -209,7 +209,7 @@
         {
           "check": "sep-2243-x-mcp-header-primitive-only",
           "status": "tested",
-          "text": "x-mcp-header MUST only be applied to parameters with primitive types (number, string, or boolean).",
+          "text": "x-mcp-header MUST only be applied to parameters with primitive types (integer, string, boolean). Parameters with type `number` are not permitted.",
           "url": "https://modelcontextprotocol.io/specification/draft/server/tools#custom-headers"
         },
         {
@@ -221,7 +221,7 @@
         {
           "check": "sep-2243-client-encode-values",
           "status": "tested",
-          "text": "Clients MUST encode parameter values before including them in HTTP headers: number values MUST be converted to their decimal string representation; boolean values MUST be converted to the lowercase strings \"true\" or \"false\"."
+          "text": "Clients MUST encode parameter values before including them in HTTP headers: integer values MUST be converted to their decimal string representation; boolean values MUST be converted to the lowercase strings \"true\" or \"false\"."
         },
         {
           "check": "sep-2243-client-base64-unsafe",


### PR DESCRIPTION
Closes #344

## Why this is still open after #371

SEP-2243 permits `x-mcp-header` only on **integer, string and boolean** parameters. The released `2026-07-28` spec is explicit:

> `x-mcp-header` **MUST** only be applied to parameters with primitive types (integer, string, boolean). Parameters with type `number` are not permitted.
> — [`server/tools.mdx`](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/docs/specification/2026-07-28/server/tools.mdx)

and the value-encoding table in `basic/transports/streamable-http.mdx` lists only `string` / `integer` / `boolean`.

#371 fixed the **positive** fixture (`priority` is now `integer`, `float_val` is served unannotated and asserted *not* mirrored) but left the two items #344 listed as optional, which is why the issue stayed open. This finishes them.

## Changes

**1. Negative case for the `number` rule.** `HttpInvalidToolHeadersScenario` served invalid tools for every other `x-mcp-header` constraint — empty / object / array / null / duplicate / space / colon / non-ascii / control-char — but had no number-typed one. `sep-2243-x-mcp-header-primitive-only` was only ever exercised via object/array/null, so nothing verified the rule the issue was actually about. Adds an `invalid_number_header` tool with `score: { type: 'number', 'x-mcp-header': 'Score' }`, mapped to the existing requirement.

No check IDs added or removed — `INVALID_TOOL_DECLARED_CHECK_IDS` is unchanged.

**2. Requirement text corrected.** `sep-2243.yaml` still described the permitted set as "(number, string, or boolean)" and said "number values MUST be converted to their decimal string representation" — both contradict the released spec. `traceability.json` embeds this text verbatim, so its two `text` fields are updated in place; check IDs and `status` are untouched.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run build` clean; `npm test` 505 passed / 43 files.
- **Mutation-tested**: removing the `INVALID_TOOL_CONSTRAINT_IDS` mapping makes the new test fail (`expected [ 'SUCCESS', 'SUCCESS', 'SUCCESS' ] to include 'FAILURE'`), so it isn't vacuous.
- Ran both scenarios against typescript-sdk@main: positive `http-custom-headers` still 18/18.

## The new check finds a real SDK bug

`http-invalid-tool-headers` against typescript-sdk@main goes 11/12 — `sep-2243-x-mcp-header-primitive-only` fails on `invalid_number_header`. The cause is in the SDK, not the harness:

```ts
// packages/core-internal/src/shared/mcpParamHeaders.ts
const PERMITTED_X_MCP_HEADER_TYPES = new Set(['string', 'integer', 'boolean', 'number']);
```

`number` was allow-listed there *specifically* to tolerate this fixture bug, with a comment noting the discrepancy is "tracked upstream." With #371 having fixed the fixture, that workaround can be dropped. Worth a follow-up on the SDK side.

This won't red-light CI: `ci.yml` runs only `npm ci` / `check` / `build` / `test`. The typescript-sdk run lives in `traceability.yml`, which is manual/scheduled, uses `|| true`, and per AGENTS.md is not a PR gate.

## Out of scope

#354 (positive scenario's `ttlMs: 0` vs. SEP-2549 stale-schema) is a separate defect owned by #358. The positive scenario's TTL is untouched here, and #358's scope note confirms it doesn't modify the invalid-tool scenario — so these shouldn't collide beyond a trivial rebase.