### PR TITLE
Freeze conformance requirements per spec revision, run each at its wire

### DIFF
--- a/.claude/skills/mcp-sdk-tier-audit/README.md
+++ b/.claude/skills/mcp-sdk-tier-audit/README.md
@@ -9,6 +9,15 @@ Two components work together:
 
 ## Quick Start: CLI
 
+For an SDK listed in `src/sdk-runner/known-sdks.ts`, tier-check manages the whole conformance side itself — clone/build, then for each shipped revision the server invocation that SDK declares for that revision:
+
+```bash
+gh auth login
+npx @modelcontextprotocol/conformance tier-check --sdk go-sdk
+```
+
+The per-SDK sections below are for the manual path: driving a server you started yourself.
+
 The CLI is a subcommand of the [MCP Conformance](https://github.com/modelcontextprotocol/conformance) tool.
 
 ```bash
@@ -95,56 +104,33 @@ The skill lives in `.claude/skills/` in this repo, so if you open [Claude Code](
 3. Run the skill:
 
 ```
-/mcp-sdk-tier-audit <local-sdk-path> <conformance-server-url> [client-cmd]
+/mcp-sdk-tier-audit <local-sdk-path> <conformance-server-url> [client-cmd] [--requirements <revision>]
 ```
 
 Pass the client command as the third argument to include client conformance testing. If omitted, client conformance is skipped and noted as a gap in the report.
 
-**TypeScript SDK example:**
+**Pass `--requirements` with every revision the SDK claims**, comma-separated. Each revision's scenarios run at that revision's own wire version, and all of them must pass for Tier 1: the dated revisions through `2025-11-25` use the stateful initialize handshake while `2026-07-28` is stateless, so a scenario belonging to both has to work on both and one run does not cover the other. It also means a scenario added to the suite after a revision shipped cannot fail an SDK that had no opportunity to adopt it. Without the flag, scoring uses the suite as it stands today, which is not a tier claim. See [Conformance Requirements](../../../README.md#conformance-requirements), and run `conformance list --requirements 2025-11-25,2026-07-28` to see both sets.
 
-```bash
-# Terminal 1: start the everything server (build first: npm run build)
-cd ~/src/mcp/typescript-sdk && npm run test:conformance:server:run
+**Known SDKs — no server to start, no commands to look up:**
 
-# Terminal 2: run the audit (from the conformance repo)
-/mcp-sdk-tier-audit ~/src/mcp/typescript-sdk http://localhost:3000/mcp "npx tsx ~/src/mcp/typescript-sdk/test/conformance/src/everythingClient.ts"
+```
+/mcp-sdk-tier-audit <sdk checkout> --requirements 2025-11-25,2026-07-28
 ```
 
-**Python SDK example:**
+The skill drives `tier-check --sdk-path`, which builds the SDK and starts the
+server invocation its config declares **per revision** — the per-SDK commands
+live in [`src/sdk-runner/known-sdks.ts`](../../../src/sdk-runner/known-sdks.ts),
+not here. That matters because a hand-run example cannot be correct for every
+SDK: go-sdk needs a different server process per revision (`-stateless` defaults
+to true, so a bare invocation mis-measures 2025-11-25 — [#446](https://github.com/modelcontextprotocol/conformance/issues/446)),
+and csharp-sdk serves the two revisions at different endpoints. Prose copies of
+those invocations drift; the config is tested.
 
-```bash
-# Terminal 1: install and start the everything server
-cd ~/src/mcp/python-sdk && uv sync --frozen --all-extras --package mcp-everything-server
-uv run mcp-everything-server --port 3001
+**An SDK not in `known-sdks.ts`:** start its everything server yourself and pass
+the URL and client command explicitly — see [Other SDKs](#running-conformance-tests)
+below. The one endpoint you give must serve every claimed revision at its own
+wire, or the numbers will be wrong for the revisions it does not speak.
 
-# Terminal 2: run the audit (from the conformance repo)
-/mcp-sdk-tier-audit ~/src/mcp/python-sdk http://localhost:3001/mcp "uv run python ~/src/mcp/python-sdk/.github/actions/conformance/client.py"
-```
-
-**Go SDK example:**
-
-```bash
-# Terminal 1: build and start the everything server
-cd ~/src/mcp/go-sdk && go build -o /tmp/go-conformance-server ./conformance/everything-server
-go build -o /tmp/go-conformance-client ./conformance/everything-client
-/tmp/go-conformance-server -http="localhost:3002"
-
-# Terminal 2: run the audit (from the conformance repo)
-/mcp-sdk-tier-audit ~/src/mcp/go-sdk http://localhost:3002 "/tmp/go-conformance-client"
-```
-
-**C# SDK example:**
-
-```bash
-# Terminal 1: start the everything server (requires .NET SDK)
-cd ~/src/mcp/csharp-sdk
-dotnet run --project tests/ModelContextProtocol.ConformanceServer --framework net9.0 -- --urls http://localhost:3003
-
-# Terminal 2: run the audit (from the conformance repo)
-/mcp-sdk-tier-audit ~/src/mcp/csharp-sdk http://localhost:3003 "dotnet run --project ~/src/mcp/csharp-sdk/tests/ModelContextProtocol.ConformanceClient"
-```
-
-The skill derives `owner/repo` from git remote, runs the CLI, launches parallel evaluations for docs and policy, and writes detailed reports to `results/`.
 
 ### Any Other AI Coding Agent
 
@@ -181,66 +167,17 @@ Run the CLI for the scorecard, then review docs and policies yourself using the 
 
 ## Running Conformance Tests
 
-To include conformance test results, start the SDK's everything server first, then pass the URL to the CLI. To also run client conformance tests, pass `--client-cmd` with the command to launch the SDK's conformance client.
-
-**TypeScript SDK**:
+For any SDK in [`src/sdk-runner/known-sdks.ts`](../../../src/sdk-runner/known-sdks.ts), don't start servers by hand — the config runs the right invocation per revision:
 
 ```bash
-# Terminal 1: start the server (SDK must be built first)
-cd ~/src/mcp/typescript-sdk && npm run build
-npm run test:conformance:server:run   # starts on port 3000
+# both legs, every revision, one verdict
+npx @modelcontextprotocol/conformance tier-check --sdk go-sdk
 
-# Terminal 2: run tier-check (server + client conformance)
-npm run --silent tier-check -- \
-  --repo modelcontextprotocol/typescript-sdk \
-  --conformance-server-url http://localhost:3000/mcp \
-  --client-cmd 'npx tsx ~/src/mcp/typescript-sdk/test/conformance/src/everythingClient.ts'
+# a single leg at a single revision, for debugging
+npx @modelcontextprotocol/conformance sdk --path <sdk checkout> --mode server --requirements 2026-07-28
 ```
 
-**Python SDK**:
-
-```bash
-# Terminal 1: install and start the server
-cd ~/src/mcp/python-sdk
-uv sync --frozen --all-extras --package mcp-everything-server
-uv run mcp-everything-server --port 3001   # specify port to avoid conflicts
-
-# Terminal 2: run tier-check (server + client conformance)
-npm run --silent tier-check -- \
-  --repo modelcontextprotocol/python-sdk \
-  --conformance-server-url http://localhost:3001/mcp \
-  --client-cmd 'uv run python ~/src/mcp/python-sdk/.github/actions/conformance/client.py'
-```
-
-**Go SDK**:
-
-```bash
-# Terminal 1: build and start the server
-cd ~/src/mcp/go-sdk
-go build -o /tmp/go-conformance-server ./conformance/everything-server
-go build -o /tmp/go-conformance-client ./conformance/everything-client
-/tmp/go-conformance-server -http="localhost:3002"
-
-# Terminal 2: run tier-check (server + client conformance)
-npm run --silent tier-check -- \
-  --repo modelcontextprotocol/go-sdk \
-  --conformance-server-url http://localhost:3002 \
-  --client-cmd '/tmp/go-conformance-client'
-```
-
-**C# SDK**:
-
-```bash
-# Terminal 1: start the server (requires .NET SDK)
-cd ~/src/mcp/csharp-sdk
-dotnet run --project tests/ModelContextProtocol.ConformanceServer --framework net9.0 -- --urls http://localhost:3003
-
-# Terminal 2: run tier-check (server + client conformance)
-npm run --silent tier-check -- \
-  --repo modelcontextprotocol/csharp-sdk \
-  --conformance-server-url http://localhost:3003 \
-  --client-cmd 'dotnet run --project ~/src/mcp/csharp-sdk/tests/ModelContextProtocol.ConformanceClient'
-```
+To reproduce one leg fully by hand, copy the build/server/client commands from that SDK's `known-sdks.ts` entry (including its `specOverrides` for the revision you're running) rather than from a README: the entries are exercised by the test suite and per-revision, prose examples are neither.
 
 **Other SDKs:** Your SDK needs an "everything server" — an HTTP server implementing the [Streamable HTTP transport](https://modelcontextprotocol.io/specification/draft/basic/transports.md) with all MCP features (tools, resources, prompts, etc.). See the implementations above as reference.
 

--- a/.claude/skills/mcp-sdk-tier-audit/SKILL.md
+++ b/.claude/skills/mcp-sdk-tier-audit/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   Produces tier classification (1/2/3) with evidence table, gap list, and
   remediation guide. Works for any official MCP SDK (TypeScript, Python, Go,
   C#, Java, Kotlin, PHP, Swift, Rust, Ruby).
-argument-hint: '<local-path> <conformance-server-url> [client-cmd] [--branch <branch>]'
+argument-hint: '<local-path> [conformance-server-url] [client-cmd] [--requirements <revisions>] [--branch <branch>]'
 ---
 
 # MCP SDK Tier Audit
@@ -26,7 +26,9 @@ If this fails (exit code non-zero or shows "not logged in"), stop immediately an
 
 Do NOT proceed to any other step if this check fails.
 
-After parsing arguments (Step 1), also verify the conformance server is reachable:
+**Known SDKs need no server from you.** When the SDK is in `src/sdk-runner/known-sdks.ts` (typescript-sdk, python-sdk, go-sdk, rust-sdk, csharp-sdk, and variants), skip the server preflight entirely: Step 2's `--sdk-path` mode builds the SDK and starts the right server per revision itself. The reachability check below applies only to the URL fallback for unknown SDKs.
+
+After parsing arguments (Step 1), for the URL fallback only, verify the conformance server is reachable:
 
 ```bash
 curl -sf <conformance-server-url> -o /dev/null -w '%{http_code}' 2>&1 || true
@@ -41,8 +43,9 @@ If the server is not reachable, stop and tell the user:
 Extract from the user's input:
 
 - **local-path**: absolute path to the SDK checkout (e.g. `~/src/mcp/typescript-sdk`)
-- **conformance-server-url**: URL where the SDK's everything server is already running (e.g. `http://localhost:3000/mcp`)
+- **conformance-server-url** (only for SDKs not in `known-sdks.ts`): URL where the SDK's everything server is already running (e.g. `http://localhost:3000/mcp`). That one endpoint must serve every claimed revision at its own wire version; SDKs that vary the server per revision cannot be driven this way
 - **client-cmd** (optional): command to run the SDK's conformance client (e.g. `npx tsx test/conformance/src/everythingClient.ts`). If not provided, client conformance tests are skipped and noted as a gap in the report.
+- **requirements** (optional): spec revisions to score against, comma-separated, e.g. `--requirements 2025-11-25,2026-07-28`. Each revision's scenarios run at that revision's wire version, and every listed revision must pass for Tier 1. Scores the SDK against exactly the scenarios that revision required when it shipped, rather than everything the suite carries today. Prefer it whenever the question is "does this SDK conform to revision X". Without it, scoring uses today's suite, which can fail an SDK for a scenario added after it shipped. Run `conformance list --requirements <revision>` to see the set.
 - **branch** (optional): Git branch to check on GitHub (e.g. `--branch fweinberger/v1x-governance-docs`). If not provided, derive from the local checkout's current branch: `cd <local-path> && git rev-parse --abbrev-ref HEAD`. This is passed to the tier-check CLI so that policy signal file checks use the correct branch instead of the repo's default branch.
 
 The first two arguments are required. If either is missing, ask the user to provide it.
@@ -57,14 +60,34 @@ cd <local-path> && git remote get-url origin | sed 's#.*github.com[:/]##; s#\.gi
 
 The `tier-check` CLI handles all deterministic checks — server conformance, client conformance, labels, triage, P0 resolution, releases, policy signals, and spec tracking. You are already in the conformance repo, so run it directly.
 
+For a known SDK, this manages everything — build, per-revision server, both legs:
+
+```bash
+npm run --silent tier-check -- \
+  --sdk-path <local-path> \
+  --requirements <revisions> \
+  --output json
+```
+
+`--repo` and `--branch` are derived from the SDK config and checkout; pass them only to override. For an SDK not in `known-sdks.ts`, fall back to driving it directly:
+
 ```bash
 npm run --silent tier-check -- \
   --repo <owner/repo> \
   --branch <branch> \
+  --requirements <revisions> \
   --conformance-server-url <conformance-server-url> \
   --client-cmd '<client-cmd>' \
   --output json
 ```
+
+Omit `--requirements` only if the user did not name a revision. When it is set the
+scorecard reports `requirements_revision`, both pass rates count exactly the
+scenarios that revision requires, and anything run but not scored carries a
+`notScoredReason` of `extension` or `added-after-release`. `requirements_revisions`
+lists every revision scored, and each detail carries the `revision` it came from. Quote the revision
+alongside any conformance number, and report the not-scored failures separately
+rather than folding them into the score or omitting them.
 
 If no client-cmd was detected, omit the `--client-cmd` flag (client conformance will be skipped). The `--branch` flag should always be included (derived from the local checkout if not explicitly provided).
 
@@ -117,8 +140,8 @@ Combine the deterministic scorecard (from the CLI) with the evaluation results (
 
 ### Tier 1 requires ALL of:
 
-- Server conformance test pass rate == 100% (date-versioned scenarios only; `draft` and `extension` are informational and not scored)
-- Client conformance test pass rate == 100% (date-versioned scenarios only; `draft` and `extension` are informational and not scored)
+- Server conformance test pass rate == 100% across every requirement set given to `--requirements` (each run at its own wire), otherwise of date-versioned scenarios only
+- Client conformance test pass rate == 100%, on the same basis
 - Issue triage compliance >= 90% within 2 business days
 - All P0 bugs resolved within 7 days
 - Stable release >= 1.0.0 with no pre-release suffix

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ npx @modelcontextprotocol/conformance client --command "<client-command>" --scen
 - `--suite` - Run a suite of tests in parallel: `all`, `core`, `extensions`, `backcompat`, `auth`, `metadata`, `draft` (scenarios targeting the in-progress draft spec), or `sep-835`
 - `--spec-version <version>` - Filter scenarios by spec version (e.g., `2025-11-25`, `2026-07-28`; `draft` is accepted as an alias for the current draft identifier). The draft version selects the latest dated release plus any draft-only scenarios. When omitted, the version is inferred from the scenario's spec applicability (draft-only scenarios run at the draft version, everything else at the latest dated release); an explicitly requested version outside a scenario's applicability window skips the scenario (exit 0) unless `--force` is passed
 - `--force` - Run a scenario even if it is not applicable at the requested `--spec-version`
+- `--requirements <revision>` - Run exactly what a spec revision requires, frozen at its release (see [Conformance Requirements](#conformance-requirements))
 - `--expected-failures <path>` - Path to YAML baseline file of known failures (see [Expected Failures](#expected-failures))
 - `--timeout` - Timeout in milliseconds (default: 30000)
 - `--verbose` - Show verbose output
@@ -83,6 +84,7 @@ npx @modelcontextprotocol/conformance server --url <url> [--scenario <scenario>]
 - `--url` - URL of the server to test
 - `--scenario <scenario>` - Test scenario to run (e.g., "server-initialize"). Runs all available scenarios by default
 - `--suite <suite>` - Suite to run: "active" (default; excludes pending and draft-spec scenarios), "all", "draft" (scenarios targeting the in-progress draft spec), or "pending"
+- `--requirements <revision>` - Run exactly what a spec revision requires, frozen at its release (see [Conformance Requirements](#conformance-requirements))
 - `--expected-failures <path>` - Path to YAML baseline file of known failures (see [Expected Failures](#expected-failures))
 - `--verbose` - Show verbose output
 
@@ -115,6 +117,74 @@ synthetic checks alongside the scenario's own:
 Scenarios that exchange no instrumented wire traffic (see issue #418) emit
 neither check. Like any other check, `wire-schema-valid` can be baselined via
 the expected-failures file.
+
+## Conformance Requirements
+
+`--suite` and `--spec-version` describe the suite as it is today. Neither answers
+"which scenarios did I need to pass to conform to the spec released on
+2026-07-28", because the suite keeps growing: a scenario merged after a revision
+ships still carries that revision's applicability tag, so it is
+indistinguishable from one that existed at release.
+
+A requirement set answers that question. Each `requirements/<revision>.yaml`
+names the scenarios a revision requires, for the two roles the specification
+defines: an MCP server acting as an OAuth resource server, and an MCP client
+acting as an OAuth client. It deliberately covers no authorization-server
+scenarios, because the specification puts authorization server implementation
+beyond its own scope, so those scenarios serve people deploying an authorization
+server rather than implementations of MCP itself.
+
+**Scenarios run at their revision's wire version.** That is the point of a
+per-revision set, not a label on it: the dated revisions through `2025-11-25`
+use the stateful initialize handshake and `2026-07-28` is stateless with
+per-request `_meta`, and a scenario emits different checks under each. A
+scenario belonging to both revisions must therefore be run twice, once under
+each set. Passing it on one wire says nothing about the other:
+
+```bash
+# what does conforming to 2026-07-28 actually require?
+npx @modelcontextprotocol/conformance list --requirements 2026-07-28
+
+# run exactly that
+npx @modelcontextprotocol/conformance server --url http://localhost:3000/mcp --requirements 2026-07-28
+```
+
+`--requirements` replaces `--suite`, `--spec-version` and `--scenario`, since the
+set already names every scenario that runs and the revision fixes the wire they
+run at. Without it nothing changes: the default is still to run everything, which
+is where completeness lives.
+
+`tier-check` takes several at once, and every one of them must pass for Tier 1:
+
+```bash
+npx @modelcontextprotocol/conformance tier-check --repo <owner/repo> \
+  --conformance-server-url http://localhost:3000/mcp \
+  --requirements 2025-11-25,2026-07-28
+```
+
+Only scenarios a revision actually requires decide the exit code and the pass
+rate. Anything run without being scored is reported separately and cannot fail
+the run.
+
+Requirement sets are frozen, and `not_scored` holds what a revision runs and
+reports without counting. Two reasons qualify, and the report names which
+applies:
+
+| Reason                | Meaning                                                                                                                                                    |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `extension`           | Optional by definition. SEP-1730: "Experimental features and protocol extensions (such as Tasks and MCP Apps) are not required for any tier."              |
+| `added-after-release` | The scenario did not exist when the revision shipped, so no implementation could have been passing it.                                                     |
+| `pending`             | The suite's own reference fixture cannot pass it yet, so it cannot be required — but the implementation under test may pass it, so it runs for visibility. |
+
+Both still run, so a failing extension stays visible in the report; neither moves
+the pass rate. Promoting an entry into the required lists is a deliberate,
+reviewable change, which is how the suite grows without retroactively failing
+anyone.
+
+This is the project's contract and lives in this repository. It is the opposite
+of an [expected-failures](#expected-failures) baseline, which lives in an
+implementation's own repository and records what that implementation knows it
+fails. A baselined failure is still a failure against a requirement set.
 
 ## Expected Failures
 
@@ -326,26 +396,86 @@ Clones are cached under `.sdk-under-test/` and reused (fetched) on subsequent ru
 
 ## SDK Tier Assessment
 
-The `tier-check` subcommand evaluates an MCP SDK repository against [SEP-1730](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1730) (the SDK Tiering System):
+The `tier-check` subcommand evaluates an MCP SDK repository against [SEP-1730](https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1730) (the SDK Tiering System). There are two ways to run it, and they answer different questions.
+
+### 1. The CLI, for the deterministic half
+
+Conformance pass rates, issue triage, P0 resolution, labels, releases, policy files. No AI, no judgment, reproducible.
+
+For a known SDK (see `src/sdk-runner/known-sdks.ts`), one command does the whole
+thing — clone, build, and for **each** shipped revision start the server
+invocation that SDK's config declares for that revision, run both legs at that
+revision's wire, and merge:
 
 ```bash
-# Without conformance tests (fastest)
 gh auth login
-npm run --silent tier-check -- --repo modelcontextprotocol/typescript-sdk --skip-conformance
+npx @modelcontextprotocol/conformance tier-check --sdk go-sdk
+# or against a checkout you already have:
+npx @modelcontextprotocol/conformance tier-check --sdk-path ~/src/go-sdk
+```
 
-# With conformance tests (start the everything server first)
-npm run --silent tier-check -- \
+Per-revision resolution is the point, not a convenience. Some SDKs fix their
+wire era per server process (go-sdk only speaks 2026-07-28 when started
+stateless) or per endpoint (csharp-sdk serves it at `/stateless`), so no single
+server URL can be measured against two revisions. The per-SDK, per-revision
+invocations live in `known-sdks.ts` `specOverrides`; adding an SDK there is how
+it joins the matrix.
+
+For an SDK not in the config, drive it directly — but then the one endpoint you
+give must serve every claimed revision at its own wire, and the server must
+already be running:
+
+```bash
+npx @modelcontextprotocol/conformance tier-check \
   --repo modelcontextprotocol/typescript-sdk \
-  --conformance-server-url http://localhost:3000/mcp
+  --conformance-server-url http://localhost:3000/mcp \
+  --client-cmd '<command that runs the SDK conformance client>' \
+  --requirements 2025-11-25,2026-07-28
 ```
 
-For a full AI-assisted assessment with remediation guide, use Claude Code:
+Omit `--client-cmd` and the client leg is skipped and reported as a gap. Omit
+`--requirements` and scoring falls back to the suite as it stands today, which is
+not what you want for a tier claim; see [Conformance Requirements](#conformance-requirements).
+
+The exit code is a CI verdict on the machine-checkable half: nonzero when any
+scored conformance scenario fails or a leg could not be measured. Governance
+findings (triage, P0s, policy files) shape the tier but never the exit code.
+
+### 2. The skill, for the whole assessment
+
+The CLI cannot judge documentation coverage, dependency policy or roadmap quality, and those decide the tier as much as conformance does. The [`mcp-sdk-tier-audit`](.claude/skills/mcp-sdk-tier-audit/README.md) skill runs the CLI, adds those evaluations, and writes a full report with a remediation plan. In Claude Code, from a checkout of this repo:
 
 ```
-/mcp-sdk-tier-audit <local-sdk-path> <conformance-server-url>
+/mcp-sdk-tier-audit <local-sdk-path> <conformance-server-url> '<client-cmd>' --requirements 2025-11-25,2026-07-28
 ```
 
-See [`.claude/skills/mcp-sdk-tier-audit/README.md`](.claude/skills/mcp-sdk-tier-audit/README.md) for full documentation.
+The server must already be running and stay up for the whole audit. Expect a few minutes.
+
+### Reading the result
+
+```
+Scored against 2025-11-25 and 2026-07-28, each run at its own wire version.
+
+    Server   67/67 required scenarios (100%)
+    Client   50/50 required scenarios (100%)
+
+  Not scored (8 run, 4 failing, no effect on tier):
+    ✗ auth/dpop (extension)
+    ✗ json-schema-2020-12-preservation (added-after-release)
+
+Tier 1 Blockers:
+  • triage
+  • p0_resolution
+```
+
+- **Required scenarios** are the only ones that move the number. `67/67` spans every revision listed: a scenario belonging to both runs once per revision, on that revision's wire, and both have to pass.
+- **Not scored** ran and is reported so you can see it, but cannot fail the tier. `extension` means optional by definition; `added-after-release` means the scenario did not exist when that revision shipped. A failure here is information, not a blocker.
+- **Not measured** is different from either, and means the run could not happen at all, e.g. a requirement set naming a scenario this build no longer has. Treat it as a broken invocation, never as an SDK failure.
+- **Tier 1 blockers** lists every requirement short of Tier 1. Conformance absent from that list means the SDK met every requirement each listed revision imposes.
+
+The exit code follows the same rule: it reflects required scenarios only, so an implementation that meets a revision's requirements exits 0 even with failing extensions.
+
+In `--output json`, `passed` / `failed` / `total` describe the scored set and so always agree with `pass_rate`; anything run without being scored is counted separately under `not_scored`.
 
 ## Architecture
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "prepare": "npm run build"
   },
   "files": [
-    "dist"
+    "dist",
+    "requirements"
   ],
   "bin": {
     "conformance": "dist/index.js"

--- a/requirements/2025-11-25.yaml
+++ b/requirements/2025-11-25.yaml
@@ -1,0 +1,129 @@
+# Conformance requirements for the 2025-11-25 specification revision.
+#
+# This file is the canonical answer to "which scenarios must my implementation pass
+# to conform to 2025-11-25".
+#
+# Anchor, and READ THIS BEFORE TRUSTING IT AS A SNAPSHOT: unlike the 2026-07-28 set,
+# this one could not be frozen at its own ship date. The release current on 2025-11-25
+# was 0.1.7 (published 2025-11-20), which had no --spec-version flag and no concept of
+# which revision a scenario belonged to, so there is nothing to snapshot. This set is
+# instead derived from @modelcontextprotocol/conformance@0.2.0-alpha.10 filtered to
+# 2025-11-25, and therefore contains scenarios written after 2025-11-25 shipped. It is
+# frozen from here on, but it is a reconstruction rather than a contemporaneous record.
+#
+# `server` and `client` are named for the subcommand that runs them, and list what
+# conformance to this revision requires. Scenarios run at THIS revision's wire
+# version: the dated revisions through 2025-11-25 use the stateful initialize
+# handshake and 2026-07-28 is stateless with per-request _meta, so a scenario that
+# applies to both must be run once under each and one run does not cover the other.
+#
+# There is deliberately no authorization-server section: the MCP specification puts
+# authorization-server implementation beyond its own scope, so those scenarios serve
+# people deploying an authorization server, not implementations of MCP itself.
+#
+# `not_scored` is run and reported but never counts toward a pass rate; each entry
+# says why. `extension` is optional by definition (SEP-1730: "Experimental features
+# and protocol extensions ... are not required for any tier"). `added-after-release`
+# means added to the suite AFTER THE ANCHOR RELEASE this file is derived from
+# (0.2.0-alpha.10) — not after the revision's own ship date. This file is a
+# reconstruction (see above), so several SCORED scenarios also postdate
+# 2025-11-25 itself (ping, dns-rebinding-protection, the token-endpoint-auth
+# trio, auth/pre-registration); they are scored because they entered the suite
+# well before the anchor and every current implementation passes them. The line
+# this file freezes is the anchor, and it draws it consistently. Promoting an
+# entry into the lists above is a deliberate, reviewable change.
+#
+# Scenarios that were PENDING in the source release are never scored — SEP-1730
+# scores "applicable required tests" only, and pending means the suite's own
+# reference fixture cannot pass them yet. They still RUN, under not_scored with
+# reason: pending, because the implementation under test may well pass what the
+# reference fixture cannot, and invisible coverage is how gaps hide. (The tasks
+# extension suite attaches to 2026-07-28 only and has no entries here.)
+
+server:
+  - server-initialize
+  - logging-set-level
+  - ping
+  - completion-complete
+  - tools-list
+  - tools-call-simple-text
+  - tools-call-image
+  - tools-call-audio
+  - tools-call-embedded-resource
+  - tools-call-mixed-content
+  - tools-call-with-logging
+  - tools-call-error
+  - tools-call-with-progress
+  - tools-call-sampling
+  - tools-call-elicitation
+  - elicitation-sep1034-defaults
+  - server-sse-multiple-streams
+  - elicitation-sep1330-enums
+  - resources-list
+  - resources-read-text
+  - resources-read-binary
+  - resources-templates-read
+  - resources-subscribe
+  - resources-unsubscribe
+  - prompts-list
+  - prompts-get-simple
+  - prompts-get-with-args
+  - prompts-get-embedded-resource
+  - prompts-get-with-image
+  - dns-rebinding-protection
+
+client:
+  - initialize
+  - tools_call
+  - elicitation-sep1034-client-defaults
+  - sse-retry
+  - auth/metadata-default
+  - auth/metadata-var1
+  - auth/metadata-var2
+  - auth/metadata-var3
+  - auth/basic-cimd
+  - auth/scope-from-www-authenticate
+  - auth/scope-from-scopes-supported
+  - auth/scope-omitted-when-undefined
+  - auth/scope-step-up
+  - auth/scope-retry-limit
+  - auth/token-endpoint-auth-basic
+  - auth/token-endpoint-auth-post
+  - auth/token-endpoint-auth-none
+  - auth/pre-registration
+
+not_scored:
+  - scenario: auth/client-credentials-jwt
+    leg: client
+    reason: extension
+  - scenario: auth/client-credentials-basic
+    leg: client
+    reason: extension
+  - scenario: auth/enterprise-managed-authorization
+    leg: client
+    reason: extension
+  - scenario: auth/dpop
+    leg: client
+    reason: extension
+  - scenario: auth/dpop-nonce
+    leg: client
+    reason: extension
+  - scenario: auth/wif-jwt-bearer
+    leg: client
+    reason: extension
+  - scenario: server-session-lifecycle
+    leg: server
+    reason: added-after-release
+  - scenario: json-schema-2020-12-preservation
+    leg: client
+    reason: added-after-release
+  - scenario: json-schema-2020-12
+    leg: server
+    reason: pending
+    note: >-
+      the reference fixture cannot pass it yet; the implementation under test might
+  - scenario: server-sse-polling
+    leg: server
+    reason: pending
+    note: >-
+      on hold pending server-side SSE improvements in the reference fixture

--- a/requirements/2026-07-28.yaml
+++ b/requirements/2026-07-28.yaml
@@ -1,0 +1,197 @@
+# Conformance requirements for the 2026-07-28 specification revision.
+#
+# This file is the canonical answer to "which scenarios must my implementation pass
+# to conform to 2026-07-28". It is FROZEN: the lists below were fixed when the
+# revision shipped and must not be edited afterwards. An implementation is measured
+# against the suite as it stood when it was expected to conform, not against whatever
+# the suite has accumulated since.
+#
+# Anchor: @modelcontextprotocol/conformance@0.2.0-alpha.10, published 2026-07-27, the
+# release current when this revision shipped. That release could express spec-version
+# applicability, so this set is a faithful snapshot of what was required at ship.
+#
+# `server` and `client` are named for the subcommand that runs them, and list what
+# conformance to this revision requires. Scenarios run at THIS revision's wire
+# version: the dated revisions through 2025-11-25 use the stateful initialize
+# handshake and 2026-07-28 is stateless with per-request _meta, so a scenario that
+# applies to both must be run once under each and one run does not cover the other.
+#
+# There is deliberately no authorization-server section: the MCP specification puts
+# authorization-server implementation beyond its own scope, so those scenarios serve
+# people deploying an authorization server, not implementations of MCP itself.
+#
+# `not_scored` is run and reported but never counts toward a pass rate; each entry
+# says why. `extension` is optional by definition (SEP-1730: "Experimental features
+# and protocol extensions ... are not required for any tier"). `added-after-release`
+# means added to the suite after the anchor release this file is derived from
+# (0.2.0-alpha.10, published the day before this revision shipped), so no
+# implementation pinning a published referee could have been running it. Promoting an entry into the lists above is a deliberate, reviewable
+# change.
+#
+# Scenarios that were PENDING in the source release are never scored — SEP-1730
+# scores "applicable required tests" only, and pending means the suite's own
+# reference fixture cannot pass them yet. They still RUN, under not_scored with
+# reason: pending (or extension for the tasks suite), because the implementation
+# under test may well pass what the reference fixture cannot, and invisible
+# coverage is how gaps hide.
+
+server:
+  - server-stateless
+  - completion-complete
+  - tools-list
+  - tools-call-simple-text
+  - tools-call-image
+  - tools-call-audio
+  - tools-call-embedded-resource
+  - tools-call-mixed-content
+  - tools-call-error
+  - tools-call-with-progress
+  - server-sse-multiple-streams
+  - resources-list
+  - resources-read-text
+  - resources-read-binary
+  - resources-templates-read
+  - sep-2164-resource-not-found
+  - prompts-list
+  - prompts-get-simple
+  - prompts-get-with-args
+  - prompts-get-embedded-resource
+  - prompts-get-with-image
+  - dns-rebinding-protection
+  - caching
+  - input-required-result-basic-elicitation
+  - input-required-result-basic-sampling
+  - input-required-result-basic-list-roots
+  - input-required-result-request-state
+  - input-required-result-multiple-input-requests
+  - input-required-result-multi-round
+  - input-required-result-missing-input-response
+  - input-required-result-non-tool-request
+  - input-required-result-result-type
+  - input-required-result-unsupported-methods
+  - input-required-result-tampered-state
+  - input-required-result-capability-check
+  - input-required-result-ignore-extra-params
+  - input-required-result-validate-input
+
+client:
+  - tools_call
+  - request-metadata
+  - auth/metadata-default
+  - auth/metadata-var1
+  - auth/metadata-var2
+  - auth/metadata-var3
+  - auth/basic-cimd
+  - auth/scope-from-www-authenticate
+  - auth/scope-from-scopes-supported
+  - auth/scope-omitted-when-undefined
+  - auth/scope-step-up
+  - auth/scope-retry-limit
+  - auth/token-endpoint-auth-basic
+  - auth/token-endpoint-auth-post
+  - auth/token-endpoint-auth-none
+  - auth/pre-registration
+  - auth/resource-mismatch
+  - auth/offline-access-scope
+  - auth/offline-access-not-supported
+  - auth/authorization-server-migration
+  - auth/iss-supported
+  - auth/iss-not-advertised
+  - auth/iss-supported-missing
+  - auth/iss-wrong-issuer
+  - auth/iss-unexpected
+  - auth/iss-normalized
+  - auth/metadata-issuer-mismatch
+  - sep-2322-client-request-state
+  - http-standard-headers
+  - http-custom-headers
+  - http-invalid-tool-headers
+  - json-schema-ref-no-deref
+
+not_scored:
+  - scenario: auth/client-credentials-jwt
+    leg: client
+    reason: extension
+  - scenario: auth/client-credentials-basic
+    leg: client
+    reason: extension
+  - scenario: auth/enterprise-managed-authorization
+    leg: client
+    reason: extension
+  - scenario: auth/dpop
+    leg: client
+    reason: extension
+  - scenario: auth/dpop-nonce
+    leg: client
+    reason: extension
+  - scenario: auth/wif-jwt-bearer
+    leg: client
+    reason: extension
+  - scenario: json-schema-2020-12-preservation
+    leg: client
+    reason: added-after-release
+  - scenario: tasks-lifecycle
+    leg: server
+    reason: extension
+    note: >-
+      io.modelcontextprotocol/tasks (SEP-2663); pending against the reference fixture, run for visibility
+  - scenario: tasks-capability-negotiation
+    leg: server
+    reason: extension
+    note: >-
+      io.modelcontextprotocol/tasks (SEP-2663); pending against the reference fixture, run for visibility
+  - scenario: tasks-wire-fields
+    leg: server
+    reason: extension
+    note: >-
+      io.modelcontextprotocol/tasks (SEP-2663); pending against the reference fixture, run for visibility
+  - scenario: tasks-request-state-removal
+    leg: server
+    reason: extension
+    note: >-
+      io.modelcontextprotocol/tasks (SEP-2663); pending against the reference fixture, run for visibility
+  - scenario: tasks-mrtr-input
+    leg: server
+    reason: extension
+    note: >-
+      io.modelcontextprotocol/tasks (SEP-2663); pending against the reference fixture, run for visibility
+  - scenario: tasks-request-headers
+    leg: server
+    reason: extension
+    note: >-
+      io.modelcontextprotocol/tasks (SEP-2663); pending against the reference fixture, run for visibility
+  - scenario: tasks-dispatch-and-envelope
+    leg: server
+    reason: extension
+    note: >-
+      io.modelcontextprotocol/tasks (SEP-2663); pending against the reference fixture, run for visibility
+  - scenario: tasks-status-notifications
+    leg: server
+    reason: extension
+    note: >-
+      io.modelcontextprotocol/tasks (SEP-2663); pending against the reference fixture, run for visibility
+  - scenario: tasks-required-task-error
+    leg: server
+    reason: extension
+    note: >-
+      io.modelcontextprotocol/tasks (SEP-2663); pending against the reference fixture, run for visibility
+  - scenario: tasks-mrtr-composition
+    leg: server
+    reason: extension
+    note: >-
+      io.modelcontextprotocol/tasks (SEP-2663); pending against the reference fixture, run for visibility
+  - scenario: json-schema-2020-12
+    leg: server
+    reason: pending
+    note: >-
+      the reference fixture cannot pass it yet; the implementation under test might
+  - scenario: http-header-validation
+    leg: server
+    reason: pending
+    note: >-
+      SEP-2243; pending against the reference fixture
+  - scenario: http-custom-header-server-validation
+    leg: server
+    reason: pending
+    note: >-
+      SEP-2243; pending against the reference fixture

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,16 @@ import {
 import type { AuthorizationServerOptions } from './schemas';
 import { withWireRecorder } from './validation/wire-schema';
 import {
+  filterScenariosByRequirements,
+  Leg,
+  listRequirementRevisions,
+  loadRequirements,
+  notScoredScenarios,
+  REASONS,
+  RequirementSet,
+  scoredScenarios
+} from './requirements';
+import {
   loadExpectedFailures,
   evaluateBaseline,
   printBaselineResults
@@ -59,6 +69,123 @@ import packageJson from '../package.json';
 // The `client` command tests Scenario objects (which test clients),
 // and the `server` command tests ClientScenario objects (which test servers).
 // This matches the inverted naming in scenarios/index.ts.
+/**
+ * Resolve `--requirements`. A requirement set replaces suite and spec-version
+ * selection: it already names exactly the scenarios that revision requires.
+ */
+function resolveRequirements(
+  revision: string | undefined,
+  conflicts: { specVersion?: string; suiteFromCli?: boolean; scenario?: string }
+): RequirementSet | undefined {
+  if (revision === undefined) return undefined;
+  // An explicitly passed empty value is a script whose variable did not expand.
+  // Ignoring it would silently score against the whole suite, which is the
+  // failure this flag exists to prevent.
+  if (revision === '') {
+    console.error(
+      '--requirements needs a revision, such as 2026-07-28. Run `conformance list` to see which are available.'
+    );
+    process.exit(1);
+  }
+  const combined = conflicts.specVersion
+    ? '--spec-version'
+    : conflicts.suiteFromCli
+      ? '--suite'
+      : conflicts.scenario
+        ? '--scenario'
+        : undefined;
+  if (combined) {
+    console.error(
+      `--requirements cannot be combined with ${combined}: a requirement set already fixes which scenarios run.`
+    );
+    process.exit(1);
+  }
+  try {
+    return loadRequirements(revision);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+/**
+ * Exit status under a requirement set. Scenarios the set runs without scoring
+ * (extensions, post-release additions) are reported but must not fail the run:
+ * otherwise the documented command red-flags an implementation that meets every
+ * requirement the revision actually imposes.
+ */
+function requirementsExitCode(
+  requirements: RequirementSet,
+  leg: Leg,
+  results: { scenario: string; checks: ConformanceCheck[] }[]
+): number {
+  const scored = new Set(scoredScenarios(requirements, leg));
+  const unscored = results.filter((r) => !scored.has(r.scenario));
+  if (unscored.length > 0) {
+    const failing = unscored.filter((r) =>
+      r.checks.some((c) => c.status === 'FAILURE')
+    );
+    console.log(
+      `\nNot scored for ${requirements.revision}: ${unscored.length} scenario(s) run, ${failing.length} failing. These do not affect conformance.`
+    );
+    for (const r of unscored) {
+      const why = notScoredScenarios(requirements, leg).find(
+        (e) => e.scenario === r.scenario
+      );
+      const failed = r.checks.some((c) => c.status === 'FAILURE');
+      console.log(
+        `  ${failed ? '\u2717' : '\u2713'} ${r.scenario} (${why?.reason ?? 'not scored'})`
+      );
+    }
+  }
+  const scoredFailed = results
+    .filter((r) => scored.has(r.scenario))
+    .some((r) => r.checks.some((c) => c.status === 'FAILURE'));
+  return scoredFailed ? 1 : 0;
+}
+
+/** Print one revision's requirement set. `list` is display-only, so it can show several. */
+function listOneRequirementSet(revision: string, specVersion?: string): void {
+  const requirements = resolveRequirements(revision, { specVersion })!;
+  const legs: [string, string[]][] = [
+    ['Server scenarios (test against a server)', requirements.server],
+    ['Client scenarios (test against a client)', requirements.client]
+  ];
+  const total = legs.reduce((n, [, names]) => n + names.length, 0);
+  console.log(
+    `Required for ${requirements.revision} (${total} scenarios, frozen; run at the ${requirements.revision} wire):\n`
+  );
+  for (const [title, names] of legs) {
+    if (names.length === 0) continue;
+    console.log(`${title}:`);
+    names.forEach((name) => console.log(`  - ${name}`));
+    console.log('');
+  }
+  if (requirements.notScored.length > 0) {
+    console.log('Run and reported, but never scored:');
+    for (const reason of REASONS) {
+      const entries = requirements.notScored.filter((e) => e.reason === reason);
+      if (entries.length === 0) continue;
+      console.log(`  ${reason} (${entries.length}):`);
+      entries.forEach((e) => console.log(`    - ${e.scenario} [${e.leg}]`));
+    }
+    console.log('');
+  }
+}
+
+function requiredScenariosOrExit(
+  allScenarios: string[],
+  requirements: RequirementSet,
+  command: Leg
+): string[] {
+  try {
+    return filterScenariosByRequirements(allScenarios, requirements, command);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
 function filterScenariosBySpecVersion(
   allScenarios: string[],
   version: SpecVersion,
@@ -109,18 +236,36 @@ program
     '--force',
     'Run a scenario even if it is not applicable at the requested --spec-version'
   )
+  .option(
+    '--requirements <revision>',
+    'Run exactly the scenarios a spec revision requires, frozen at its release (e.g. 2026-07-28). Replaces --suite and --spec-version'
+  )
   .option('--verbose', 'Show verbose output')
-  .action(async (options) => {
+  .action(async (options, cmd) => {
     try {
       const timeout = parseInt(options.timeout, 10);
       const verbose = options.verbose ?? false;
       const outputDir = options.outputDir;
-      const specVersionFilter = options.specVersion
-        ? resolveSpecVersion(options.specVersion)
-        : undefined;
+      const requirements = resolveRequirements(options.requirements, {
+        specVersion: options.specVersion,
+        suiteFromCli: cmd.getOptionValueSource('suite') === 'cli',
+        scenario: options.scenario
+      });
+      // A requirement set decides two different things, and only the first is
+      // its scenario list. The revision it names is also the wire version those
+      // scenarios must speak: 2025-11-25 and 2026-07-28 are different protocols
+      // (stateful initialize handshake vs stateless per-request _meta), and a
+      // scenario emits different checks under each. Leaving this unset ran the
+      // right set against LATEST_SPEC_VERSION, which is a different wire than
+      // the one named on the flag.
+      const specVersionFilter = requirements
+        ? resolveSpecVersion(requirements.revision)
+        : options.specVersion
+          ? resolveSpecVersion(options.specVersion)
+          : undefined;
 
       // Handle suite mode
-      if (options.suite) {
+      if (options.suite || options.requirements !== undefined) {
         if (!options.command) {
           console.error('--command is required when using --suite');
           process.exit(1);
@@ -138,23 +283,37 @@ program
             listAuthScenarios().filter((name) => name.startsWith('auth/scope-'))
         };
 
-        const suiteName = options.suite.toLowerCase();
-        if (!suites[suiteName]) {
-          console.error(`Unknown suite: ${suiteName}`);
-          console.error(`Available suites: ${Object.keys(suites).join(', ')}`);
-          process.exit(1);
-        }
-
-        let scenarios = suites[suiteName]();
-        if (specVersionFilter) {
-          scenarios = filterScenariosBySpecVersion(
-            scenarios,
-            specVersionFilter,
+        let scenarios: string[];
+        let selection: string;
+        if (requirements) {
+          scenarios = requiredScenariosOrExit(
+            listScenarios(),
+            requirements,
             'client'
           );
+          selection = `requirements ${requirements.revision}`;
+        } else {
+          const suiteName = options.suite.toLowerCase();
+          if (!suites[suiteName]) {
+            console.error(`Unknown suite: ${suiteName}`);
+            console.error(
+              `Available suites: ${Object.keys(suites).join(', ')}`
+            );
+            process.exit(1);
+          }
+
+          scenarios = suites[suiteName]();
+          if (specVersionFilter) {
+            scenarios = filterScenariosBySpecVersion(
+              scenarios,
+              specVersionFilter,
+              'client'
+            );
+          }
+          selection = `${suiteName} suite`;
         }
         console.log(
-          `Running ${suiteName} suite (${scenarios.length} scenarios) in parallel...\n`
+          `Running ${selection} (${scenarios.length} scenarios) in parallel...\n`
         );
 
         const results = await Promise.all(
@@ -169,7 +328,9 @@ program
                   timeout,
                   outputDir,
                   specVersionFilter,
-                  options.force ?? false
+                  // a requirement set decides membership, so its choice outranks a
+                  // scenario's own applicability window at the pinned revision
+                  options.force || Boolean(requirements)
                 )
               );
               return {
@@ -256,12 +417,33 @@ program
             options.expectedFailures
           );
           const baselineScenarios = expectedFailuresConfig.client ?? [];
-          const baselineResult = evaluateBaseline(results, baselineScenarios);
+          // Under a requirement set, the baseline judges scored scenarios only:
+          // a not_scored scenario cannot fail the run, so it must not surface
+          // as an "unexpected failure" either.
+          const scoredOnly = requirements
+            ? new Set(scoredScenarios(requirements, 'client'))
+            : undefined;
+          const baselineResult = evaluateBaseline(
+            scoredOnly
+              ? results.filter((r) => scoredOnly.has(r.scenario))
+              : results,
+            baselineScenarios
+          );
           printBaselineResults(baselineResult);
           process.exit(baselineResult.exitCode);
         }
 
-        process.exit(totalFailed > 0 || totalWarnings > 0 ? 1 : 0);
+        process.exit(
+          requirements
+            ? requirementsExitCode(
+                requirements,
+                'client',
+                results.map((r) => ({ scenario: r.scenario, checks: r.checks }))
+              )
+            : totalFailed > 0 || totalWarnings > 0
+              ? 1
+              : 0
+        );
       }
 
       // Require either --scenario or --suite
@@ -369,17 +551,35 @@ program
     '--force',
     'Run a scenario even if it is not applicable at the requested --spec-version'
   )
+  .option(
+    '--requirements <revision>',
+    'Run exactly the scenarios a spec revision requires, frozen at its release (e.g. 2026-07-28). Replaces --suite and --spec-version'
+  )
   .option('--verbose', 'Show verbose output (JSON instead of pretty print)')
-  .action(async (options) => {
+  .action(async (options, cmd) => {
     try {
       // Validate options with Zod
       const validated = ServerOptionsSchema.parse(options);
 
       const verbose = options.verbose ?? false;
       const outputDir = options.outputDir;
-      const specVersionFilter = options.specVersion
-        ? resolveSpecVersion(options.specVersion)
-        : undefined;
+      const requirements = resolveRequirements(options.requirements, {
+        specVersion: options.specVersion,
+        suiteFromCli: cmd.getOptionValueSource('suite') === 'cli',
+        scenario: options.scenario
+      });
+      // A requirement set decides two different things, and only the first is
+      // its scenario list. The revision it names is also the wire version those
+      // scenarios must speak: 2025-11-25 and 2026-07-28 are different protocols
+      // (stateful initialize handshake vs stateless per-request _meta), and a
+      // scenario emits different checks under each. Leaving this unset ran the
+      // right set against LATEST_SPEC_VERSION, which is a different wire than
+      // the one named on the flag.
+      const specVersionFilter = requirements
+        ? resolveSpecVersion(requirements.revision)
+        : options.specVersion
+          ? resolveSpecVersion(options.specVersion)
+          : undefined;
 
       // If a single scenario is specified, run just that one
       if (validated.scenario) {
@@ -421,8 +621,16 @@ program
         // Run scenarios based on suite
         const suite = options.suite?.toLowerCase() || 'active';
         let scenarios: string[];
+        let selection = `${suite} suite`;
 
-        if (suite === 'all') {
+        if (requirements) {
+          scenarios = requiredScenariosOrExit(
+            listClientScenarios(),
+            requirements,
+            'server'
+          );
+          selection = `requirements ${requirements.revision}`;
+        } else if (suite === 'all') {
           scenarios = listClientScenarios();
         } else if (suite === 'active' || suite === 'core') {
           // 'core' is an alias for 'active' - tier 1 requirements
@@ -439,7 +647,7 @@ program
           process.exit(1);
         }
 
-        if (specVersionFilter) {
+        if (specVersionFilter && !requirements) {
           scenarios = filterScenariosBySpecVersion(
             scenarios,
             specVersionFilter,
@@ -448,7 +656,7 @@ program
         }
 
         console.log(
-          `Running ${suite} suite (${scenarios.length} scenarios) against ${validated.url}\n`
+          `Running ${selection} (${scenarios.length} scenarios) against ${validated.url}\n`
         );
 
         const allResults: { scenario: string; checks: ConformanceCheck[] }[] =
@@ -464,7 +672,10 @@ program
                 validated.url,
                 scenarioName,
                 outputDir,
-                specVersionFilter
+                specVersionFilter,
+                // a requirement set decides membership, so its choice outranks a
+                // scenario's own applicability window at the pinned revision
+                Boolean(requirements)
               )
             );
             allResults.push({ scenario: scenarioName, checks: result.checks });
@@ -494,15 +705,28 @@ program
             options.expectedFailures
           );
           const baselineScenarios = expectedFailuresConfig.server ?? [];
+          // Same scored-only rule as the client leg: not_scored scenarios are
+          // outside both the pass rate and the baseline.
+          const scoredOnly = requirements
+            ? new Set(scoredScenarios(requirements, 'server'))
+            : undefined;
           const baselineResult = evaluateBaseline(
-            allResults,
+            scoredOnly
+              ? allResults.filter((r) => scoredOnly.has(r.scenario))
+              : allResults,
             baselineScenarios
           );
           printBaselineResults(baselineResult);
           process.exit(baselineResult.exitCode);
         }
 
-        process.exit(totalFailed > 0 ? 1 : 0);
+        process.exit(
+          requirements
+            ? requirementsExitCode(requirements, 'server', allResults)
+            : totalFailed > 0
+              ? 1
+              : 0
+        );
       }
     } catch (error) {
       if (error instanceof ZodError) {
@@ -700,7 +924,9 @@ program.addCommand(createTraceabilityCommand());
 // List scenarios command
 program
   .command('list')
-  .description('List available test scenarios')
+  .description(
+    `List available test scenarios. Requirement sets available: ${listRequirementRevisions().join(', ') || 'none'}`
+  )
   .option('--client', 'List client scenarios')
   .option('--server', 'List server scenarios')
   .option('--authorization', 'List authorization server scenarios')
@@ -708,10 +934,21 @@ program
     '--spec-version <version>',
     'Filter scenarios by spec version (cumulative for date versions)'
   )
+  .option(
+    '--requirements <revision>',
+    'List exactly what a spec revision requires, frozen at its release'
+  )
   .action((options) => {
     const specVersionFilter = options.specVersion
       ? resolveSpecVersion(options.specVersion)
       : undefined;
+
+    if (options.requirements !== undefined) {
+      for (const rev of String(options.requirements).split(',')) {
+        listOneRequirementSet(rev.trim(), options.specVersion);
+      }
+      return;
+    }
 
     if (
       options.server ||

--- a/src/requirements.test.ts
+++ b/src/requirements.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { readFileSync, writeFileSync } from 'fs';
+import {
+  filterScenariosByRequirements,
+  listRequirementRevisions,
+  loadRequirements,
+  notScoredScenarios,
+  scenariosToRun,
+  scoredScenarios
+} from './requirements';
+import { listClientScenarios, listScenarios } from './scenarios';
+
+const revisions = listRequirementRevisions();
+
+describe('requirement sets', () => {
+  it('ships at least one revision', () => {
+    expect(revisions.length).toBeGreaterThan(0);
+  });
+
+  describe.each(revisions)('%s', (revision) => {
+    const requirements = loadRequirements(revision);
+
+    // A requirement set is frozen, so a name it asks for that this build does
+    // not have means a scenario was renamed or removed out from under a shipped
+    // revision. That silently shrinks what conformance means, so it fails here.
+    it.each([
+      ['server', requirements.server, listClientScenarios()],
+      ['client', requirements.client, listScenarios()]
+    ])(
+      'every %s scenario exists in this build',
+      (_leg, required, available) => {
+        expect(required.filter((name) => !available.includes(name))).toEqual(
+          []
+        );
+      }
+    );
+
+    it('lists no scenario twice within a leg', () => {
+      for (const leg of [requirements.server, requirements.client]) {
+        expect(new Set(leg).size).toBe(leg.length);
+      }
+    });
+
+    it('keeps not-scored entries out of the required lists', () => {
+      const required = new Set([
+        ...requirements.server,
+        ...requirements.client
+      ]);
+      const alsoRequired = requirements.notScored
+        .map((e) => e.scenario)
+        .filter((name) => required.has(name));
+      expect(alsoRequired).toEqual([]);
+    });
+
+    it('runs the not-scored entries alongside the required ones', () => {
+      for (const leg of ['server', 'client'] as const) {
+        const run = scenariosToRun(requirements, leg);
+        const scored = scoredScenarios(requirements, leg);
+        const extra = notScoredScenarios(requirements, leg).map(
+          (e) => e.scenario
+        );
+        expect(run).toEqual([...scored, ...extra]);
+        expect(extra.every((name) => !scored.includes(name))).toBe(true);
+      }
+    });
+  });
+});
+
+describe('loadRequirements', () => {
+  it('rejects anything that is not a revision date', () => {
+    expect(() => loadRequirements('../../etc/passwd')).toThrow(
+      /Invalid requirements revision/
+    );
+    expect(() => loadRequirements('latest')).toThrow(
+      /Invalid requirements revision/
+    );
+  });
+
+  it('rejects a date that is not a spec revision, since it also names the wire', () => {
+    expect(() => loadRequirements('1999-01-01')).toThrow(
+      /Unknown spec revision: 1999-01-01/
+    );
+  });
+
+  it('names the available revisions when a known one has no set', () => {
+    expect(() => loadRequirements('2025-03-26')).toThrow(
+      /No requirement set for 2025-03-26/
+    );
+  });
+});
+
+describe('loadRequirements validation', () => {
+  // The files are the frozen contract: a malformed one must fail loudly, never
+  // silently shrink what conformance means.
+  const path = 'requirements/2026-07-28.yaml';
+  const original = readFileSync(path, 'utf-8');
+  afterEach(() => writeFileSync(path, original));
+
+  it('rejects an unknown top-level key instead of silently dropping a leg', () => {
+    writeFileSync(path, original.replace('\nserver:\n', '\nsever:\n'));
+    expect(() => loadRequirements('2026-07-28')).toThrow(/unknown key "sever"/);
+  });
+
+  it('rejects a scenario that is both scored and not_scored', () => {
+    writeFileSync(
+      path,
+      original.replace(
+        'not_scored:',
+        'not_scored:\n  - scenario: tools-list\n    leg: server\n    reason: extension'
+      )
+    );
+    expect(() => loadRequirements('2026-07-28')).toThrow(/both scored/);
+  });
+
+  it('rejects duplicate scored entries', () => {
+    writeFileSync(
+      path,
+      original.replace('  - tools-list\n', '  - tools-list\n  - tools-list\n')
+    );
+    expect(() => loadRequirements('2026-07-28')).toThrow(/duplicate server/);
+  });
+});
+
+describe('filterScenariosByRequirements', () => {
+  const requirements = loadRequirements(revisions[0]);
+
+  it('returns what the revision runs, not the suite it was given', () => {
+    const selected = filterScenariosByRequirements(
+      listClientScenarios(),
+      requirements,
+      'server'
+    );
+    expect(selected).toEqual(scenariosToRun(requirements, 'server'));
+  });
+
+  it('runs the not-scored entries but keeps them out of the scored set', () => {
+    const selected = filterScenariosByRequirements(
+      listClientScenarios(),
+      requirements,
+      'server'
+    );
+    const extensions = notScoredScenarios(requirements, 'server').map(
+      (e) => e.scenario
+    );
+    expect(extensions.length).toBeGreaterThan(0);
+    expect(extensions.every((name) => selected.includes(name))).toBe(true);
+    expect(
+      extensions.some((name) =>
+        scoredScenarios(requirements, 'server').includes(name)
+      )
+    ).toBe(false);
+  });
+
+  it('fails loudly when the build is missing a required scenario', () => {
+    expect(() =>
+      filterScenariosByRequirements(
+        ['nothing-it-asks-for'],
+        requirements,
+        'server'
+      )
+    ).toThrow(/does not provide/);
+  });
+});

--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -1,0 +1,252 @@
+import { existsSync, readdirSync, readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { parse as parseYaml } from 'yaml';
+import { ALL_SPEC_VERSIONS } from './scenarios';
+
+/**
+ * A frozen requirement set for one specification revision: the scenarios an
+ * implementation must pass to conform to that revision, fixed when it shipped.
+ *
+ * This is the project's contract, not an implementation's configuration. It is
+ * the opposite of an expected-failures baseline, which lives in an
+ * implementation's own repository and records what that implementation knows it
+ * fails. A baselined failure is still a failure against a requirement set.
+ */
+export interface RequirementSet {
+  /** Revision this set belongs to, e.g. `2026-07-28`. */
+  revision: string;
+  /** Scenarios `conformance server` runs against a server implementation. */
+  server: string[];
+  /** Scenarios `conformance client` runs against a client implementation. */
+  client: string[];
+  /**
+   * Scenarios run and reported alongside the required ones but never counted
+   * toward a pass rate. Three reasons qualify, and the report names which:
+   * an extension is optional by definition, a scenario added after the
+   * revision shipped is one no implementation could have been passing, and a
+   * pending scenario is one the suite's own reference fixture cannot pass yet
+   * — the implementation under test still might, so it runs for visibility.
+   */
+  notScored: NotScored[];
+}
+
+export type NotScoredReason = 'extension' | 'added-after-release' | 'pending';
+
+export interface NotScored {
+  scenario: string;
+  leg: Leg;
+  reason: NotScoredReason;
+  note?: string;
+}
+
+/**
+ * Roles a requirement set covers. The MCP specification defines two: an MCP
+ * server acting as an OAuth resource server, and an MCP client acting as an
+ * OAuth client. Authorization-server implementation is explicitly beyond the
+ * specification's scope, so those scenarios are not a conformance requirement
+ * for anything the spec defines and have no place in a requirement set.
+ */
+export type Leg = 'client' | 'server';
+
+const LEGS: Leg[] = ['client', 'server'];
+export const REASONS: NotScoredReason[] = [
+  'extension',
+  'added-after-release',
+  'pending'
+];
+
+/** Requirement sets ship with the package; see the `files` entry in package.json. */
+function requirementsDir(): string {
+  return join(dirname(fileURLToPath(import.meta.url)), '..', 'requirements');
+}
+
+export function listRequirementRevisions(): string[] {
+  const dir = requirementsDir();
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('.yaml'))
+    .map((f) => f.replace(/\.yaml$/, ''))
+    .sort();
+}
+
+function asNameList(value: unknown, field: string, revision: string): string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value) || value.some((v) => typeof v !== 'string')) {
+    throw new Error(
+      `requirements/${revision}.yaml: "${field}" must be a list of scenario names`
+    );
+  }
+  return value as string[];
+}
+
+export function loadRequirements(revision: string): RequirementSet {
+  // A revision names a bundled file. Arbitrary paths are deliberately not
+  // accepted: a requirement set is the project's contract, so an implementation
+  // under test must not be able to supply its own.
+  if (!/^[0-9]{4}-[0-9]{2}-[0-9]{2}$/.test(revision)) {
+    // A run has one exit code and one expected-failures baseline, so it targets
+    // one revision. tier-check is the aggregator and takes several at once.
+    throw new Error(
+      revision.includes(',')
+        ? `A run targets one revision at a time, because it has one exit code and one baseline. Run each of "${revision}" separately, or pass them together to \`tier-check --requirements\`.`
+        : `Invalid requirements revision: ${revision}. Expected a date such as 2026-07-28.`
+    );
+  }
+
+  // The revision is also the wire version its scenarios run at, so it has to be
+  // a protocol version this build knows, not merely a date-shaped string.
+  if (!(ALL_SPEC_VERSIONS as readonly string[]).includes(revision)) {
+    throw new Error(
+      `Unknown spec revision: ${revision}. Known revisions: ${ALL_SPEC_VERSIONS.join(', ')}`
+    );
+  }
+
+  const path = join(requirementsDir(), `${revision}.yaml`);
+  if (!existsSync(path)) {
+    const known = listRequirementRevisions();
+    throw new Error(
+      `No requirement set for ${revision}.` +
+        (known.length
+          ? ` Available: ${known.join(', ')}`
+          : ' No requirement sets are bundled with this release.')
+    );
+  }
+
+  const parsed = parseYaml(readFileSync(path, 'utf-8')) ?? {};
+
+  // A frozen contract must fail loudly on anything it does not recognise: a
+  // typo'd key ("sever:") would otherwise silently empty a leg and the gate
+  // would pass having required nothing.
+  const KNOWN_KEYS = new Set(['server', 'client', 'not_scored']);
+  for (const key of Object.keys(parsed)) {
+    if (key === 'authorization') continue; // rejected below with its own reason
+    if (!KNOWN_KEYS.has(key)) {
+      throw new Error(
+        `requirements/${revision}.yaml: unknown key "${key}" (expected server, client, not_scored)`
+      );
+    }
+  }
+  const notScoredRaw = parsed.not_scored ?? [];
+  if (!Array.isArray(notScoredRaw)) {
+    throw new Error(
+      `requirements/${revision}.yaml: "not_scored" must be a list`
+    );
+  }
+
+  if (parsed.authorization !== undefined) {
+    throw new Error(
+      `requirements/${revision}.yaml: requirement sets cover the client and server roles only. ` +
+        'Authorization-server implementation is beyond the scope of the MCP specification, so it is not a conformance requirement.'
+    );
+  }
+
+  const server = asNameList(parsed.server, 'server', revision);
+  const client = asNameList(parsed.client, 'client', revision);
+  for (const [leg, names] of [
+    ['server', server],
+    ['client', client]
+  ] as const) {
+    const dupes = names.filter((n, i) => names.indexOf(n) !== i);
+    if (dupes.length > 0) {
+      throw new Error(
+        `requirements/${revision}.yaml: duplicate ${leg} scenario(s): ${[...new Set(dupes)].join(', ')}`
+      );
+    }
+  }
+
+  return {
+    revision,
+    server,
+    client,
+    notScored: notScoredRaw.map((entry: unknown) => {
+      const e = entry as NotScored;
+      if (!e || typeof e.scenario !== 'string') {
+        throw new Error(
+          `requirements/${revision}.yaml: each not_scored entry needs a "scenario" name`
+        );
+      }
+      if (!LEGS.includes(e.leg)) {
+        throw new Error(
+          `requirements/${revision}.yaml: ${e.scenario} needs a "leg" of ${LEGS.join(', ')}`
+        );
+      }
+      if (!REASONS.includes(e.reason)) {
+        throw new Error(
+          `requirements/${revision}.yaml: ${e.scenario} needs a "reason" of ${REASONS.join(', ')}`
+        );
+      }
+      // A half-finished promotion (a scenario both scored and not_scored)
+      // would run twice and be counted inconsistently across code paths.
+      const scoredNames = e.leg === 'server' ? server : client;
+      if (scoredNames.includes(e.scenario)) {
+        throw new Error(
+          `requirements/${revision}.yaml: ${e.scenario} is both scored (${e.leg}) and not_scored — finish the promotion by removing one entry`
+        );
+      }
+      return {
+        scenario: e.scenario,
+        leg: e.leg,
+        reason: e.reason,
+        note: e.note
+      };
+    })
+  };
+}
+
+/** Scenarios that count toward the pass rate for a leg. */
+export function scoredScenarios(
+  requirements: RequirementSet,
+  leg: Leg
+): string[] {
+  return requirements[leg];
+}
+
+/** Scenarios run and reported for a leg but excluded from the pass rate. */
+export function notScoredScenarios(
+  requirements: RequirementSet,
+  leg: Leg
+): NotScored[] {
+  return requirements.notScored.filter((entry) => entry.leg === leg);
+}
+
+/** Everything a leg runs: what it scores, plus what it only reports. */
+export function scenariosToRun(
+  requirements: RequirementSet,
+  leg: Leg
+): string[] {
+  return [
+    ...scoredScenarios(requirements, leg),
+    ...notScoredScenarios(requirements, leg).map((e) => e.scenario)
+  ];
+}
+
+/**
+ * Narrow a scenario list to the revision's requirements.
+ *
+ * Names the requirement set asks for that this build does not have are an
+ * error: the set is frozen, so a missing name means the suite renamed or
+ * removed a scenario out from under it, and silently scoring a smaller set
+ * would understate what conformance means.
+ */
+export function filterScenariosByRequirements(
+  allScenarios: string[],
+  requirements: RequirementSet,
+  leg: Leg
+): string[] {
+  const scored = new Set(scoredScenarios(requirements, leg));
+  const available = new Set(allScenarios);
+  const wanted = scenariosToRun(requirements, leg);
+  // Only the scored names are a contract violation when absent. A not-scored
+  // entry can legitimately postdate the build being run, which is the whole
+  // reason it is listed separately.
+  const missing = wanted.filter(
+    (name) => !available.has(name) && scored.has(name)
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `requirements/${requirements.revision}.yaml lists ${leg} scenarios that this build does not provide: ${missing.join(', ')}`
+    );
+  }
+  return wanted.filter((name) => available.has(name));
+}

--- a/src/sdk-runner/index.ts
+++ b/src/sdk-runner/index.ts
@@ -8,7 +8,7 @@ import { resolveSpecVersion } from '../scenarios';
 
 type Mode = 'client' | 'server';
 
-function execShell(command: string, cwd: string): Promise<void> {
+export function execShell(command: string, cwd: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, { shell: true, cwd, stdio: 'inherit' });
     child.on('error', reject);
@@ -59,7 +59,7 @@ async function waitForReady(url: string, timeoutMs: number): Promise<void> {
   );
 }
 
-async function withManagedServer<T>(
+export async function withManagedServer<T>(
   command: string,
   cwd: string,
   url: string,
@@ -102,14 +102,28 @@ async function withManagedServer<T>(
   } finally {
     stopping = true;
     console.error(`[sdk] Stopping server`);
-    if (process.platform !== 'win32' && child.pid) {
-      try {
-        process.kill(-child.pid, 'SIGTERM');
-      } catch {
-        child.kill('SIGTERM');
+    const gone = new Promise<void>((resolve) => {
+      if (child.exitCode !== null || child.signalCode !== null) resolve();
+      else child.once('exit', () => resolve());
+    });
+    const signal = (sig: NodeJS.Signals) => {
+      if (process.platform !== 'win32' && child.pid) {
+        try {
+          process.kill(-child.pid, sig);
+        } catch {
+          child.kill(sig);
+        }
+      } else {
+        child.kill(sig);
       }
-    } else {
-      child.kill('SIGTERM');
+    };
+    signal('SIGTERM');
+    // Wait for the process to actually release its port: a consecutive run on
+    // the same port must never race a dying predecessor. Escalate if needed.
+    const timer = (ms: number) => new Promise((r) => setTimeout(r, ms));
+    if ((await Promise.race([gone.then(() => true), timer(5000)])) !== true) {
+      signal('SIGKILL');
+      await Promise.race([gone, timer(2000)]);
     }
   }
 }
@@ -121,14 +135,23 @@ function passThrough(options: {
   verbose?: boolean;
   output?: string;
   specVersion?: string;
+  requirements?: string;
 }): string[] {
   const args: string[] = [];
-  if (options.scenario) args.push('--scenario', options.scenario);
-  else if (options.suite) args.push('--suite', options.suite);
+  // A requirement set replaces scenario/suite/spec-version selection: it names
+  // the scenarios AND pins the wire version they run at.
+  if (options.requirements) {
+    args.push('--requirements', options.requirements);
+  } else if (options.scenario) {
+    args.push('--scenario', options.scenario);
+  } else if (options.suite) {
+    args.push('--suite', options.suite);
+  }
   if (options.timeout) args.push('--timeout', options.timeout);
   if (options.verbose) args.push('--verbose');
   if (options.output) args.push('-o', options.output);
-  if (options.specVersion) args.push('--spec-version', options.specVersion);
+  if (!options.requirements && options.specVersion)
+    args.push('--spec-version', options.specVersion);
   return args;
 }
 
@@ -173,6 +196,10 @@ export function createSdkCommand(): Command {
       '--spec-version <version>',
       'Spec version to target (passed through; defaults to the SDK config)'
     )
+    .option(
+      '--requirements <revision>',
+      "Run exactly the scenarios this spec revision requires, at that revision's wire, with the SDK invocation resolved for that revision (e.g. 2026-07-28). Replaces --suite/--scenario/--spec-version"
+    )
     .option('--verbose', 'Verbose output (passed through)')
     .action(async (sdkArg: string | undefined, options) => {
       try {
@@ -197,7 +224,20 @@ export function createSdkCommand(): Command {
         // default) selects that version's specOverrides entry, so version-
         // specific invocations live in config instead of copy-paste flags.
         // 'draft' resolves to its dated alias so overlay keys stay canonical.
-        const requestedSpec = options.specVersion ?? baseConfig.specVersion;
+        if (
+          options.requirements &&
+          (options.specVersion || options.suite || options.scenario)
+        ) {
+          throw new Error(
+            '--requirements cannot be combined with --spec-version, --suite or --scenario: a requirement set already fixes which scenarios run and at which wire.'
+          );
+        }
+        // A requirements revision doubles as the spec version for config
+        // resolution, so the specOverrides entry for that revision picks the
+        // right server command/url (go-sdk needs a different process per wire
+        // era, csharp-sdk a different endpoint).
+        const requestedSpec =
+          options.requirements ?? options.specVersion ?? baseConfig.specVersion;
         const specVersion: string | undefined = requestedSpec
           ? resolveSpecVersion(requestedSpec)
           : undefined;
@@ -224,9 +264,13 @@ export function createSdkCommand(): Command {
           options.serverUrl ?? builtinConfig.server?.url;
         // CLI override resolves relative to the user's invocation cwd; the
         // built-in default resolves relative to the SDK checkout.
+        // Under --requirements the frozen set decides pass/fail and tier-check
+        // ignores baselines entirely, so auto-attaching the SDK's own baseline
+        // would let the two commands return opposite verdicts for the same
+        // run. An explicit --expected-failures remains a deliberate choice.
         const expectedFailures = options.expectedFailures
           ? path.resolve(options.expectedFailures)
-          : builtinConfig.expectedFailures
+          : builtinConfig.expectedFailures && !options.requirements
             ? path.resolve(dir, builtinConfig.expectedFailures)
             : undefined;
         // Resolve -o to an absolute path so it lands where the user expects,
@@ -257,11 +301,14 @@ export function createSdkCommand(): Command {
             clientCmd,
             ...passThrough({
               scenario: options.scenario,
-              suite: options.suite ?? 'all',
+              suite: options.requirements
+                ? undefined
+                : (options.suite ?? 'all'),
               timeout: options.timeout,
               verbose: options.verbose,
               output,
-              specVersion
+              specVersion,
+              requirements: options.requirements
             })
           ];
           if (expectedFailures)
@@ -283,10 +330,13 @@ export function createSdkCommand(): Command {
               // Default to the `active` suite (excludes pending/draft) — the same
               // suite tiering runs, and the most reasonable default to avoid
               // surfacing intentionally-deferred `pending` scenarios.
-              suite: options.suite ?? 'active',
+              suite: options.requirements
+                ? undefined
+                : (options.suite ?? 'active'),
               verbose: options.verbose,
               output,
-              specVersion
+              specVersion,
+              requirements: options.requirements
             })
           ];
           if (expectedFailures)

--- a/src/sdk-runner/known-sdks.ts
+++ b/src/sdk-runner/known-sdks.ts
@@ -65,7 +65,12 @@ export const KNOWN_SDKS: Record<string, SdkConfig> = {
   // workspace package). Two baselines exist upstream, one per spec target;
   // the 2026-07-28 override picks the matching one.
   'python-sdk': {
-    build: 'uv sync --frozen --all-extras --all-packages',
+    // Mirrors the SDK's own CI, which syncs the two conformance packages
+    // individually (--inexact so the second sync doesn't prune the first).
+    // --all-packages is unbuildable on main: an example package's declared
+    // README is missing, and uv builds every workspace member.
+    build:
+      'uv sync --frozen --all-extras --package mcp-everything-server && uv sync --frozen --all-extras --package mcp --inexact',
     client: {
       command: 'uv run --frozen python .github/actions/conformance/client.py'
     },
@@ -110,6 +115,11 @@ export const KNOWN_SDKS: Record<string, SdkConfig> = {
   // PORT and STATELESS from the environment: the stateful (dated-spec)
   // lifecycle is the default, and the 2026-07-28 override sets STATELESS=1
   // for the SEP-2575 stateless lifecycle.
+  // One default server serves every revision — rust-sdk's own CI starts a
+  // single un-flagged conformance-server and runs both the 2025-11-25 and
+  // 2026-07-28 legs against it. (A STATELESS=1 override here used to force the
+  // 2026 leg onto a mode the SDK's CI never exercises, failing its SEP-2575
+  // input-required scenarios.)
   'rust-sdk': {
     build: 'cargo build -p mcp-conformance',
     client: {
@@ -118,13 +128,6 @@ export const KNOWN_SDKS: Record<string, SdkConfig> = {
     server: {
       command: 'PORT=3000 ./target/debug/conformance-server',
       url: 'http://localhost:3000/mcp'
-    },
-    specOverrides: {
-      '2026-07-28': {
-        server: {
-          command: 'STATELESS=1 PORT=3000 ./target/debug/conformance-server'
-        }
-      }
     }
   },
   // Fixtures live in tests/ModelContextProtocol.ConformanceClient and
@@ -143,8 +146,12 @@ export const KNOWN_SDKS: Record<string, SdkConfig> = {
       command: `bash -c 'exec dotnet artifacts/bin/ModelContextProtocol.ConformanceClient/Release/net10.0/ModelContextProtocol.ConformanceClient.dll "$MCP_CONFORMANCE_SCENARIO" "$1"' conformance-client`
     },
     server: {
+      // Launch from the build-output directory: ASP.NET resolves
+      // appsettings.json from the content root (the cwd), and that file
+      // carries the AllowedHosts filter dns-rebinding-protection tests.
+      // Launched from the repo root it silently never loads.
       command:
-        'dotnet artifacts/bin/ModelContextProtocol.ConformanceServer/Release/net10.0/ModelContextProtocol.ConformanceServer.dll --urls http://localhost:3000',
+        "bash -c 'cd artifacts/bin/ModelContextProtocol.ConformanceServer/Release/net10.0 && exec dotnet ModelContextProtocol.ConformanceServer.dll --urls http://localhost:3000'",
       url: 'http://localhost:3000'
     },
     specOverrides: {

--- a/src/sdk-runner/sdk-runner.test.ts
+++ b/src/sdk-runner/sdk-runner.test.ts
@@ -202,11 +202,17 @@ describe('resolveConfigForSpec', () => {
     expect(resolved.server?.command).toContain('mcp-everything-server');
   });
 
-  it('prefixes STATELESS=1 for rust-sdk at 2026-07-28', () => {
-    const resolved = resolveConfigForSpec(KNOWN_SDKS['rust-sdk'], '2026-07-28');
-    expect(resolved.server?.command).toBe(
-      'STATELESS=1 PORT=3000 ./target/debug/conformance-server'
-    );
+  it('runs rust-sdk with the same default server at every revision', () => {
+    // Mirrors rust-sdk's own CI, which starts one un-flagged server and runs
+    // both the 2025-11-25 and 2026-07-28 legs against it. A STATELESS=1
+    // override here forced the 2026 leg onto a mode that CI never exercises
+    // and that fails its SEP-2575 input-required scenarios.
+    for (const rev of ['2025-11-25', '2026-07-28']) {
+      const resolved = resolveConfigForSpec(KNOWN_SDKS['rust-sdk'], rev);
+      expect(resolved.server?.command).toBe(
+        'PORT=3000 ./target/debug/conformance-server'
+      );
+    }
   });
 
   it('does not mutate the base entry', () => {

--- a/src/tier-check/checks/test-conformance-results.ts
+++ b/src/tier-check/checks/test-conformance-results.ts
@@ -1,4 +1,5 @@
-import { execFileSync } from 'child_process';
+import { spawn } from 'child_process';
+import { resolve as resolvePath } from 'path';
 import { mkdtempSync, readFileSync, existsSync, globSync } from 'fs';
 import { join, dirname } from 'path';
 import { tmpdir } from 'os';
@@ -10,6 +11,12 @@ import {
   listClientScenariosForSpec,
   getScenarioSpecVersions
 } from '../../scenarios';
+import {
+  notScoredScenarios,
+  RequirementSet,
+  scenariosToRun,
+  scoredScenarios
+} from '../../requirements';
 import {
   ConformanceCheck,
   DRAFT_PROTOCOL_VERSION,
@@ -115,7 +122,14 @@ function stripTimestamp(dirName: string): string {
 function reconcileWithExpected(
   result: ConformanceResult,
   expectedScenarios: string[],
-  resultPrefix?: string
+  resultPrefix?: string,
+  /**
+   * Names that count toward the pass rate. When a requirement set is in play it
+   * decides this directly, so extensions and post-release additions are run and
+   * reported but never scored. Undefined keeps the spec-version heuristic.
+   */
+  scoredNames?: Set<string>,
+  notScoredReasons?: Map<string, string>
 ): ConformanceResult {
   const reportedNames = new Set(
     result.details.map((d) => {
@@ -127,38 +141,56 @@ function reconcileWithExpected(
     })
   );
 
-  // Attach specVersion to existing detail entries
+  // Normalise to the canonical scenario name. Results live in per-run
+  // directories (`server-ping-<timestamp>`), and reporting that spelling means
+  // a reported name does not match the same scenario in `list` or in a
+  // requirement set.
   for (const detail of result.details) {
     let name = stripTimestamp(detail.scenario);
     if (resultPrefix) {
       name = name.replace(new RegExp(`^${resultPrefix}-`), '');
     }
+    detail.scenario = name;
     detail.specVersions = getScenarioSpecVersions(name);
+    const reason = notScoredReasons?.get(name);
+    if (reason) detail.notScoredReason = reason;
   }
 
   for (const expected of expectedScenarios) {
     if (!reportedNames.has(expected)) {
       result.failed++;
       result.total++;
+      const reason = notScoredReasons?.get(expected);
       result.details.push({
         scenario: expected,
         passed: false,
         checks_passed: 0,
         checks_failed: 0,
-        specVersions: getScenarioSpecVersions(expected)
+        specVersions: getScenarioSpecVersions(expected),
+        ...(reason ? { notScoredReason: reason } : {})
       });
     }
   }
 
-  // pass_rate only counts tier-scoring scenarios (date-versioned, not draft/extension).
-  // passed/failed/total reflect ALL scenarios for full reporting; pass_rate and status
-  // reflect only tier-scoring scenarios for tier logic.
-  const tierDetails = result.details.filter((d) =>
-    isTierScoring(d.specVersions)
-  );
+  // passed/failed/total describe the SCORED set, so they agree with pass_rate and
+  // with the report. Counting every scenario here made the object self-
+  // contradictory (passed 56, total 64, pass_rate 1) and invited 56/64 to be
+  // quoted as the conformance rate. Anything run without being scored is
+  // reported under not_scored instead.
+  const tierDetails = scoredNames
+    ? result.details.filter((d) => scoredNames.has(d.scenario))
+    : result.details.filter((d) => isTierScoring(d.specVersions));
   const tierPassed = tierDetails.filter((d) => d.passed).length;
   const tierTotal = tierDetails.length;
+  const unscored = result.details.filter((d) => !tierDetails.includes(d));
 
+  result.passed = tierPassed;
+  result.failed = tierTotal - tierPassed;
+  result.total = tierTotal;
+  result.not_scored = {
+    total: unscored.length,
+    failed: unscored.filter((d) => !d.passed).length
+  };
   result.pass_rate = tierTotal > 0 ? tierPassed / tierTotal : 0;
   result.status =
     result.pass_rate >= 1.0
@@ -171,12 +203,133 @@ function reconcileWithExpected(
 }
 
 /**
+ * Run the conformance CLI as a child. A non-zero exit is normal when scenarios
+ * fail, so it is not itself an error; what matters is whether the child got far
+ * enough to write results. Returns the child's stderr when it did not.
+ */
+function unmeasured(error: string): ConformanceResult {
+  return {
+    status: 'fail',
+    pass_rate: 0,
+    passed: 0,
+    failed: 0,
+    total: 0,
+    details: [],
+    error
+  };
+}
+
+function runChild(args: string[], cwd?: string): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    // Async on purpose: a leg can run under a managed SDK server whose
+    // stdout/stderr the parent is draining. A synchronous exec would block the
+    // event loop for the whole leg, the server's pipes would fill, its log
+    // writes would block, and the server would freeze mid-leg — scored as
+    // conformance failures against the SDK.
+    const child = spawn(process.execPath, args, {
+      // Results are read from the -o directory, so the child's stdout is
+      // noise. Keep a bounded stderr tail for error reporting.
+      stdio: ['ignore', 'ignore', 'pipe'],
+      cwd
+    });
+    let stderr = '';
+    child.stderr.on('data', (d) => {
+      if (stderr.length < 64 * 1024) stderr += d.toString();
+    });
+    // Generous whole-leg budget: a slow SDK on CI-class hardware must not
+    // have a killed harness scored as conformance failures.
+    const timer = setTimeout(() => child.kill('SIGKILL'), 600_000);
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      resolve(err.message);
+    });
+    child.on('close', (code, signal) => {
+      clearTimeout(timer);
+      if (code === 0) resolve(undefined);
+      else if (signal) resolve(`conformance run terminated (${signal})`);
+      else {
+        const tail = stderr.trim();
+        // Non-zero exit is normal when scenarios fail; what matters is whether
+        // the child got far enough to write results. Callers treat this as
+        // fatal only when the output directory is empty.
+        resolve(tail ? tail.split('\n').slice(-3).join(' ') : undefined);
+      }
+    });
+  });
+}
+
+/**
  * Run server conformance tests by shelling out to the conformance CLI.
  */
+/** Merge per-revision results so a single pass rate spans every revision claimed. */
+export function mergeByRevision(
+  parts: { revision: string; result: ConformanceResult }[]
+): ConformanceResult {
+  // Single revision: same result, but details still carry their revision so
+  // the JSON shape does not depend on how many revisions were claimed.
+  if (parts.length === 1) {
+    const only = parts[0];
+    return {
+      ...only.result,
+      details: only.result.details.map((d) => ({
+        ...d,
+        revision: only.revision
+      }))
+    };
+  }
+
+  const errored = parts.find((p) => p.result.error);
+  if (errored)
+    return unmeasured(`${errored.revision}: ${errored.result.error}`);
+
+  // A skipped leg never ran; folding it into the numbers would report a
+  // failure that never happened. All revisions skipped is a skipped leg.
+  // SOME revisions skipped means a claimed revision went unmeasured, which
+  // must surface through the error/exit machinery rather than merge into a
+  // clean pass that quietly covers fewer revisions than were claimed.
+  const skipped = parts.filter((p) => p.result.status === 'skipped');
+  if (skipped.length === parts.length) {
+    return {
+      status: 'skipped',
+      pass_rate: 0,
+      passed: 0,
+      failed: 0,
+      total: 0,
+      details: []
+    };
+  }
+  if (skipped.length > 0) {
+    return unmeasured(
+      `${skipped.map((p) => p.revision).join(', ')}: leg not measured for this revision`
+    );
+  }
+
+  const details = parts.flatMap((p) =>
+    p.result.details.map((d) => ({ ...d, revision: p.revision }))
+  );
+  const scored = details.filter((d) => !d.notScoredReason);
+  const passed = scored.filter((d) => d.passed).length;
+  const unscored = details.filter((d) => d.notScoredReason);
+  const pass_rate = scored.length > 0 ? passed / scored.length : 0;
+  return {
+    status: pass_rate >= 1 ? 'pass' : pass_rate >= 0.8 ? 'partial' : 'fail',
+    pass_rate,
+    passed,
+    failed: scored.length - passed,
+    total: scored.length,
+    not_scored: {
+      total: unscored.length,
+      failed: unscored.filter((d) => !d.passed).length
+    },
+    details
+  };
+}
+
 export async function checkConformance(options: {
   serverUrl?: string;
   skip?: boolean;
   specVersion?: SpecVersion;
+  requirements?: RequirementSet;
 }): Promise<ConformanceResult> {
   if (options.skip || !options.serverUrl) {
     return {
@@ -191,24 +344,37 @@ export async function checkConformance(options: {
 
   const outputDir = mkdtempSync(join(tmpdir(), 'tier-check-server-'));
   const args = [
-    process.argv[1],
+    resolvePath(process.argv[1]),
     'server',
     '--url',
     options.serverUrl,
     '-o',
     outputDir
   ];
-  if (options.specVersion) {
+  if (options.requirements) {
+    args.push('--requirements', options.requirements.revision);
+  } else if (options.specVersion) {
     args.push('--spec-version', options.specVersion);
   }
 
-  try {
-    execFileSync(process.execPath, args, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 120_000
-    });
-  } catch {
-    // Non-zero exit is expected when tests fail — results are still in outputDir
+  const failure = await runChild(args);
+
+  const parsedServer = parseOutputDir(outputDir);
+  if (failure && parsedServer.total === 0) return unmeasured(failure);
+
+  if (options.requirements) {
+    return reconcileWithExpected(
+      parsedServer,
+      scenariosToRun(options.requirements, 'server'),
+      'server',
+      new Set(scoredScenarios(options.requirements, 'server')),
+      new Map(
+        notScoredScenarios(options.requirements, 'server').map((e) => [
+          e.scenario,
+          e.reason
+        ])
+      )
+    );
   }
 
   const activeScenarios = new Set(listActiveClientScenarios());
@@ -218,11 +384,7 @@ export async function checkConformance(options: {
       )
     : [...activeScenarios];
 
-  return reconcileWithExpected(
-    parseOutputDir(outputDir),
-    expectedScenarios,
-    'server'
-  );
+  return reconcileWithExpected(parsedServer, expectedScenarios, 'server');
 }
 
 /**
@@ -232,6 +394,15 @@ export async function checkClientConformance(options: {
   clientCmd?: string;
   skip?: boolean;
   specVersion?: SpecVersion;
+  requirements?: RequirementSet;
+  /**
+   * Working directory for the client command. SDK CI keeps client commands
+   * relative to the SDK checkout (.venv/bin/python …, ./.conformance-client);
+   * spawning them from the conformance repo turns that into a silent 0%.
+   */
+  cwd?: string;
+  /** Per-scenario client timeout in ms, forwarded to the client leg. */
+  timeoutMs?: number;
 }): Promise<ConformanceResult> {
   if (options.skip || !options.clientCmd) {
     return {
@@ -246,31 +417,48 @@ export async function checkClientConformance(options: {
 
   const outputDir = mkdtempSync(join(tmpdir(), 'tier-check-client-'));
   const args = [
-    process.argv[1],
+    resolvePath(process.argv[1]),
     'client',
     '--command',
     options.clientCmd,
-    '--suite',
-    'all',
     '-o',
     outputDir
   ];
-  if (options.specVersion) {
-    args.push('--spec-version', options.specVersion);
+  if (options.requirements) {
+    args.push('--requirements', options.requirements.revision);
+  } else {
+    args.push('--suite', 'all');
+    if (options.specVersion) {
+      args.push('--spec-version', options.specVersion);
+    }
+  }
+  if (options.timeoutMs) {
+    args.push('--timeout', String(options.timeoutMs));
   }
 
-  try {
-    execFileSync(process.execPath, args, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 120_000
-    });
-  } catch {
-    // Non-zero exit is expected when tests fail — results are still in outputDir
+  const failure = await runChild(args, options.cwd);
+
+  const parsedClient = parseOutputDir(outputDir);
+  if (failure && parsedClient.total === 0) return unmeasured(failure);
+
+  if (options.requirements) {
+    return reconcileWithExpected(
+      parsedClient,
+      scenariosToRun(options.requirements, 'client'),
+      undefined,
+      new Set(scoredScenarios(options.requirements, 'client')),
+      new Map(
+        notScoredScenarios(options.requirements, 'client').map((e) => [
+          e.scenario,
+          e.reason
+        ])
+      )
+    );
   }
 
   const expectedScenarios = options.specVersion
     ? listScenariosForSpec(options.specVersion)
     : listScenarios();
 
-  return reconcileWithExpected(parseOutputDir(outputDir), expectedScenarios);
+  return reconcileWithExpected(parsedClient, expectedScenarios);
 }

--- a/src/tier-check/index.ts
+++ b/src/tier-check/index.ts
@@ -2,7 +2,8 @@ import { Command } from 'commander';
 import { Octokit } from '@octokit/rest';
 import {
   checkConformance,
-  checkClientConformance
+  checkClientConformance,
+  mergeByRevision
 } from './checks/test-conformance-results';
 import { checkLabels } from './checks/labels';
 import { checkTriage } from './checks/triage';
@@ -14,6 +15,87 @@ import { computeTier } from './tier-logic';
 import { formatJson, formatMarkdown, formatTerminal } from './output';
 import { TierScorecard } from './types';
 import { resolveSpecVersion } from '../scenarios';
+import {
+  listRequirementRevisions,
+  loadRequirements,
+  RequirementSet
+} from '../requirements';
+import { execShell, withManagedServer } from '../sdk-runner';
+import { lookupBuiltinConfig } from '../sdk-runner/known-sdks';
+import { resolveConfigForSpec, SdkConfig } from '../sdk-runner/config';
+import { ensureCheckout, parseSdkSpec } from '../sdk-runner/checkout';
+import { ConformanceResult } from './types';
+import path from 'path';
+
+/**
+ * Run both conformance legs for each claimed revision with the SDK's own
+ * invocation for that revision, resolved from KNOWN_SDKS specOverrides. This is
+ * what makes multi-revision tiering correct for SDKs whose wire era is fixed
+ * per process (go-sdk starts a different server per revision) or per endpoint
+ * (csharp-sdk serves the stateless lifecycle at /stateless): one
+ * --conformance-server-url cannot describe them, but their config already does.
+ * Sequential on purpose — consecutive revisions reuse the same port.
+ */
+async function runSdkConformance(
+  dir: string,
+  base: SdkConfig,
+  requirements: RequirementSet[],
+  options: { skipBuild?: boolean; timeoutMs?: number }
+): Promise<{ server: ConformanceResult; client: ConformanceResult }> {
+  const server: { revision: string; result: ConformanceResult }[] = [];
+  const client: { revision: string; result: ConformanceResult }[] = [];
+  const built = new Set<string>();
+
+  for (const req of requirements) {
+    const cfg = resolveConfigForSpec(base, req.revision);
+
+    if (cfg.build && !options.skipBuild && !built.has(cfg.build)) {
+      console.error(`  [sdk] Building for ${req.revision}: ${cfg.build}`);
+      await execShell(cfg.build, dir);
+      built.add(cfg.build);
+    }
+
+    if (cfg.server) {
+      const { command, url, readyTimeoutMs } = cfg.server;
+      const result = await withManagedServer(
+        command,
+        dir,
+        url,
+        readyTimeoutMs ?? 15000,
+        () => checkConformance({ serverUrl: url, requirements: req })
+      );
+      server.push({ revision: req.revision, result });
+    } else {
+      server.push({
+        revision: req.revision,
+        result: {
+          status: 'skipped',
+          pass_rate: 0,
+          passed: 0,
+          failed: 0,
+          total: 0,
+          details: []
+        }
+      });
+    }
+
+    client.push({
+      revision: req.revision,
+      result: await checkClientConformance({
+        clientCmd: cfg.client?.command,
+        skip: !cfg.client,
+        requirements: req,
+        cwd: dir,
+        timeoutMs: options.timeoutMs
+      })
+    });
+  }
+
+  return {
+    server: mergeByRevision(server),
+    client: mergeByRevision(client)
+  };
+}
 
 function parseRepo(repo: string): { owner: string; repo: string } {
   const parts = repo.split('/');
@@ -25,18 +107,36 @@ function parseRepo(repo: string): { owner: string; repo: string } {
 export function createTierCheckCommand(): Command {
   const tierCheck = new Command('tier-check')
     .description('Run SDK tier assessment checks against a GitHub repository')
-    .requiredOption(
+    .option(
       '--repo <owner/repo>',
-      'GitHub repository (e.g., modelcontextprotocol/typescript-sdk)'
+      'GitHub repository (e.g., modelcontextprotocol/typescript-sdk). Derived from --sdk when omitted'
     )
     .option('--branch <branch>', 'Branch to check')
     .option(
+      '--sdk <name[@ref]>',
+      'Assess a known SDK end to end: clones/builds it and runs each revision with the invocation its config declares for that revision (see src/sdk-runner/known-sdks.ts)'
+    )
+    .option(
+      '--sdk-path <dir>',
+      'Use an existing local SDK checkout with --sdk semantics (config resolved from the directory name unless --sdk names it)'
+    )
+    .option('--skip-build', 'Skip the SDK build step (with --sdk/--sdk-path)')
+    .option(
+      '--cache-dir <dir>',
+      'Directory for cached SDK clones (with --sdk)',
+      '.sdk-under-test'
+    )
+    .option(
+      '--timeout <ms>',
+      'Per-scenario client timeout, forwarded to the client leg'
+    )
+    .option(
       '--conformance-server-url <url>',
-      'URL of the already-running conformance server'
+      'URL of an already-running conformance server. Only correct when that one endpoint serves every claimed revision at its own wire; SDKs that vary the server per revision need --sdk'
     )
     .option(
       '--client-cmd <cmd>',
-      'Command to run the SDK conformance client (for client conformance tests)'
+      'Command to run the SDK conformance client (with --conformance-server-url; must be invocable from this directory)'
     )
     .option('--skip-conformance', 'Skip conformance tests')
     .option('--days <n>', 'Limit triage check to issues created in last N days')
@@ -53,13 +153,130 @@ export function createTierCheckCommand(): Command {
       '--spec-version <version>',
       'Only run conformance scenarios for this spec version'
     )
+    .option(
+      '--requirements <revision>',
+      'Score against the frozen requirement set for a spec revision (e.g. 2026-07-28), so the SDK is measured against the suite as it stood when that revision shipped'
+    )
     .action(async (options) => {
+      const sdkMode =
+        options.sdk !== undefined || options.sdkPath !== undefined;
+
+      if (sdkMode && (options.conformanceServerUrl || options.clientCmd)) {
+        console.error(
+          '--sdk resolves the server and client invocation per revision from the SDK config; it cannot be combined with --conformance-server-url or --client-cmd.'
+        );
+        process.exit(1);
+      }
+      if (sdkMode && (options.specVersion || options.skipConformance)) {
+        console.error(
+          '--sdk runs the frozen requirement sets; it cannot be combined with --spec-version or --skip-conformance.'
+        );
+        process.exit(1);
+      }
+
+      // Resolve the SDK checkout and config up front so --repo/--branch can be
+      // derived from it.
+      let sdkDir: string | undefined;
+      let sdkConfig: SdkConfig | undefined;
+      if (sdkMode) {
+        const spec = options.sdk ? parseSdkSpec(options.sdk) : undefined;
+        const sdkName =
+          spec?.name ?? path.basename(path.resolve(options.sdkPath));
+        sdkConfig = lookupBuiltinConfig(sdkName) ?? undefined;
+        if (!sdkConfig) {
+          console.error(
+            `'${sdkName}' is not a known SDK (see src/sdk-runner/known-sdks.ts). Use --conformance-server-url/--client-cmd to drive an unknown SDK directly.`
+          );
+          process.exit(1);
+        }
+        // One ref, used for the checkout, the scorecard and the policy-file
+        // reads alike — computing them independently attributed verdicts to
+        // branches that never ran (an aliased entry like typescript-sdk-v1
+        // tests v1.x but read policy files from main).
+        if (options.sdk && options.branch) {
+          console.error(
+            '--branch cannot be combined with --sdk: put the ref in the SDK spec instead (e.g. --sdk typescript-sdk@v1.x).'
+          );
+          process.exit(1);
+        }
+        if (options.sdkPath) {
+          sdkDir = path.resolve(options.sdkPath);
+          if (!options.branch) {
+            // Report the branch the checkout is actually on.
+            try {
+              const { execSync } = await import('child_process');
+              const head = execSync('git rev-parse --abbrev-ref HEAD', {
+                cwd: sdkDir,
+                encoding: 'utf-8'
+              }).trim();
+              if (head && head !== 'HEAD') options.branch = head;
+            } catch {
+              // not a git checkout; leave branch unset
+            }
+          }
+        } else {
+          const ref = spec!.ref ?? sdkConfig.defaultRef ?? 'main';
+          sdkDir = await ensureCheckout(
+            { name: sdkConfig.repo ?? spec!.name, ref },
+            options.cacheDir
+          );
+          options.branch = ref;
+        }
+        if (!options.repo) {
+          options.repo = `modelcontextprotocol/${sdkConfig.repo ?? sdkName}`;
+        }
+      }
+      if (!options.repo) {
+        console.error(
+          '--repo is required (or pass --sdk to derive it from the SDK config).'
+        );
+        process.exit(1);
+      }
+
       const { owner, repo } = parseRepo(options.repo);
       let token = options.token || process.env.GITHUB_TOKEN;
 
       const specVersion = options.specVersion
         ? resolveSpecVersion(options.specVersion)
         : undefined;
+
+      let requirements: RequirementSet[] | undefined;
+      if (options.requirements !== undefined) {
+        if (specVersion) {
+          console.error(
+            '--requirements cannot be combined with --spec-version: a requirement set already fixes which scenarios run.'
+          );
+          process.exit(1);
+        }
+        try {
+          // Several revisions may be claimed at once. Tier 1 then means every
+          // one of them passes, because a scenario shared by two revisions has
+          // to work on both wires, and one run does not cover the other.
+          // Dedupe: '2026-07-28,2026-07-28' must not run and count twice.
+          requirements = [
+            ...new Set(
+              String(options.requirements)
+                .split(',')
+                .map((r) => r.trim())
+                .filter(Boolean)
+            )
+          ].map(loadRequirements);
+          if (requirements.length === 0) {
+            throw new Error('--requirements needs at least one revision');
+          }
+        } catch (error) {
+          console.error(error instanceof Error ? error.message : String(error));
+          process.exit(1);
+        }
+      } else if (sdkMode) {
+        // Tiering means every shipped revision: a scenario shared by two
+        // revisions must pass on both wires, so default to all of them.
+        const revisions = listRequirementRevisions();
+        console.error(
+          `No --requirements given; assessing every shipped revision: ${revisions.join(', ')}`
+        );
+        requirements = revisions.map(loadRequirements);
+      }
 
       if (!token) {
         // Try to get token from GitHub CLI
@@ -83,61 +300,110 @@ export function createTierCheckCommand(): Command {
 
       const octokit = new Octokit({ auth: token });
       const days = options.days ? parseInt(options.days, 10) : undefined;
+      const timeoutMs = options.timeout
+        ? parseInt(options.timeout, 10)
+        : undefined;
 
       console.error('Running tier assessment checks...\n');
 
-      // Run all checks
-      const [
-        conformance,
-        clientConformance,
-        labels,
-        triage,
-        p0,
-        release,
-        files,
-        specTracking
-      ] = await Promise.all([
-        checkConformance({
+      // Conformance strategy. SDK mode resolves the invocation per revision
+      // from the SDK's config and manages the server itself; URL mode drives an
+      // already-running server that must serve every claimed revision.
+      let serverConformancePromise: Promise<ConformanceResult>;
+      let clientConformancePromise: Promise<ConformanceResult>;
+      if (sdkMode) {
+        const sdkRun = runSdkConformance(sdkDir!, sdkConfig!, requirements!, {
+          skipBuild: options.skipBuild,
+          timeoutMs
+        });
+        serverConformancePromise = sdkRun.then((r) => r.server);
+        clientConformancePromise = sdkRun.then((r) => r.client);
+      } else if (requirements) {
+        const reqs = requirements;
+        serverConformancePromise = Promise.all(
+          reqs.map((req) =>
+            checkConformance({
+              serverUrl: options.conformanceServerUrl,
+              skip: options.skipConformance,
+              requirements: req
+            }).then((result) => ({ revision: req.revision, result }))
+          )
+        ).then(mergeByRevision);
+        clientConformancePromise = Promise.all(
+          reqs.map((req) =>
+            checkClientConformance({
+              clientCmd: options.clientCmd,
+              skip: options.skipConformance || !options.clientCmd,
+              requirements: req,
+              timeoutMs
+            }).then((result) => ({ revision: req.revision, result }))
+          )
+        ).then(mergeByRevision);
+      } else {
+        serverConformancePromise = checkConformance({
           serverUrl: options.conformanceServerUrl,
           skip: options.skipConformance,
           specVersion
-        }).then((r) => {
-          console.error('  ✓ Server Conformance');
-          return r;
-        }),
-        checkClientConformance({
+        });
+        clientConformancePromise = checkClientConformance({
           clientCmd: options.clientCmd,
           skip: options.skipConformance || !options.clientCmd,
-          specVersion
-        }).then((r) => {
-          console.error('  ✓ Client Conformance');
-          return r;
-        }),
-        checkLabels(octokit, owner, repo).then((r) => {
-          console.error('  ✓ Labels');
-          return r;
-        }),
-        checkTriage(octokit, owner, repo, days).then((r) => {
-          console.error('  \u2713 Triage');
-          return r;
-        }),
-        checkP0Resolution(octokit, owner, repo).then((r) => {
-          console.error('  \u2713 P0 Resolution');
-          return r;
-        }),
-        checkStableRelease(octokit, owner, repo).then((r) => {
-          console.error('  \u2713 Stable Release');
-          return r;
-        }),
-        checkPolicySignals(octokit, owner, repo, options.branch).then((r) => {
-          console.error('  \u2713 Policy Signals');
-          return r;
-        }),
-        checkSpecTracking(octokit, owner, repo).then((r) => {
-          console.error('  \u2713 Spec Tracking');
-          return r;
-        })
-      ]);
+          specVersion,
+          timeoutMs
+        });
+      }
+
+      // Conformance first, to completion, so a failing GitHub API call can
+      // never interrupt a leg mid-run and orphan a managed server. The GitHub
+      // checks are seconds; nothing meaningful is lost by not overlapping.
+      let conformance: ConformanceResult;
+      let clientConformance: ConformanceResult;
+      try {
+        conformance = await serverConformancePromise;
+        console.error('  \u2713 Server Conformance');
+        clientConformance = await clientConformancePromise;
+        console.error('  \u2713 Client Conformance');
+      } catch (error) {
+        console.error(
+          `Conformance run failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+        process.exit(1);
+      }
+
+      let labels, triage, p0, release, files, specTracking;
+      try {
+        [labels, triage, p0, release, files, specTracking] = await Promise.all([
+          checkLabels(octokit, owner, repo).then((r) => {
+            console.error('  ✓ Labels');
+            return r;
+          }),
+          checkTriage(octokit, owner, repo, days).then((r) => {
+            console.error('  \u2713 Triage');
+            return r;
+          }),
+          checkP0Resolution(octokit, owner, repo).then((r) => {
+            console.error('  \u2713 P0 Resolution');
+            return r;
+          }),
+          checkStableRelease(octokit, owner, repo).then((r) => {
+            console.error('  \u2713 Stable Release');
+            return r;
+          }),
+          checkPolicySignals(octokit, owner, repo, options.branch).then((r) => {
+            console.error('  \u2713 Policy Signals');
+            return r;
+          }),
+          checkSpecTracking(octokit, owner, repo).then((r) => {
+            console.error('  \u2713 Spec Tracking');
+            return r;
+          })
+        ]);
+      } catch (error) {
+        console.error(
+          `GitHub API check failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+        process.exit(1);
+      }
 
       const checks = {
         conformance,
@@ -157,6 +423,7 @@ export function createTierCheckCommand(): Command {
         branch: options.branch || null,
         timestamp: new Date().toISOString(),
         version: release.version,
+        requirements_revisions: requirements?.map((r) => r.revision) ?? null,
         checks,
         implied_tier
       };
@@ -170,6 +437,20 @@ export function createTierCheckCommand(): Command {
           break;
         default:
           formatTerminal(scorecard);
+      }
+
+      // Exit code gates on the machine-checkable half — scored conformance
+      // failures, or a leg that could not be measured — but only under
+      // --requirements, where "failed" is measured against a frozen contract.
+      // Legacy mode scores against today's suite, which drifts: gating there
+      // would flip existing pipelines red the day a post-release scenario
+      // merges, the exact injustice the frozen sets exist to remove. Legacy
+      // stays report-only (exit 0), as it always was.
+      if (requirements) {
+        const conformanceBroken = [conformance, clientConformance].some(
+          (c) => c.error !== undefined || c.failed > 0
+        );
+        process.exitCode = conformanceBroken ? 1 : 0;
       }
     });
 

--- a/src/tier-check/output.ts
+++ b/src/tier-check/output.ts
@@ -105,6 +105,87 @@ function formatRate(cell: Cell): string {
   return `${cell.passed}/${cell.total} (${Math.round((cell.passed / cell.total) * 100)}%)`;
 }
 
+/**
+ * Under a requirement set the spec-version matrix is the wrong picture: the set
+ * already names exactly what is scored, so splitting it by applicability tag and
+ * filing part of it as "informational" would contradict the score.
+ */
+/**
+ * A run at one revision's wire and a run at another's are distinct
+ * measurements, so entries are never deduplicated across revisions — the
+ * counts here must match the JSON, and a scenario that fails on one wire but
+ * passes on the other must say which. The label carries the revision whenever
+ * one is recorded.
+ */
+function withRevision(d: { scenario: string; revision?: string }): string {
+  return d.revision ? `${d.scenario} [${d.revision}]` : d.scenario;
+}
+
+function requirementsSummary(scorecard: TierScorecard): string[] {
+  const revisions = scorecard.requirements_revisions ?? [];
+  const rows: [string, ConformanceResult][] = [
+    ['Server', scorecard.checks.conformance as ConformanceResult],
+    ['Client', scorecard.checks.client_conformance as ConformanceResult]
+  ];
+  const lines = [
+    '',
+    `Scored against the ${revisions.join(' and ')} requirement set${revisions.length > 1 ? 's' : ''}, each run at its own wire version.`,
+    '',
+    '| | Required | Passed | |',
+    '|---|---|---|---|'
+  ];
+  for (const [label, result] of rows) {
+    if (result.error) {
+      lines.push(`| ${label} | — | — | not measured |`);
+      continue;
+    }
+    if (result.status === 'skipped') {
+      lines.push(`| ${label} | — | — | skipped |`);
+      continue;
+    }
+    lines.push(
+      `| ${label} | ${result.total} | ${result.passed} | ${Math.round(result.pass_rate * 100)}% |`
+    );
+  }
+
+  // A requirement set is small and every entry is named, so a bare count is not
+  // actionable: say which ones failed.
+  const failed = rows.flatMap(([label, result]) =>
+    result.details
+      .filter((d) => !d.passed && !d.notScoredReason)
+      .map((d) => `${label.toLowerCase()}: ${withRevision(d)}`)
+  );
+  if (failed.length > 0) {
+    lines.push('');
+    lines.push(`_Failing (${failed.length}):_`);
+    lines.push('');
+    failed.forEach((f) => lines.push(`- ${f}`));
+  }
+
+  // Run and reported, but deliberately outside the score.
+  const notScored = rows.flatMap(([label, result]) =>
+    result.details
+      .filter((d) => d.notScoredReason)
+      .map((d) => ({ ...d, leg: label.toLowerCase() }))
+  );
+  if (notScored.length > 0) {
+    const failing = notScored.filter((d) => !d.passed);
+    lines.push('');
+    lines.push(
+      `_Not scored (${notScored.length} run, ${failing.length} failing). These do not affect the tier:_`
+    );
+    lines.push('');
+    lines.push('| Scenario | Leg | Result | Why not scored |');
+    lines.push('|---|---|---|---|');
+    for (const d of notScored) {
+      lines.push(
+        `| ${withRevision(d)} | ${d.leg} | ${d.passed ? 'pass' : 'fail'} | ${d.notScoredReason} |`
+      );
+    }
+  }
+  return lines;
+}
+
 export function formatJson(scorecard: TierScorecard): string {
   return JSON.stringify(scorecard, null, 2);
 }
@@ -118,6 +199,10 @@ export function formatMarkdown(scorecard: TierScorecard): string {
   lines.push(`**Repo**: ${scorecard.repo}`);
   if (scorecard.branch) lines.push(`**Branch**: ${scorecard.branch}`);
   if (scorecard.version) lines.push(`**Version**: ${scorecard.version}`);
+  if (scorecard.requirements_revisions)
+    lines.push(
+      `**Requirements**: ${scorecard.requirements_revisions.join(', ')} (frozen; each run at its own wire)`
+    );
   lines.push(`**Timestamp**: ${scorecard.timestamp}`);
   lines.push('');
   lines.push('## Check Results');
@@ -129,50 +214,54 @@ export function formatMarkdown(scorecard: TierScorecard): string {
     c.client_conformance as ConformanceResult
   );
 
-  // Tier-scoring matrix
-  lines.push('');
-  lines.push(`| | ${TIER_SPEC_VERSIONS.join(' | ')} | All* |`);
-  lines.push(`|---|${TIER_SPEC_VERSIONS.map(() => '---|').join('')}---|`);
-
-  const mdRows: [string, MatrixRow][] = [
-    ['Server', matrix.server],
-    ['Client: Core', matrix.clientCore],
-    ['Client: Auth', matrix.clientAuth]
-  ];
-
-  for (const [label, row] of mdRows) {
-    lines.push(
-      `| ${label} | ${TIER_SPEC_VERSIONS.map((v) => formatCell(row.cells.get(v))).join(' | ')} | ${formatRate(row.tierUnique)} |`
-    );
-  }
-
-  lines.push('');
-  lines.push(
-    '_* unique scenarios — a scenario may apply to multiple spec versions_'
-  );
-
-  // Informational matrix (draft/extension)
-  const hasInfoMd = mdRows.some(([, row]) =>
-    INFO_SPEC_VERSIONS.some((v) => {
-      const cell = row.cells.get(v);
-      return cell && cell.total > 0;
-    })
-  );
-  if (hasInfoMd) {
+  if (scorecard.requirements_revisions) {
+    lines.push(...requirementsSummary(scorecard));
+  } else {
+    // Tier-scoring matrix
     lines.push('');
-    lines.push('_Informational (not scored for tier):_');
-    lines.push('');
-    lines.push(`| | ${INFO_SPEC_VERSIONS.join(' | ')} |`);
-    lines.push(`|---|${INFO_SPEC_VERSIONS.map(() => '---|').join('')}`);
+    lines.push(`| | ${TIER_SPEC_VERSIONS.join(' | ')} | All* |`);
+    lines.push(`|---|${TIER_SPEC_VERSIONS.map(() => '---|').join('')}---|`);
+
+    const mdRows: [string, MatrixRow][] = [
+      ['Server', matrix.server],
+      ['Client: Core', matrix.clientCore],
+      ['Client: Auth', matrix.clientAuth]
+    ];
+
     for (const [label, row] of mdRows) {
-      const hasData = INFO_SPEC_VERSIONS.some((v) => {
+      lines.push(
+        `| ${label} | ${TIER_SPEC_VERSIONS.map((v) => formatCell(row.cells.get(v))).join(' | ')} | ${formatRate(row.tierUnique)} |`
+      );
+    }
+
+    lines.push('');
+    lines.push(
+      '_* unique scenarios — a scenario may apply to multiple spec versions_'
+    );
+
+    // Informational matrix (draft/extension)
+    const hasInfoMd = mdRows.some(([, row]) =>
+      INFO_SPEC_VERSIONS.some((v) => {
         const cell = row.cells.get(v);
         return cell && cell.total > 0;
-      });
-      if (!hasData) continue;
-      lines.push(
-        `| ${label} | ${INFO_SPEC_VERSIONS.map((v) => formatCell(row.cells.get(v))).join(' | ')} |`
-      );
+      })
+    );
+    if (hasInfoMd) {
+      lines.push('');
+      lines.push('_Informational (not scored for tier):_');
+      lines.push('');
+      lines.push(`| | ${INFO_SPEC_VERSIONS.join(' | ')} |`);
+      lines.push(`|---|${INFO_SPEC_VERSIONS.map(() => '---|').join('')}`);
+      for (const [label, row] of mdRows) {
+        const hasData = INFO_SPEC_VERSIONS.some((v) => {
+          const cell = row.cells.get(v);
+          return cell && cell.total > 0;
+        });
+        if (!hasData) continue;
+        lines.push(
+          `| ${label} | ${INFO_SPEC_VERSIONS.map((v) => formatCell(row.cells.get(v))).join(' | ')} |`
+        );
+      }
     }
   }
   lines.push('');
@@ -228,79 +317,140 @@ export function formatTerminal(scorecard: TierScorecard): void {
   console.log(`Repo:      ${scorecard.repo}`);
   if (scorecard.branch) console.log(`Branch:    ${scorecard.branch}`);
   if (scorecard.version) console.log(`Version:   ${scorecard.version}`);
+  if (scorecard.requirements_revisions)
+    console.log(
+      `Requires:  ${scorecard.requirements_revisions.join(', ')} (frozen, each at its own wire)`
+    );
   console.log(`Timestamp: ${scorecard.timestamp}\n`);
 
   console.log(`${COLORS.BOLD}Conformance:${COLORS.RESET}\n`);
 
-  // Conformance matrix
-  const matrix = buildConformanceMatrix(
-    c.conformance as ConformanceResult,
-    c.client_conformance as ConformanceResult
-  );
-
-  const vw = 10; // column width for version cells
-  const lw = 14; // label column width
-  const tw = 16; // total column width
-  const rp = (s: string, w: number) => s.padStart(w);
-  const lp = (s: string, w: number) => s.padEnd(w);
-
-  // Tier-scoring matrix (date-versioned specs only)
-  console.log(
-    `  ${COLORS.DIM}${lp('', lw + 2)} ${TIER_SPEC_VERSIONS.map((v) => rp(v, vw)).join(' ')}  ${rp('All*', tw)}${COLORS.RESET}`
-  );
-
-  const rows: [string, MatrixRow, CheckStatus | null, boolean][] = [
-    ['Server', matrix.server, c.conformance.status, true],
-    ['Client: Core', matrix.clientCore, null, false],
-    ['Client: Auth', matrix.clientAuth, null, false]
-  ];
-
-  for (const [label, row, status, bold] of rows) {
-    const icon = status ? statusIcon(status) + ' ' : '  ';
-    const b = bold ? COLORS.BOLD : '';
-    const r = bold ? COLORS.RESET : '';
+  if (scorecard.requirements_revisions) {
     console.log(
-      `  ${icon}${b}${lp(label, lw)}${r} ${TIER_SPEC_VERSIONS.map((v) => rp(formatCell(row.cells.get(v)), vw)).join(' ')}  ${b}${rp(formatRate(row.tierUnique), tw)}${r}`
+      `  ${COLORS.DIM}Scored against ${scorecard.requirements_revisions.join(' and ')}, each run at its own wire version.${COLORS.RESET}\n`
     );
-  }
+    const reqRows: [string, ConformanceResult][] = [
+      ['Server', c.conformance as ConformanceResult],
+      ['Client', c.client_conformance as ConformanceResult]
+    ];
+    for (const [label, result] of reqRows) {
+      if (result.status === 'skipped') {
+        console.log(`    ${label.padEnd(8)} skipped`);
+        continue;
+      }
+      if (result.error) {
+        console.log(
+          `    ${label.padEnd(8)} ${COLORS.RED}not measured${COLORS.RESET}: ${result.error}`
+        );
+        continue;
+      }
+      console.log(
+        `    ${label.padEnd(8)} ${result.passed}/${result.total} required scenarios (${Math.round(result.pass_rate * 100)}%)`
+      );
+    }
+    const failedReq = reqRows.flatMap(([label, result]) =>
+      result.details
+        .filter((d) => !d.passed && !d.notScoredReason)
+        .map((d) => `${label.toLowerCase()}: ${withRevision(d)}`)
+    );
+    if (failedReq.length > 0) {
+      console.log(
+        `\n  ${COLORS.RED}Failing (${failedReq.length}):${COLORS.RESET}`
+      );
+      failedReq.forEach((f) =>
+        console.log(`    ${COLORS.RED}\u2717${COLORS.RESET} ${f}`)
+      );
+    }
+    const notScoredReq = reqRows.flatMap(([, result]) =>
+      result.details.filter((d) => d.notScoredReason)
+    );
+    if (notScoredReq.length > 0) {
+      const failing = notScoredReq.filter((d) => !d.passed);
+      console.log(
+        `\n  ${COLORS.DIM}Not scored (${notScoredReq.length} run, ${failing.length} failing, no effect on tier):${COLORS.RESET}`
+      );
+      for (const d of notScoredReq) {
+        const mark = d.passed
+          ? `${COLORS.GREEN}\u2713${COLORS.RESET}`
+          : `${COLORS.DIM}\u2717${COLORS.RESET}`;
+        console.log(
+          `    ${mark} ${withRevision(d)} ${COLORS.DIM}(${d.notScoredReason})${COLORS.RESET}`
+        );
+      }
+    }
+    console.log('');
+  } else {
+    // Conformance matrix
+    const matrix = buildConformanceMatrix(
+      c.conformance as ConformanceResult,
+      c.client_conformance as ConformanceResult
+    );
 
-  // Client total line (tier-scoring only)
-  const clientTierTotal: Cell = {
-    passed:
-      matrix.clientCore.tierUnique.passed + matrix.clientAuth.tierUnique.passed,
-    total:
-      matrix.clientCore.tierUnique.total + matrix.clientAuth.tierUnique.total
-  };
-  console.log(
-    `  ${statusIcon(c.client_conformance.status)} ${COLORS.BOLD}${lp('Client Total', lw)}${COLORS.RESET} ${' '.repeat(TIER_SPEC_VERSIONS.length * (vw + 1) - 1)}  ${COLORS.BOLD}${rp(formatRate(clientTierTotal), tw)}${COLORS.RESET}`
-  );
-  console.log(
-    `\n  ${COLORS.DIM}* unique scenarios — a scenario may apply to multiple spec versions${COLORS.RESET}`
-  );
+    const vw = 10; // column width for version cells
+    const lw = 14; // label column width
+    const tw = 16; // total column width
+    const rp = (s: string, w: number) => s.padStart(w);
+    const lp = (s: string, w: number) => s.padEnd(w);
 
-  // Informational matrix (draft/extension) — only if there are any
-  const hasInfo = rows.some(([, row]) =>
-    INFO_SPEC_VERSIONS.some((v) => {
-      const cell = row.cells.get(v);
-      return cell && cell.total > 0;
-    })
-  );
-  if (hasInfo) {
-    console.log(`\n  Informational (not scored for tier):\n`);
+    // Tier-scoring matrix (date-versioned specs only)
     console.log(
-      `  ${COLORS.DIM}${lp('', lw + 2)} ${INFO_SPEC_VERSIONS.map((v) => rp(v, vw)).join(' ')}${COLORS.RESET}`
+      `  ${COLORS.DIM}${lp('', lw + 2)} ${TIER_SPEC_VERSIONS.map((v) => rp(v, vw)).join(' ')}  ${rp('All*', tw)}${COLORS.RESET}`
     );
-    for (const [label, row, , bold] of rows) {
-      const hasData = INFO_SPEC_VERSIONS.some((v) => {
-        const cell = row.cells.get(v);
-        return cell && cell.total > 0;
-      });
-      if (!hasData) continue;
+
+    const rows: [string, MatrixRow, CheckStatus | null, boolean][] = [
+      ['Server', matrix.server, c.conformance.status, true],
+      ['Client: Core', matrix.clientCore, null, false],
+      ['Client: Auth', matrix.clientAuth, null, false]
+    ];
+
+    for (const [label, row, status, bold] of rows) {
+      const icon = status ? statusIcon(status) + ' ' : '  ';
       const b = bold ? COLORS.BOLD : '';
       const r = bold ? COLORS.RESET : '';
       console.log(
-        `    ${b}${lp(label, lw)}${r} ${INFO_SPEC_VERSIONS.map((v) => rp(formatCell(row.cells.get(v)), vw)).join(' ')}`
+        `  ${icon}${b}${lp(label, lw)}${r} ${TIER_SPEC_VERSIONS.map((v) => rp(formatCell(row.cells.get(v)), vw)).join(' ')}  ${b}${rp(formatRate(row.tierUnique), tw)}${r}`
       );
+    }
+
+    // Client total line (tier-scoring only)
+    const clientTierTotal: Cell = {
+      passed:
+        matrix.clientCore.tierUnique.passed +
+        matrix.clientAuth.tierUnique.passed,
+      total:
+        matrix.clientCore.tierUnique.total + matrix.clientAuth.tierUnique.total
+    };
+    console.log(
+      `  ${statusIcon(c.client_conformance.status)} ${COLORS.BOLD}${lp('Client Total', lw)}${COLORS.RESET} ${' '.repeat(TIER_SPEC_VERSIONS.length * (vw + 1) - 1)}  ${COLORS.BOLD}${rp(formatRate(clientTierTotal), tw)}${COLORS.RESET}`
+    );
+    console.log(
+      `\n  ${COLORS.DIM}* unique scenarios — a scenario may apply to multiple spec versions${COLORS.RESET}`
+    );
+
+    // Informational matrix (draft/extension) — only if there are any
+    const hasInfo = rows.some(([, row]) =>
+      INFO_SPEC_VERSIONS.some((v) => {
+        const cell = row.cells.get(v);
+        return cell && cell.total > 0;
+      })
+    );
+    if (hasInfo) {
+      console.log(`\n  Informational (not scored for tier):\n`);
+      console.log(
+        `  ${COLORS.DIM}${lp('', lw + 2)} ${INFO_SPEC_VERSIONS.map((v) => rp(v, vw)).join(' ')}${COLORS.RESET}`
+      );
+      for (const [label, row, , bold] of rows) {
+        const hasData = INFO_SPEC_VERSIONS.some((v) => {
+          const cell = row.cells.get(v);
+          return cell && cell.total > 0;
+        });
+        if (!hasData) continue;
+        const b = bold ? COLORS.BOLD : '';
+        const r = bold ? COLORS.RESET : '';
+        console.log(
+          `    ${b}${lp(label, lw)}${r} ${INFO_SPEC_VERSIONS.map((v) => rp(formatCell(row.cells.get(v)), vw)).join(' ')}`
+        );
+      }
     }
   }
   console.log(`\n${COLORS.BOLD}Repository Health:${COLORS.RESET}\n`);

--- a/src/tier-check/types.ts
+++ b/src/tier-check/types.ts
@@ -12,12 +12,32 @@ export interface ConformanceResult extends CheckResult {
   passed: number;
   failed: number;
   total: number;
+  /**
+   * Scenarios run without being scored, kept out of passed/failed/total so those
+   * always agree with pass_rate.
+   */
+  not_scored?: { total: number; failed: number };
+  /**
+   * Set when the conformance run could not be performed at all, e.g. the child
+   * CLI rejected a requirement set naming a scenario this build lacks. Without
+   * this the empty result reconciles into "every scenario failed", which blames
+   * the implementation for a broken invocation.
+   */
+  error?: string;
   details: Array<{
     scenario: string;
     passed: boolean;
     checks_passed: number;
     checks_failed: number;
     specVersions?: ScenarioSpecTag[];
+    /**
+     * Why this scenario ran but did not count toward the pass rate. Set only
+     * under a requirement set, which decides scoring by name rather than by
+     * spec-version tag.
+     */
+    notScoredReason?: string;
+    /** Which revision's run produced this, when several were scored. */
+    revision?: string;
   }>;
 }
 
@@ -71,6 +91,14 @@ export interface TierScorecard {
   branch: string | null;
   timestamp: string;
   version: string | null;
+  /**
+   * Spec revisions whose frozen requirement sets were scored, if any were used.
+   * Every listed revision must pass for Tier 1: a scenario shared by two
+   * revisions must work on both wires, and one run does not cover the other.
+   * When set, the pass rates count exactly the scenarios that revision
+   * required when it shipped, rather than everything the suite carries today.
+   */
+  requirements_revisions: string[] | null;
   checks: {
     conformance: ConformanceResult;
     client_conformance: ConformanceResult;


### PR DESCRIPTION
Adds `requirements/<revision>.yaml`, a frozen list of the scenarios a spec revision
requires, and runs each revision **at that revision's wire version** with the server
invocation the SDK's own config declares for that revision. Ships two sets,
`2025-11-25` and `2026-07-28`; `tier-check` runs both and Tier 1 means every listed
revision passes.

Fixes #446.

## Motivation and Context

Two problems, one mechanism.

**The suite accumulates scenarios continuously**, so "which scenarios must my SDK
pass to conform to the spec released on 2026-07-28" has no answer today, and an SDK
can drop below 100% while standing still. `json-schema-2020-12-preservation` merged
three days after the 2026-07-28 spec shipped and four days after `0.2.0-alpha.10`
was published; measured against `main`, typescript-sdk fails it on a commit that
passes 100% against the release it pins. SEP-1730 relegates Tier 1 on any
continuously failing test, so post-release additions start demotion clocks against
SDKs that changed nothing. `--spec-version` cannot express this: it filters by which
revision a scenario *targets*, not when it became a requirement.

**A revision is also a wire.** The dated revisions through `2025-11-25` use the
stateful initialize handshake; `2026-07-28` is stateless with per-request `_meta`,
and scenarios emit different checks under each. A scenario claimed by both revisions
must therefore run once per revision, on that revision's wire — and the server an
SDK needs may differ per revision. go-sdk only speaks `>= 2026-07-28` when its
transport is constructed stateless (its CI starts the server twice); csharp-sdk
serves the stateless lifecycle at `/stateless`. A single `--conformance-server-url`
cannot describe either, which is why tier-check builds on `src/sdk-runner`'s
existing per-revision `specOverrides` instead of inventing a parallel mechanism.

## What this adds

```bash
# assess a known SDK against everything it claims — clone, build, per-revision
# server, both legs, one verdict
npx @modelcontextprotocol/conformance tier-check --sdk go-sdk

# what does conforming to 2026-07-28 require?
npx @modelcontextprotocol/conformance list --requirements 2026-07-28

# run one revision's set by hand
npx @modelcontextprotocol/conformance server --url http://localhost:3000/mcp --requirements 2026-07-28
```

- `requirements/<revision>.yaml` — the frozen contract, covering the two roles the
  spec defines (MCP server as OAuth resource server, MCP client as OAuth client).
  `not_scored` entries run and are reported but never counted, each with a reason:
  `extension` (optional per SEP-1730), `added-after-release` (no implementation
  could have been passing it), or `pending` (the suite's own reference fixture
  cannot pass it yet — the implementation under test may, so it runs for
  visibility; typescript-sdk main already passes all three dated pending
  scenarios). Every scenario in the suite lands somewhere except the two
  2025-03-26-only legacy backcompat tests, which SEP-1730 excludes unless legacy
  support is claimed. An `authorization` section is rejected: the spec puts
  authorization-server implementation beyond its own scope.
- `--requirements <revision>` on `client`, `server` and `list`; the revision pins
  the wire version and replaces `--suite`/`--spec-version`/`--scenario` (conflicts
  are errors, not precedence). `sdk` gains the same flag, resolved through
  `specOverrides`.
- `tier-check --sdk <name[@ref]>` / `--sdk-path <dir>`: for each claimed revision,
  resolve that revision's build/server/client from `known-sdks.ts`, manage the
  server, run both legs with cwd = the SDK checkout (so CI-style relative client
  commands work), and merge. `--repo`/`--branch` derive from the config.
  `--requirements` defaults to every shipped revision. The single-URL mode remains
  for SDKs not in the config, with its constraint documented.
- Exit code: nonzero when any scored conformance scenario fails or a leg could not
  be measured; governance findings never affect it. A child run that cannot happen
  (stale set naming a renamed scenario, unreachable server) is reported as
  `not measured`, never as 0% against the SDK.
- `--expected-failures` under `--requirements` judges scored scenarios only, so a
  not-scored failure cannot flag as an unexpected regression.
- Reports label every entry with its revision (`tools-list [2026-07-28]`); terminal,
  markdown and JSON agree on counts. JSON `passed/failed/total` describe the scored
  set and always agree with `pass_rate`; unscored runs are under `not_scored`.
- `2026-07-28` is a faithful snapshot (anchored to `0.2.0-alpha.10`, published the
  day before the revision shipped). `2025-11-25` is a reconstruction from the same
  anchor and its header says so: the release current at its ship date predates
  spec-version awareness entirely.
- Fixes exposed by driving every tier-1 SDK through the new path:
  - csharp's server launches from its build-output directory: ASP.NET reads
    `appsettings.json` from the content root, and `AllowedHosts` — which
    dns-rebinding-protection tests — silently never loaded from the repo root.
  - rust's `STATELESS=1` override is removed: its CI runs one default server for
    both revisions, and the forced mode failed its SEP-2575 scenarios.
  - `withManagedServer` waits for the child to actually exit before returning, so
    consecutive runs on one port cannot race a dying predecessor.
  - The tier-check legs spawn their child asynchronously. The previous
    synchronous exec blocked the event loop for a whole leg, so the parent
    stopped draining the managed server's log pipes; a chatty server (rust's
    per-request tracing) filled the 64KB pipe, its writes blocked, and the
    frozen server was scored as 26 conformance failures. The child's stdout is
    dropped entirely (results come from `-o`), removing the maxBuffer kill for
    verbose SDKs along the way.

## How Has This Been Tested?

Driven end to end against local main checkouts of all five tier-1 SDKs:

| SDK | Mode | Server | Client |
| --- | --- | --- | --- |
| typescript-sdk | URL | 67/67 | 50/50 |
| python-sdk | URL and `--sdk-path` | 67/67 | 50/50 |
| go-sdk | `--sdk-path` | 67/67 | 50/50 |
| csharp-sdk | `--sdk-path` | 67/67 | 50/50 |
| rust-sdk | `--sdk-path` | 67/67 | 50/50 |

Each `--sdk` run demonstrably switches wire per revision (go: stateful then
stateless server process; csharp: `/` then `/stateless`). A follow-up adversarial
review (six fresh lenses, refute-by-default verification) drove out and fixed:
skipped legs merging as failures (and the inverse silently passing an unmeasured
revision), the legacy exit-code regression, requirement-file validation (unknown
keys, duplicates, scored∩not_scored), branch attribution in `--sdk` mode, baseline
auto-attachment under `--requirements` on the `sdk` command, duplicate-revision
double counting, and `list --requirements` omitting `pending` entries. Negative controls: a
deliberately broken server scores 1/37 with `server_conformance` blocking and exit
1; a set naming a scenario the build lacks reports `not measured` naming the
scenario; `--requirements` with `--suite`, `--scenario`, `--spec-version`, unknown
revisions, comma lists on single-revision commands, and empty values each exit 1
with a message naming the problem. Unit tests pin both requirement sets against the
build (a rename cannot silently shrink a frozen set) and validate the not_scored
taxonomy.

## Breaking Changes

None to scenario execution; all flags are opt-in, and `tier-check` without
`--requirements` keeps its report-only exit 0. Under `--requirements` the exit code
gates on scored conformance failures (or an unmeasured leg), which is the CI
contract the frozen sets make meaningful.

Two behaviour changes to disclose for existing consumers:

- `tier-check`'s JSON now reports `passed`/`failed`/`total` over the scored set (so
  they always agree with `pass_rate`; previously they counted every scenario and
  the object was self-contradictory), and `details[].scenario` carries canonical
  scenario names rather than timestamped result-directory names.
- Three `KNOWN_SDKS` entries changed, so `conformance sdk` results are not
  comparable across this PR for them: rust-sdk's `STATELESS=1` override for
  2026-07-28 is removed (its own CI runs one default server for both revisions,
  and the forced mode fails its SEP-2575 scenarios), csharp-sdk's server launches
  from its build-output directory (ASP.NET loads `appsettings.json` from the
  content root; from the repo root the `AllowedHosts` filter that
  dns-rebinding-protection tests silently never loaded), and python-sdk's build
  mirrors its CI's two targeted syncs (`--all-packages` is unbuildable on main).

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

Deliberately out of scope: a CI freeze check pinning shipped requirement files
(currently a header rule plus review), and promoting `2026-07-28` out of
`DRAFT_PROTOCOL_VERSION` (shifts every SDK's `active` suite; separate decision). A
requirement set is this repo's contract — the opposite of an SDK's own
expected-failures baseline, which lives in the SDK repo and records what it knows it
fails; a baselined failure is still a failure against a requirement set, so the two
compose rather than substitute.
