### PR TITLE
chore: bump version to 0.2.0-alpha.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@modelcontextprotocol/conformance",
-  "version": "0.2.0-alpha.10",
+  "version": "0.2.0-alpha.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@modelcontextprotocol/conformance",
-      "version": "0.2.0-alpha.10",
+      "version": "0.2.0-alpha.11",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@modelcontextprotocol/conformance",
-  "version": "0.2.0-alpha.10",
+  "version": "0.2.0-alpha.11",
   "type": "module",
   "license": "MIT",
   "author": "Anthropic, PBC (https://anthropic.com)",


### PR DESCRIPTION
First release carrying the frozen requirement sets and `tier-check --sdk` mode from #447 — and the first whose tarball ships `requirements/`, which `--requirements` needs at runtime. Publish via the CI workflow's `publish_alpha` dispatch once merged.