### PR TITLE
fix(everything-server): normalize streamed tool responses

### DIFF
--- a/examples/servers/typescript/everything-server.ts
+++ b/examples/servers/typescript/everything-server.ts
@@ -1246,14 +1246,13 @@ const STATELESS_CACHEABLE_METHODS: ReadonlySet<string> = new Set([
   'resources/read'
 ]);
 
-/** Send a stateless (draft) JSON-RPC response. Draft results MUST carry `resultType`
+/** Normalize a stateless (draft) JSON-RPC response. Draft results MUST carry `resultType`
  * and cacheable operations the SEP-2549 caching hints; stamp any the dispatch site did
  * not set so every stateless result is draft-schema-valid. Errors pass through untouched. */
-function sendStatelessJson(
-  res: import('express').Response,
+function normalizeStatelessResponse(
   method: string,
   payload: { result?: Record<string, unknown>; [key: string]: unknown }
-): import('express').Response {
+): { result?: Record<string, unknown>; [key: string]: unknown } {
   const result = payload.result;
   if (result && typeof result === 'object' && !Array.isArray(result)) {
     result.resultType ??= 'complete';
@@ -1262,7 +1261,16 @@ function sendStatelessJson(
       result.cacheScope ??= 'private';
     }
   }
-  return res.json(payload);
+  return payload;
+}
+
+/** Send a normalized stateless response as JSON. */
+function sendStatelessJson(
+  res: import('express').Response,
+  method: string,
+  payload: { result?: Record<string, unknown>; [key: string]: unknown }
+): import('express').Response {
+  return res.json(normalizeStatelessResponse(method, payload));
 }
 
 // Handle POST requests - stateful mode
@@ -2257,7 +2265,9 @@ app.post('/mcp', async (req, res) => {
           ResultSchema as any
         );
         for (const n of dispatch.drainNotifications()) write(n);
-        write({ jsonrpc: '2.0', id, result });
+        write(
+          normalizeStatelessResponse(method, { jsonrpc: '2.0', id, result })
+        );
       } catch (e: any) {
         for (const n of dispatch.drainNotifications()) write(n);
         write({

--- a/src/scenarios/server/all-scenarios.test.ts
+++ b/src/scenarios/server/all-scenarios.test.ts
@@ -7,7 +7,11 @@ import {
   listDraftClientScenarios,
   listPendingClientScenarios
 } from '../index';
-import { DRAFT_PROTOCOL_VERSION, LATEST_SPEC_VERSION } from '../../types';
+import {
+  DRAFT_PROTOCOL_VERSION,
+  LATEST_SPEC_VERSION,
+  type SpecVersion
+} from '../../types';
 import path from 'path';
 
 function getFreePort(): Promise<number> {
@@ -132,40 +136,67 @@ describe('Server Scenarios', () => {
     ...listDraftClientScenarios().filter((name) => !pendingScenarios.has(name))
   ];
 
+  async function expectScenarioToPass(
+    scenarioName: string,
+    specVersion?: SpecVersion
+  ): Promise<void> {
+    const scenario = getClientScenario(scenarioName);
+    expect(scenario).toBeDefined();
+
+    if (!scenario) {
+      throw new Error(`Scenario ${scenarioName} not found`);
+    }
+
+    // Draft-only scenarios expect the draft (stateless) connection. Other
+    // scenarios normally use the latest stateful wire unless a test overrides it.
+    const targetSpecVersion =
+      specVersion ??
+      ('introducedIn' in scenario.source &&
+      scenario.source.introducedIn === DRAFT_PROTOCOL_VERSION
+        ? DRAFT_PROTOCOL_VERSION
+        : LATEST_SPEC_VERSION);
+
+    const checks = await scenario.run(
+      testContext(serverUrl, targetSpecVersion)
+    );
+
+    // Verify checks were returned
+    expect(checks.length).toBeGreaterThan(0);
+
+    // Verify all checks passed
+    const failures = checks.filter((c) => c.status === 'FAILURE');
+    if (failures.length > 0) {
+      const failureMessages = failures
+        .map((c) => `${c.name}: ${c.errorMessage || c.description}`)
+        .join('\n  ');
+      throw new Error(`Scenario failed with checks:\n  ${failureMessages}`);
+    }
+
+    // All checks should be non-FAILURE (SUCCESS, WARNING, or INFO are acceptable)
+    const nonFailures = checks.filter((c) => c.status !== 'FAILURE');
+    expect(nonFailures.length).toBe(checks.length);
+  }
+
   for (const scenarioName of scenarios) {
     it(`${scenarioName}`, async () => {
-      const scenario = getClientScenario(scenarioName);
-      expect(scenario).toBeDefined();
-
-      if (!scenario) {
-        throw new Error(`Scenario ${scenarioName} not found`);
-      }
-
-      // Draft-only scenarios expect the draft (stateless) connection, so
-      // derive the spec version from the scenario's declared source.
-      const specVersion =
-        'introducedIn' in scenario.source &&
-        scenario.source.introducedIn === DRAFT_PROTOCOL_VERSION
-          ? DRAFT_PROTOCOL_VERSION
-          : LATEST_SPEC_VERSION;
-
-      const checks = await scenario.run(testContext(serverUrl, specVersion));
-
-      // Verify checks were returned
-      expect(checks.length).toBeGreaterThan(0);
-
-      // Verify all checks passed
-      const failures = checks.filter((c) => c.status === 'FAILURE');
-      if (failures.length > 0) {
-        const failureMessages = failures
-          .map((c) => `${c.name}: ${c.errorMessage || c.description}`)
-          .join('\n  ');
-        throw new Error(`Scenario failed with checks:\n  ${failureMessages}`);
-      }
-
-      // All checks should be non-FAILURE (SUCCESS, WARNING, or INFO are acceptable)
-      const nonFailures = checks.filter((c) => c.status !== 'FAILURE');
-      expect(nonFailures.length).toBe(checks.length);
+      await expectScenarioToPass(scenarioName);
     }, 10000); // 10 second timeout per scenario
+  }
+
+  // These scenarios are introduced before the stateless protocol, so the normal
+  // fixture matrix exercises them on the latest stateful wire. Run them again on
+  // the modern wire to cover the streamed response adapter used by tools/call.
+  for (const scenarioName of [
+    'tools-call-simple-text',
+    'tools-call-image',
+    'tools-call-audio',
+    'tools-call-embedded-resource',
+    'tools-call-mixed-content',
+    'tools-call-error',
+    'tools-call-with-progress'
+  ]) {
+    it(`${scenarioName} on ${DRAFT_PROTOCOL_VERSION}`, async () => {
+      await expectScenarioToPass(scenarioName, DRAFT_PROTOCOL_VERSION);
+    }, 10000);
   }
 });


### PR DESCRIPTION
Normalizes streamed `tools/call` results from the bundled TypeScript everything-server so modern `2026-07-28` responses include the required `resultType: "complete"` discriminator.

## Motivation and Context

The stateless JSON response helper adds the required discriminator, but the streamed `tools/call` branch wrote SSE frames directly and bypassed that normalization. The bundled reference fixture therefore produced schema-invalid modern-wire results for all seven streamed tool-call fixture scenarios.

This change centralizes stateless result normalization, applies it before both JSON and SSE output, and extends the existing fixture-to-fixture coverage to all seven streamed tool scenarios.

Fixes #461.

## How Has This Been Tested?

- `npm test -- src/scenarios/server/all-scenarios.test.ts` — 55/55 tests passed, including all seven streamed tool scenarios on the `2026-07-28` wire
- `npm test` — 44 test files, 531/531 tests passed
- `npm run check`
- `npm run build`
- `node dist/index.js server --url http://127.0.0.1:43117/mcp --spec-version 2026-07-28 --scenario tools-call-simple-text --verbose` — 2/2 checks passed

## Breaking Changes

None. This corrects the bundled reference fixture's output to match the `2026-07-28` wire schema. It does not change public CLI, configuration, scenario, or check-ID interfaces.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context

This is a focused reference-fixture correction and regression test. It does not add or change a conformance scenario, requirement, or check ID, so scenario registration, traceability updates, and external SDK validation are not applicable. No new error paths or documentation requirements are introduced.
