### PR TITLE
fix(tier-check): count an SDK release in the 24h before a spec release as tracking it

### DIFF
--- a/src/tier-check/checks/spec-tracking.ts
+++ b/src/tier-check/checks/spec-tracking.ts
@@ -1,6 +1,10 @@
 import { Octokit } from '@octokit/rest';
 import { SpecTrackingResult } from '../types';
 
+// Lockstep SDKs publish in the hours before the spec release is tagged;
+// a release up to this long before it counts as the release for that spec.
+const LEAD_MS = 24 * 60 * 60 * 1000;
+
 export async function checkSpecTracking(
   octokit: Octokit,
   owner: string,
@@ -38,7 +42,7 @@ export async function checkSpecTracking(
     // Reverse so oldest-first, then find the FIRST SDK release after the spec
     const oldestFirst = [...nonDraftSdkReleases].reverse();
     const firstSdkAfterSpec = oldestFirst.find(
-      (r) => new Date(r.published_at!) >= specDate
+      (r) => new Date(r.published_at!).getTime() >= specDate.getTime() - LEAD_MS
     );
 
     if (!firstSdkAfterSpec) {


### PR DESCRIPTION
Fixes #459.

`tier-check`'s spec-tracking check looks for the first SDK release **at or after** the latest spec release. SDKs that ship in lockstep publish in the hours *before* the spec tag, so the check reads them as "no release for this spec yet" and flips to `fail` (a Tier 1 blocker) 30 days later unless they happen to release again. This allows a 24h lead.

For the 2026-07-28 spec (tagged 16:47Z): python-sdk v2.0.0 went out at 13:41Z, go-sdk v1.7.0 at 13:09Z, typescript-sdk's 2.0.0 packages the evening before — all three currently show `19d gap` and would turn `fail` on 2026-08-28; with this change they pass at 0d/−1d. csharp-sdk (21:27Z, after the tag) is unchanged, and java-sdk (nothing since June) still fails on day 31 as it should.

Replaying the rule over every stable spec release × ten SDKs (70 pairs): 56 identical, 14 change, none from pass to fail. The pattern predates this cycle — typescript-sdk 1.23.0 was published 3 minutes before the 2025-11-25 tag, and kotlin-sdk 0.4.0 shipped the morning of 2025-03-26 yet was scored as a 35-day fail against that spec.

Noticed but left alone (pre-existing, separate if wanted): SDK releases are read with `per_page: 50`, which typescript-sdk's per-package releases (159 so far) will eventually outrun; and pre-releases count as SDK releases.
