### PR TITLE
fix(lifecycle): bound the session-id probe and release its response body

### DIFF
--- a/src/scenarios/server/lifecycle.test.ts
+++ b/src/scenarios/server/lifecycle.test.ts
@@ -140,4 +140,48 @@ describe('ServerInitializeScenario', () => {
     );
     expect(deleteCalls).toHaveLength(0);
   });
+
+  it('bounds the session-id probe so a server that never answers cannot hang it', async () => {
+    fetchMock.mockResolvedValue(new Response(null));
+
+    await new ServerInitializeScenario().run(testContext(serverUrl));
+
+    const probe = fetchMock.mock.calls.find(
+      ([, init]) => (init as RequestInit | undefined)?.method === 'POST'
+    );
+    expect(probe?.[1]?.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('cancels the probe response body so an SSE answer does not leak the connection', async () => {
+    // `Accept` on the probe includes `text/event-stream`, so a server is free
+    // to answer with a stream that stays open. Only the header is read, so the
+    // body has to be released explicitly.
+    const cancel = vi.fn().mockResolvedValue(undefined);
+    const body = new ReadableStream({
+      start() {
+        // Never enqueue, never close: an SSE stream awaiting its first event.
+      },
+      cancel
+    });
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(body, {
+        headers: {
+          'content-type': 'text/event-stream',
+          'mcp-session-id': 'session-123_ABC'
+        }
+      })
+    );
+    fetchMock.mockResolvedValue(new Response(null));
+
+    const checks = await new ServerInitializeScenario().run(
+      testContext(serverUrl)
+    );
+
+    expect(cancel).toHaveBeenCalled();
+    expect(checks[1]).toMatchObject({
+      id: 'server-session-id-visible-ascii',
+      status: 'SUCCESS'
+    });
+  });
 });

--- a/src/scenarios/server/lifecycle.ts
+++ b/src/scenarios/server/lifecycle.ts
@@ -15,6 +15,11 @@ import {
 
 const VISIBLE_ASCII_REGEX = /^[\x21-\x7E]+$/;
 
+// The session-id probe only needs the response header. Bound the request so a
+// server that accepts the connection and never answers fails this check
+// instead of hanging the scenario before teardown ever runs.
+const SESSION_ID_PROBE_TIMEOUT_MS = 5000;
+
 const SESSION_SPEC_REFERENCES = [
   {
     id: 'MCP-Session-Management',
@@ -115,11 +120,17 @@ and validates session ID format if one is assigned.`;
               version: '1.0.0'
             }
           }
-        })
+        }),
+        signal: AbortSignal.timeout(SESSION_ID_PROBE_TIMEOUT_MS)
       });
 
       const sessionId = response.headers.get('mcp-session-id');
       rawSessionId = sessionId;
+
+      // Only the header is needed. `Accept` includes `text/event-stream`, so a
+      // server answering with an open SSE stream would otherwise leave this
+      // body unconsumed and leak the connection for the rest of the run.
+      await response.body?.cancel();
 
       if (!sessionId) {
         checks.push({


### PR DESCRIPTION
Closes #428.

The visible-ASCII session-id check sends its own initialize POST, outside the SDK transport, because the transport doesn't expose the `MCP-Session-Id` header. That fetch had no abort signal and nothing ever read or cancelled the body.

So a server that accepts and never answers hung the scenario before teardown, which meant the DELETE bound from #316 never got a chance to run. And since the probe sends `Accept: application/json, text/event-stream`, a server answering with an open stream left the body dangling for the rest of the run.

5s to match `SESSION_TERMINATE_TIMEOUT_MS`, plus `response.body?.cancel()` once the header has been read.

Branched off main rather than stacking on the #427 branch, since you noted this is worth having on its own even after the runner-level bound lands. Two tests, both fail against the unmodified probe. Full suite passes.
