### PR TITLE
fix(tier-check): strip package-name prefixes from monorepo release tags

### DIFF
--- a/src/tier-check/checks/release.test.ts
+++ b/src/tier-check/checks/release.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { Octokit } from '@octokit/rest';
+import { checkStableRelease } from './release';
+
+type Release = {
+  tag_name: string;
+  draft?: boolean;
+  prerelease?: boolean;
+};
+
+/** An Octokit stub that returns a fixed release list. */
+function octokitWith(releases: Release[]): Octokit {
+  return {
+    repos: {
+      listReleases: async () => ({
+        data: releases.map((r) => ({
+          draft: false,
+          prerelease: false,
+          ...r
+        }))
+      })
+    }
+  } as unknown as Octokit;
+}
+
+async function check(releases: Release[]) {
+  return checkStableRelease(
+    octokitWith(releases),
+    'modelcontextprotocol',
+    'sdk'
+  );
+}
+
+describe('checkStableRelease', () => {
+  it('accepts a bare semver tag', async () => {
+    expect(await check([{ tag_name: '1.2.3' }])).toMatchObject({
+      status: 'pass',
+      version: '1.2.3',
+      is_stable: true
+    });
+  });
+
+  it('accepts a v-prefixed tag', async () => {
+    expect(await check([{ tag_name: 'v1.2.3' }])).toMatchObject({
+      status: 'pass',
+      version: '1.2.3',
+      is_stable: true
+    });
+  });
+
+  // https://github.com/modelcontextprotocol/conformance/issues/425
+  it('accepts a monorepo tag carrying a package-name prefix', async () => {
+    expect(await check([{ tag_name: 'rmcp-v3.0.1' }])).toMatchObject({
+      status: 'pass',
+      version: '3.0.1',
+      is_stable: true
+    });
+  });
+
+  it('accepts a monorepo tag whose package name contains a hyphen', async () => {
+    expect(await check([{ tag_name: 'rmcp-macros-v3.0.1' }])).toMatchObject({
+      status: 'pass',
+      version: '3.0.1',
+      is_stable: true
+    });
+  });
+
+  it('rejects a pre-1.0 release', async () => {
+    expect(await check([{ tag_name: 'rmcp-v0.9.0' }])).toMatchObject({
+      status: 'fail',
+      version: '0.9.0',
+      is_stable: false
+    });
+  });
+
+  it('rejects a prerelease named in the tag', async () => {
+    expect(await check([{ tag_name: 'rmcp-v3.0.1-alpha.1' }])).toMatchObject({
+      status: 'fail',
+      version: '3.0.1-alpha.1',
+      is_stable: false,
+      is_prerelease: true
+    });
+  });
+
+  it('rejects a release GitHub flags as a prerelease', async () => {
+    expect(
+      await check([{ tag_name: 'rmcp-v3.0.1', prerelease: true }])
+    ).toMatchObject({
+      status: 'fail',
+      is_stable: false,
+      is_prerelease: true
+    });
+  });
+
+  it('skips drafts and scores the first published release', async () => {
+    expect(
+      await check([
+        { tag_name: 'rmcp-v4.0.0', draft: true },
+        { tag_name: 'rmcp-v3.0.1' }
+      ])
+    ).toMatchObject({ status: 'pass', version: '3.0.1' });
+  });
+
+  it('reports an unparseable tag unchanged rather than dropping it', async () => {
+    expect(await check([{ tag_name: 'nightly' }])).toMatchObject({
+      status: 'fail',
+      version: 'nightly',
+      is_stable: false
+    });
+  });
+
+  it('fails when the repo has no releases', async () => {
+    expect(await check([])).toMatchObject({
+      status: 'fail',
+      version: null,
+      is_stable: false
+    });
+  });
+});

--- a/src/tier-check/checks/release.ts
+++ b/src/tier-check/checks/release.ts
@@ -33,7 +33,7 @@ export async function checkStableRelease(
       };
     }
 
-    const version = latest.tag_name.replace(/^v/, '');
+    const version = versionFromTag(latest.tag_name);
     const isPrerelease =
       latest.prerelease ||
       /-(alpha|beta|rc|dev|preview|snapshot)/i.test(version);
@@ -56,4 +56,17 @@ export async function checkStableRelease(
       is_prerelease: false
     };
   }
+}
+
+/**
+ * Extract the semantic version from a release tag.
+ *
+ * Handles bare tags (`1.2.3`), `v`-prefixed tags (`v1.2.3`), and the
+ * package-prefixed tags monorepos publish (`rmcp-v3.0.1`,
+ * `rmcp-macros-v3.0.1`). Tags that carry no recognizable version are
+ * returned unchanged so they still surface in the check output.
+ */
+function versionFromTag(tag: string): string {
+  const match = tag.match(/(?:^|-)v?(\d+(?:\.\d+)*(?:[-+].*)?)$/);
+  return match ? match[1] : tag;
 }


### PR DESCRIPTION
Fixes #425.

`checkStableRelease` stripped only a leading `v`, so per-package tags like `rmcp-v3.1.3` parsed to `NaN` and scored `stable_release: fail`. The version is now matched at the end of the tag, so any package-name prefix is ignored.

## Motivation and Context

`stable_release` feeds both the Tier 1 blocker list and the Tier 2 gate, so a monorepo SDK is scored below what its releases support. Running against rust-sdk with `--skip-conformance`, `main` reports `fail` with `version: "rmcp-v3.1.3"` and lists `stable_release` in `tier1_blockers`; since `tier2Met` also requires `is_stable`, the implied tier is 3. With this change the check reports `pass` with `version: "3.1.3"` and the implied tier is 2. Both runs skip conformance, so those legs block Tier 1 either way and `stable_release` is the only difference.

## How Has This Been Tested?

Ran the issue's repro against the live repo on both `main` and this branch:

```sh
node dist/index.js tier-check --repo modelcontextprotocol/rust-sdk --skip-conformance --output json
```

```jsonc
// main
"stable_release": { "status": "fail", "version": "rmcp-v3.1.3", "is_stable": false }
// this branch
"stable_release": { "status": "pass", "version": "3.1.3", "is_stable": true }
```

Since this is shared infrastructure, I ran the same comparison across all eight official SDKs. rust-sdk is the only row that changes:

```
                    main                          this branch
go-sdk          pass  1.7.0        tier 2     pass  1.7.0        tier 2
csharp-sdk      pass  2.2.0        tier 3     pass  2.2.0        tier 3
typescript-sdk  pass  1.30.0       tier 2     pass  1.30.0       tier 2
python-sdk      pass  2.0.0        tier 2     pass  2.0.0        tier 2
java-sdk        pass  2.0.0        tier 2     pass  2.0.0        tier 2
kotlin-sdk      fail  0.15.0       tier 3     fail  0.15.0       tier 3
ruby-sdk        pass  1.2.0        tier 2     pass  1.2.0        tier 2
rust-sdk        fail  rmcp-v3.1.3  tier 3     pass  3.1.3        tier 2
```

kotlin-sdk still failing at 0.15.0 is the useful half: the change ignores a package-name prefix without making the check permissive about pre-1.0 versions.

New `release.test.ts` adds 10 cases driving `checkStableRelease` through a stubbed Octokit. Five cover the monorepo tags and fail against `main`; the other five are regression guards (bare tags, `v` prefixes, the GitHub `prerelease` flag, unparseable tags, empty release list) and pass either way. Full suite green at 534 tests, with `typecheck` and `lint` clean.

## Breaking Changes

None. The `version` field now reports the parsed version rather than the raw tag, so a monorepo SDK surfaces `"3.1.3"` where it previously surfaced `"rmcp-v3.1.3"`. That matches what already happened for `v`-prefixed tags.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context

`releases.find((r) => !r.draft)` still takes the most recent published release regardless of which package it belongs to, so on a workspace the check can score whichever crate released last. The issue cites both `rmcp-v3.0.1` and `rmcp-macros-v3.0.1` as tags that should be recognized, so that behavior is left alone here. Happy to follow up if per-package selection is wanted.
