### PR TITLE
feat(server): add SEP-2350 scope challenge scenario

### DIFF
--- a/SDK_INTEGRATION.md
+++ b/SDK_INTEGRATION.md
@@ -199,6 +199,45 @@ if __name__ == "__main__":
 
 See [`src/conformance/everything-server.ts`](https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/conformance/everything-server.ts) in the TypeScript SDK for a reference implementation that handles all server scenarios.
 
+### SEP-2350 Request-Time Scope Challenge Fixture
+
+The draft server scenario `sep-2350-server-scope-challenge` tests request-time
+OAuth `insufficient_scope` behavior without prescribing a token format or
+requiring an authorization server. Conformance fixtures use two opaque tokens:
+
+- `mcp-conformance-scope-low` is valid and has only
+  `mcp:conformance:baseline`.
+- `mcp-conformance-scope-full` is valid and has every scope in the table below.
+
+Keep requests without these fixture tokens unchanged so the existing server
+scenarios continue to exercise unauthenticated fixtures.
+
+| Operation                 | Existing fixture           | Scopes required in one challenge                                         |
+| ------------------------- | -------------------------- | ------------------------------------------------------------------------ |
+| `tools/call`              | `test_simple_text`         | `mcp:conformance:tools:call mcp:conformance:tools:test_simple_text`      |
+| Static `resources/read`   | `test://static-text`       | `mcp:conformance:resources:read mcp:conformance:resources:static`        |
+| Template `resources/read` | `test://template/123/data` | `mcp:conformance:resources:read mcp:conformance:resources:template:123`  |
+| `prompts/get`             | `test_simple_prompt`       | `mcp:conformance:prompts:get mcp:conformance:prompts:test_simple_prompt` |
+
+For the low token, each operation returns HTTP 403 with a Bearer
+`WWW-Authenticate` challenge containing `error="insufficient_scope"`,
+`scope` containing both listed scopes, and `resource_metadata` equal to:
+
+```text
+{server origin}/.well-known/oauth-protected-resource{server path}
+```
+
+For example, a server URL of `http://localhost:3000/mcp` uses
+`http://localhost:3000/.well-known/oauth-protected-resource/mcp`. Parameter and
+scope ordering are not significant, and the server may include additional
+scopes. Retrying the same operation with the full token must return its normal
+successful MCP result.
+
+These static tokens are test inputs only. Production servers should use their
+normal access-token verification, and this fixture does not replace the
+separate conformance work for token validation or authorization-server
+integration.
+
 ---
 
 ## Additional Resources

--- a/SDK_INTEGRATION.md
+++ b/SDK_INTEGRATION.md
@@ -221,17 +221,23 @@ scenarios continue to exercise unauthenticated fixtures.
 
 For the low token, each operation returns HTTP 403 with a Bearer
 `WWW-Authenticate` challenge containing `error="insufficient_scope"`,
-`scope` containing both listed scopes, and `resource_metadata` equal to:
+`scope` containing both listed scopes, and a quoted, absolute
+`resource_metadata` URL. The URL may be an explicitly advertised metadata
+location, the root well-known location, or the RFC 9728 path-derived location:
 
 ```text
 {server origin}/.well-known/oauth-protected-resource{server path}
 ```
 
-For example, a server URL of `http://localhost:3000/mcp` uses
-`http://localhost:3000/.well-known/oauth-protected-resource/mcp`. Parameter and
-scope ordering are not significant, and the server may include additional
-scopes. Retrying the same operation with the full token must return its normal
-successful MCP result.
+For example, a server URL of `http://localhost:3000/mcp` may use
+`http://localhost:3000/.well-known/oauth-protected-resource/mcp` or
+`http://localhost:3000/.well-known/oauth-protected-resource`. Path-derived
+locations preserve a meaningful trailing path slash and query component.
+Parameter and scope ordering are not significant, and the server may include
+additional scopes. Retrying the same operation with the full token must return
+its normal successful MCP result. Protected-resource metadata discovery and
+document-content checks remain covered by the authorization discovery
+scenarios.
 
 These static tokens are test inputs only. Production servers should use their
 normal access-token verification, and this fixture does not replace the

--- a/examples/servers/typescript/sep-2350-no-scope-challenge.ts
+++ b/examples/servers/typescript/sep-2350-no-scope-challenge.ts
@@ -1,0 +1,128 @@
+/**
+ * Deliberately broken SEP-2350 fixture.
+ *
+ * It implements every primitive required by the scope-challenge scenario, but
+ * ignores the low-scope token and returns the normal result instead of HTTP 403.
+ */
+import { createServer } from 'node:http';
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id: string | number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+function resultFor(request: JsonRpcRequest): Record<string, unknown> {
+  if (
+    request.method === 'tools/call' &&
+    request.params?.name === 'test_simple_text'
+  ) {
+    return {
+      resultType: 'complete',
+      content: [
+        {
+          type: 'text',
+          text: 'This is a simple text response for testing.'
+        }
+      ]
+    };
+  }
+
+  if (request.method === 'resources/read') {
+    const uri = request.params?.uri;
+    if (uri === 'test://static-text') {
+      return {
+        resultType: 'complete',
+        ttlMs: 0,
+        cacheScope: 'private',
+        contents: [
+          {
+            uri,
+            mimeType: 'text/plain',
+            text: 'This is the content of the static text resource.'
+          }
+        ]
+      };
+    }
+    if (uri === 'test://template/123/data') {
+      return {
+        resultType: 'complete',
+        ttlMs: 0,
+        cacheScope: 'private',
+        contents: [
+          {
+            uri,
+            mimeType: 'application/json',
+            text: JSON.stringify({
+              id: '123',
+              templateTest: true,
+              data: 'Data for ID: 123'
+            })
+          }
+        ]
+      };
+    }
+  }
+
+  if (
+    request.method === 'prompts/get' &&
+    request.params?.name === 'test_simple_prompt'
+  ) {
+    return {
+      resultType: 'complete',
+      messages: [
+        {
+          role: 'user',
+          content: {
+            type: 'text',
+            text: 'This is a simple prompt for testing.'
+          }
+        }
+      ]
+    };
+  }
+
+  throw new Error(`Unsupported fixture request: ${request.method}`);
+}
+
+const server = createServer((req, res) => {
+  let rawBody = '';
+  req.setEncoding('utf8');
+  req.on('data', (chunk) => {
+    rawBody += chunk;
+  });
+  req.on('end', () => {
+    let response: Record<string, unknown>;
+    try {
+      const request = JSON.parse(rawBody) as JsonRpcRequest;
+      response = {
+        jsonrpc: '2.0',
+        id: request.id,
+        result: resultFor(request)
+      };
+    } catch (error) {
+      response = {
+        jsonrpc: '2.0',
+        id: null,
+        error: {
+          code: -32600,
+          message: error instanceof Error ? error.message : String(error)
+        }
+      };
+    }
+
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify(response));
+  });
+});
+
+const port = Number.parseInt(process.env.PORT ?? '3012', 10);
+server.listen(port, '127.0.0.1', () => {
+  console.log(
+    `Broken SEP-2350 fixture running on http://127.0.0.1:${port}/mcp`
+  );
+});
+
+process.on('SIGTERM', () => server.close());

--- a/requirements/2026-07-28.yaml
+++ b/requirements/2026-07-28.yaml
@@ -195,3 +195,8 @@ not_scored:
     reason: pending
     note: >-
       SEP-2243; pending against the reference fixture
+  - scenario: sep-2350-server-scope-challenge
+    leg: server
+    reason: added-after-release
+    note: >-
+      SEP-2350 server request-time scope challenges; targeted SDK runs exercise the portable fixture contract

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   runServerConformanceTest,
   printServerResults,
   printServerSummary,
+  serverExitCode,
   runInteractiveMode
 } from './runner';
 import {
@@ -580,7 +581,7 @@ program
           process.exit(baselineResult.exitCode);
         }
 
-        process.exit(failed > 0 || warnings > 0 ? 1 : 0);
+        process.exit(serverExitCode(failed, warnings));
       } else {
         // Run scenarios based on suite
         const suite = options.suite?.toLowerCase() || 'active';
@@ -687,9 +688,7 @@ program
         process.exit(
           requirements
             ? requirementsExitCode(requirements, 'server', allResults)
-            : totalFailed > 0 || totalWarnings > 0
-              ? 1
-              : 0
+            : serverExitCode(totalFailed, totalWarnings)
         );
       }
     } catch (error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,9 +49,9 @@ import {
   Leg,
   listRequirementRevisions,
   loadRequirements,
-  notScoredScenarios,
   REASONS,
   RequirementSet,
+  requirementsExitCode,
   scoredScenarios
 } from './requirements';
 import {
@@ -106,42 +106,6 @@ function resolveRequirements(
     console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);
   }
-}
-
-/**
- * Exit status under a requirement set. Scenarios the set runs without scoring
- * (extensions, post-release additions) are reported but must not fail the run:
- * otherwise the documented command red-flags an implementation that meets every
- * requirement the revision actually imposes.
- */
-function requirementsExitCode(
-  requirements: RequirementSet,
-  leg: Leg,
-  results: { scenario: string; checks: ConformanceCheck[] }[]
-): number {
-  const scored = new Set(scoredScenarios(requirements, leg));
-  const unscored = results.filter((r) => !scored.has(r.scenario));
-  if (unscored.length > 0) {
-    const failing = unscored.filter((r) =>
-      r.checks.some((c) => c.status === 'FAILURE')
-    );
-    console.log(
-      `\nNot scored for ${requirements.revision}: ${unscored.length} scenario(s) run, ${failing.length} failing. These do not affect conformance.`
-    );
-    for (const r of unscored) {
-      const why = notScoredScenarios(requirements, leg).find(
-        (e) => e.scenario === r.scenario
-      );
-      const failed = r.checks.some((c) => c.status === 'FAILURE');
-      console.log(
-        `  ${failed ? '\u2717' : '\u2713'} ${r.scenario} (${why?.reason ?? 'not scored'})`
-      );
-    }
-  }
-  const scoredFailed = results
-    .filter((r) => scored.has(r.scenario))
-    .some((r) => r.checks.some((c) => c.status === 'FAILURE'));
-  return scoredFailed ? 1 : 0;
 }
 
 /** Print one revision's requirement set. `list` is display-only, so it can show several. */
@@ -597,7 +561,7 @@ program
           process.exit(0);
         }
 
-        const { failed } = printServerResults(
+        const { failed, warnings } = printServerResults(
           result.checks,
           result.scenarioDescription,
           verbose
@@ -616,7 +580,7 @@ program
           process.exit(baselineResult.exitCode);
         }
 
-        process.exit(failed > 0 ? 1 : 0);
+        process.exit(failed > 0 || warnings > 0 ? 1 : 0);
       } else {
         // Run scenarios based on suite
         const suite = options.suite?.toLowerCase() || 'active';
@@ -698,7 +662,7 @@ program
           }
         }
 
-        const { totalFailed } = printServerSummary(allResults);
+        const { totalFailed, totalWarnings } = printServerSummary(allResults);
 
         if (options.expectedFailures) {
           const expectedFailuresConfig = await loadExpectedFailures(
@@ -723,7 +687,7 @@ program
         process.exit(
           requirements
             ? requirementsExitCode(requirements, 'server', allResults)
-            : totalFailed > 0
+            : totalFailed > 0 || totalWarnings > 0
               ? 1
               : 0
         );

--- a/src/requirements.test.ts
+++ b/src/requirements.test.ts
@@ -5,6 +5,7 @@ import {
   listRequirementRevisions,
   loadRequirements,
   notScoredScenarios,
+  requirementsExitCode,
   scenariosToRun,
   scoredScenarios
 } from './requirements';
@@ -131,6 +132,44 @@ describe('filterScenariosByRequirements', () => {
       'server'
     );
     expect(selected).toEqual(scenariosToRun(requirements, 'server'));
+  });
+
+  describe('requirementsExitCode', () => {
+    const requirements = {
+      revision: '2026-07-28',
+      server: ['scored-scenario'],
+      client: [],
+      notScored: [
+        {
+          scenario: 'post-release-scenario',
+          leg: 'server' as const,
+          reason: 'added-after-release' as const
+        }
+      ]
+    };
+    const warningCheck = {
+      id: 'should-check',
+      name: 'ShouldCheck',
+      description: 'A SHOULD-level check',
+      status: 'WARNING' as const,
+      timestamp: new Date().toISOString()
+    };
+
+    it('fails when a scored scenario emits a warning', () => {
+      expect(
+        requirementsExitCode(requirements, 'server', [
+          { scenario: 'scored-scenario', checks: [warningCheck] }
+        ])
+      ).toBe(1);
+    });
+
+    it('does not fail when only a not-scored scenario emits a warning', () => {
+      expect(
+        requirementsExitCode(requirements, 'server', [
+          { scenario: 'post-release-scenario', checks: [warningCheck] }
+        ])
+      ).toBe(0);
+    });
   });
 
   it('runs the not-scored entries but keeps them out of the scored set', () => {

--- a/src/requirements.test.ts
+++ b/src/requirements.test.ts
@@ -170,6 +170,17 @@ describe('filterScenariosByRequirements', () => {
         ])
       ).toBe(0);
     });
+
+    it('does not fail when a scored scenario emits diagnostic information', () => {
+      expect(
+        requirementsExitCode(requirements, 'server', [
+          {
+            scenario: 'scored-scenario',
+            checks: [{ ...warningCheck, status: 'INFO' }]
+          }
+        ])
+      ).toBe(0);
+    });
   });
 
   it('runs the not-scored entries but keeps them out of the scored set', () => {

--- a/src/requirements.ts
+++ b/src/requirements.ts
@@ -3,6 +3,7 @@ import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { parse as parseYaml } from 'yaml';
 import { ALL_SPEC_VERSIONS } from './scenarios';
+import type { ConformanceCheck } from './types';
 
 /**
  * A frozen requirement set for one specification revision: the scenarios an
@@ -249,4 +250,43 @@ export function filterScenariosByRequirements(
     );
   }
   return wanted.filter((name) => available.has(name));
+}
+
+function isBlockingCheck(check: ConformanceCheck): boolean {
+  return check.status === 'FAILURE' || check.status === 'WARNING';
+}
+
+/**
+ * Exit status under a frozen requirement set. Scored failures and warnings
+ * block conformance; not-scored scenarios are reported without changing it.
+ */
+export function requirementsExitCode(
+  requirements: RequirementSet,
+  leg: Leg,
+  results: { scenario: string; checks: ConformanceCheck[] }[]
+): number {
+  const scored = new Set(scoredScenarios(requirements, leg));
+  const unscored = results.filter((result) => !scored.has(result.scenario));
+  if (unscored.length > 0) {
+    const blocking = unscored.filter((result) =>
+      result.checks.some(isBlockingCheck)
+    );
+    console.log(
+      `\nNot scored for ${requirements.revision}: ${unscored.length} scenario(s) run, ${blocking.length} non-green. These do not affect conformance.`
+    );
+    for (const result of unscored) {
+      const why = notScoredScenarios(requirements, leg).find(
+        (entry) => entry.scenario === result.scenario
+      );
+      const isBlocking = result.checks.some(isBlockingCheck);
+      console.log(
+        `  ${isBlocking ? '\u2717' : '\u2713'} ${result.scenario} (${why?.reason ?? 'not scored'})`
+      );
+    }
+  }
+
+  const scoredBlocked = results
+    .filter((result) => scored.has(result.scenario))
+    .some((result) => result.checks.some(isBlockingCheck));
+  return scoredBlocked ? 1 : 0;
 }

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -10,7 +10,8 @@ export {
 export {
   runServerConformanceTest,
   printServerResults,
-  printServerSummary
+  printServerSummary,
+  serverExitCode
 } from './server';
 
 // Export utilities

--- a/src/runner/server.test.ts
+++ b/src/runner/server.test.ts
@@ -6,7 +6,7 @@
 import http from 'http';
 import type { AddressInfo } from 'net';
 import { afterEach, beforeEach, describe, test, expect } from 'vitest';
-import { runServerConformanceTest } from './server';
+import { printServerSummary, runServerConformanceTest } from './server';
 import { DRAFT_PROTOCOL_VERSION, LATEST_SPEC_VERSION } from '../types';
 
 // The skip decision happens before any network request, so an unreachable
@@ -77,6 +77,7 @@ describe('runServerConformanceTest wire selection for draft-only scenarios', () 
       req.on('data', (chunk) => {
         buf += chunk;
       });
+
       req.on('end', () => {
         let id: unknown = null;
         try {
@@ -140,4 +141,29 @@ describe('runServerConformanceTest wire selection for draft-only scenarios', () 
       'io.modelcontextprotocol/tasks': {}
     });
   }, 30000);
+});
+
+describe('server warning summaries', () => {
+  test('reports warnings as non-green scenario results', () => {
+    const summary = printServerSummary([
+      {
+        scenario: 'warning-scenario',
+        checks: [
+          {
+            id: 'should-check',
+            name: 'ShouldCheck',
+            description: 'A SHOULD-level check',
+            status: 'WARNING',
+            timestamp: new Date().toISOString()
+          }
+        ]
+      }
+    ]);
+
+    expect(summary).toEqual({
+      totalPassed: 0,
+      totalFailed: 0,
+      totalWarnings: 1
+    });
+  });
 });

--- a/src/runner/server.test.ts
+++ b/src/runner/server.test.ts
@@ -166,4 +166,27 @@ describe('server warning summaries', () => {
       totalWarnings: 1
     });
   });
+
+  test('keeps informational diagnostics green and out of warning totals', () => {
+    const summary = printServerSummary([
+      {
+        scenario: 'sessionless-scenario',
+        checks: [
+          {
+            id: 'optional-session',
+            name: 'OptionalSession',
+            description: 'The server did not opt into session management',
+            status: 'INFO',
+            timestamp: new Date().toISOString()
+          }
+        ]
+      }
+    ]);
+
+    expect(summary).toEqual({
+      totalPassed: 0,
+      totalFailed: 0,
+      totalWarnings: 0
+    });
+  });
 });

--- a/src/runner/server.test.ts
+++ b/src/runner/server.test.ts
@@ -6,7 +6,11 @@
 import http from 'http';
 import type { AddressInfo } from 'net';
 import { afterEach, beforeEach, describe, test, expect } from 'vitest';
-import { printServerSummary, runServerConformanceTest } from './server';
+import {
+  printServerSummary,
+  runServerConformanceTest,
+  serverExitCode
+} from './server';
 import { DRAFT_PROTOCOL_VERSION, LATEST_SPEC_VERSION } from '../types';
 
 // The skip decision happens before any network request, so an unreachable
@@ -165,6 +169,7 @@ describe('server warning summaries', () => {
       totalFailed: 0,
       totalWarnings: 1
     });
+    expect(serverExitCode(summary.totalFailed, summary.totalWarnings)).toBe(1);
   });
 
   test('keeps informational diagnostics green and out of warning totals', () => {
@@ -188,5 +193,6 @@ describe('server warning summaries', () => {
       totalFailed: 0,
       totalWarnings: 0
     });
+    expect(serverExitCode(summary.totalFailed, summary.totalWarnings)).toBe(0);
   });
 });

--- a/src/runner/server.ts
+++ b/src/runner/server.ts
@@ -163,24 +163,30 @@ export function printServerResults(
 
 export function printServerSummary(
   allResults: { scenario: string; checks: ConformanceCheck[] }[]
-): { totalPassed: number; totalFailed: number } {
+): { totalPassed: number; totalFailed: number; totalWarnings: number } {
   console.log('\n\n=== SUMMARY ===');
   let totalPassed = 0;
   let totalFailed = 0;
+  let totalWarnings = 0;
 
   for (const result of allResults) {
     const passed = result.checks.filter((c) => c.status === 'SUCCESS').length;
     const failed = result.checks.filter((c) => c.status === 'FAILURE').length;
+    const warnings = result.checks.filter((c) => c.status === 'WARNING').length;
     totalPassed += passed;
     totalFailed += failed;
+    totalWarnings += warnings;
 
-    const status = failed === 0 ? '✓' : '✗';
+    const status = failed === 0 && warnings === 0 ? '✓' : '✗';
+    const warningStr = warnings > 0 ? `, ${warnings} warnings` : '';
     console.log(
-      `${status} ${result.scenario}: ${passed} passed, ${failed} failed`
+      `${status} ${result.scenario}: ${passed} passed, ${failed} failed${warningStr}`
     );
   }
 
-  console.log(`\nTotal: ${totalPassed} passed, ${totalFailed} failed`);
+  console.log(
+    `\nTotal: ${totalPassed} passed, ${totalFailed} failed, ${totalWarnings} warnings`
+  );
 
-  return { totalPassed, totalFailed };
+  return { totalPassed, totalFailed, totalWarnings };
 }

--- a/src/runner/server.ts
+++ b/src/runner/server.ts
@@ -190,3 +190,7 @@ export function printServerSummary(
 
   return { totalPassed, totalFailed, totalWarnings };
 }
+
+export function serverExitCode(failed: number, warnings: number): number {
+  return failed > 0 || warnings > 0 ? 1 : 0;
+}

--- a/src/scenarios/client/sse-retry.test.ts
+++ b/src/scenarios/client/sse-retry.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'vitest';
+import { SSERetryScenario } from './sse-retry';
+
+describe('SSERetryScenario diagnostics', () => {
+  test('reports an acceptable late reconnect as INFO', () => {
+    const scenario = new SSERetryScenario();
+    Reflect.set(scenario, 'toolStreamCloseTime', 1_000);
+    Reflect.set(scenario, 'getReconnectionTime', 1_800);
+    Reflect.set(scenario, 'getConnectionCount', 1);
+    Reflect.set(scenario, 'lastEventIds', ['event-1']);
+
+    const timing = scenario
+      .getChecks()
+      .find((check) => check.id === 'client-sse-retry-timing');
+
+    expect(timing).toMatchObject({
+      status: 'INFO',
+      details: {
+        slightlyLate: true,
+        veryLate: false
+      }
+    });
+    expect(timing?.errorMessage).toBeUndefined();
+  });
+});

--- a/src/scenarios/client/sse-retry.ts
+++ b/src/scenarios/client/sse-retry.ts
@@ -467,8 +467,9 @@ export class SSERetryScenario implements Scenario {
         actualDelay > this.retryValue * this.VERY_LATE_MULTIPLIER;
       const withinTolerance = !tooEarly && !slightlyLate;
 
-      let status: 'SUCCESS' | 'FAILURE' | 'WARNING' = 'SUCCESS';
+      let status: ConformanceCheck['status'] = 'SUCCESS';
       let errorMessage: string | undefined;
+      let diagnosticMessage: string | undefined;
 
       if (tooEarly) {
         // Client reconnected too soon - MUST violation
@@ -480,8 +481,8 @@ export class SSERetryScenario implements Scenario {
         errorMessage = `Client reconnected very late (${actualDelay.toFixed(0)}ms instead of ${this.retryValue}ms). Client appears to be ignoring the retry field and using its own backoff strategy.`;
       } else if (slightlyLate) {
         // Client reconnected slightly late - not a spec violation but suspicious
-        status = 'WARNING';
-        errorMessage = `Client reconnected slightly late (${actualDelay.toFixed(0)}ms instead of ${this.retryValue}ms). This is acceptable but may indicate network delays.`;
+        status = 'INFO';
+        diagnosticMessage = `Client reconnected slightly late (${actualDelay.toFixed(0)}ms instead of ${this.retryValue}ms). This is acceptable and may reflect network delays.`;
       }
 
       this.checks.push({
@@ -510,7 +511,8 @@ export class SSERetryScenario implements Scenario {
           tooEarly,
           slightlyLate,
           veryLate,
-          getConnectionCount: this.getConnectionCount
+          getConnectionCount: this.getConnectionCount,
+          ...(diagnosticMessage ? { message: diagnosticMessage } : {})
         }
       });
     } else {

--- a/src/scenarios/index.ts
+++ b/src/scenarios/index.ts
@@ -68,6 +68,7 @@ import {
 
 import { DNSRebindingProtectionScenario } from './server/dns-rebinding';
 import { CachingScenario } from './server/caching';
+import { ServerScopeChallengeScenario } from './server/scope-challenge';
 
 // InputRequiredResult scenarios from (SEP-2322)
 import {
@@ -151,7 +152,11 @@ const pendingClientScenariosList: ClientScenario[] = [
   new TasksDispatchScenario(),
   new TasksStatusNotificationsScenario(),
   new TasksRequiredTaskErrorScenario(),
-  new TasksMrtrCompositionScenario()
+  new TasksMrtrCompositionScenario(),
+
+  // SEP-2350 server scope challenges. Pending until the bundled reference SDK
+  // exposes the request-time challenge seam; targeted SDK runs can exercise it.
+  new ServerScopeChallengeScenario()
 ];
 
 // All client scenarios
@@ -212,6 +217,7 @@ const allClientScenariosList: ClientScenario[] = [
 
   // Security scenarios
   new DNSRebindingProtectionScenario(),
+  new ServerScopeChallengeScenario(),
 
   // Caching scenarios (SEP-2549)
   new CachingScenario(),

--- a/src/scenarios/server/scope-challenge.test.ts
+++ b/src/scenarios/server/scope-challenge.test.ts
@@ -301,7 +301,73 @@ describe('ServerScopeChallengeScenario', () => {
     }
   );
 
-  it('emits pinned warnings against a server that does not challenge any primitive', async () => {
+  it.each([
+    ['missing', undefined],
+    ['malformed', 'Bearer/ error="insufficient_scope"']
+  ])(
+    'skips completeness when the WWW-Authenticate header is %s',
+    async (_case, wwwAuthenticate) => {
+      server = createServer((req, res) => {
+        let rawBody = '';
+        req.setEncoding('utf8');
+        req.on('data', (chunk) => {
+          rawBody += chunk;
+        });
+        req.on('end', () => {
+          const request = JSON.parse(rawBody) as JsonRpcRequest;
+          const fixture = findFixture(request);
+          if (!fixture) {
+            res.statusCode = 404;
+            res.end();
+            return;
+          }
+
+          if (
+            req.headers.authorization === `Bearer ${SCOPE_CHALLENGE_LOW_TOKEN}`
+          ) {
+            res.statusCode = 403;
+            if (wwwAuthenticate) {
+              res.setHeader('WWW-Authenticate', wwwAuthenticate);
+            }
+            res.end();
+            return;
+          }
+
+          res.statusCode = 200;
+          res.setHeader('Content-Type', 'application/json');
+          res.end(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              id: request.id,
+              result: fixtureResult(request)
+            })
+          );
+        });
+      });
+
+      const checks = await new ServerScopeChallengeScenario().run(
+        testContext(await listen(server), DRAFT_PROTOCOL_VERSION)
+      );
+
+      const challengeChecks = checks.filter(
+        (check) => check.id === 'server-scope-challenge-www-authenticate'
+      );
+      expect(challengeChecks).toHaveLength(4);
+      expect(challengeChecks.every((check) => check.status === 'WARNING')).toBe(
+        true
+      );
+
+      const completenessChecks = checks.filter(
+        (check) => check.id === 'sep-2350-server-single-challenge'
+      );
+      expect(completenessChecks).toHaveLength(4);
+      expect(
+        completenessChecks.every((check) => check.status === 'SKIPPED')
+      ).toBe(true);
+    }
+  );
+
+  it('emits prerequisite warnings and skips completeness against a server that does not challenge', async () => {
     const port = await getFreePort();
     process = await startBrokenFixture(port);
 
@@ -311,13 +377,20 @@ describe('ServerScopeChallengeScenario', () => {
 
     for (const id of [
       'server-scope-challenge-http-403',
-      'server-scope-challenge-www-authenticate',
-      'sep-2350-server-single-challenge'
+      'server-scope-challenge-www-authenticate'
     ]) {
       const matching = checks.filter((check) => check.id === id);
       expect(matching).toHaveLength(4);
       expect(matching.every((check) => check.status === 'WARNING')).toBe(true);
     }
+
+    const completeness = checks.filter(
+      (check) => check.id === 'sep-2350-server-single-challenge'
+    );
+    expect(completeness).toHaveLength(4);
+    expect(completeness.every((check) => check.status === 'SKIPPED')).toBe(
+      true
+    );
 
     const retries = checks.filter(
       (check) => check.id === 'server-scope-challenge-upgraded-retry'

--- a/src/scenarios/server/scope-challenge.test.ts
+++ b/src/scenarios/server/scope-challenge.test.ts
@@ -1,0 +1,253 @@
+import { spawn, type ChildProcess } from 'child_process';
+import { createServer, type Server } from 'http';
+import type { AddressInfo } from 'net';
+import path from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { testContext } from '../../connection/testing';
+import { DRAFT_PROTOCOL_VERSION } from '../../types';
+import {
+  SCOPE_CHALLENGE_FIXTURES,
+  SCOPE_CHALLENGE_FULL_TOKEN,
+  SCOPE_CHALLENGE_LOW_TOKEN,
+  ServerScopeChallengeScenario,
+  scopeChallengeResourceMetadataUrl
+} from './scope-challenge';
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id: string | number;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+function fixtureResult(request: JsonRpcRequest): Record<string, unknown> {
+  if (request.method === 'tools/call') {
+    return {
+      resultType: 'complete',
+      content: [
+        {
+          type: 'text',
+          text: 'This is a simple text response for testing.'
+        }
+      ]
+    };
+  }
+  if (request.method === 'resources/read') {
+    const uri = request.params?.uri;
+    return {
+      resultType: 'complete',
+      ttlMs: 0,
+      cacheScope: 'private',
+      contents: [
+        {
+          uri,
+          mimeType:
+            uri === 'test://static-text' ? 'text/plain' : 'application/json',
+          text:
+            uri === 'test://static-text'
+              ? 'This is the content of the static text resource.'
+              : '{"id":"123","templateTest":true,"data":"Data for ID: 123"}'
+        }
+      ]
+    };
+  }
+  return {
+    resultType: 'complete',
+    messages: [
+      {
+        role: 'user',
+        content: {
+          type: 'text',
+          text: 'This is a simple prompt for testing.'
+        }
+      }
+    ]
+  };
+}
+
+function findFixture(request: JsonRpcRequest) {
+  return SCOPE_CHALLENGE_FIXTURES.find((fixture) => {
+    if (fixture.method !== request.method) return false;
+    if (request.method === 'resources/read') {
+      return fixture.params.uri === request.params?.uri;
+    }
+    return fixture.params.name === request.params?.name;
+  });
+}
+
+async function listen(server: Server): Promise<string> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as AddressInfo).port;
+  return `http://127.0.0.1:${port}/mcp`;
+}
+
+async function close(server: Server | undefined): Promise<void> {
+  if (!server) return;
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const port = (server.address() as AddressInfo).port;
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+function startBrokenFixture(port: number): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(
+      'npx',
+      [
+        'tsx',
+        path.join(
+          process.cwd(),
+          'examples/servers/typescript/sep-2350-no-scope-challenge.ts'
+        )
+      ],
+      {
+        env: { ...process.env, PORT: String(port) },
+        stdio: ['ignore', 'pipe', 'pipe'],
+        shell: process.platform === 'win32'
+      }
+    );
+    let stderr = '';
+    const timeout = setTimeout(() => {
+      proc.kill('SIGKILL');
+      reject(new Error(`Broken fixture did not start: ${stderr}`));
+    }, 30000);
+    proc.stderr?.on('data', (data) => {
+      stderr += data.toString();
+    });
+    proc.stdout?.on('data', (data) => {
+      if (data.toString().includes('running on')) {
+        clearTimeout(timeout);
+        resolve(proc);
+      }
+    });
+    proc.on('error', (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+  });
+}
+
+function stopProcess(proc: ChildProcess | undefined): Promise<void> {
+  return new Promise((resolve) => {
+    if (!proc || proc.killed) return resolve();
+    const timeout = setTimeout(() => {
+      proc.kill('SIGKILL');
+      resolve();
+    }, 5000);
+    proc.once('exit', () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+    proc.kill('SIGTERM');
+  });
+}
+
+describe('ServerScopeChallengeScenario', () => {
+  let server: Server | undefined;
+  let process: ChildProcess | undefined;
+
+  afterEach(async () => {
+    await Promise.all([close(server), stopProcess(process)]);
+    server = undefined;
+    process = undefined;
+  });
+
+  it('passes every primitive with a complete, parseable challenge and upgraded retry', async () => {
+    let serverUrl = '';
+    server = createServer((req, res) => {
+      let rawBody = '';
+      req.setEncoding('utf8');
+      req.on('data', (chunk) => {
+        rawBody += chunk;
+      });
+      req.on('end', () => {
+        const request = JSON.parse(rawBody) as JsonRpcRequest;
+        const fixture = findFixture(request);
+        if (!fixture) {
+          res.statusCode = 404;
+          res.end();
+          return;
+        }
+
+        const authorization = req.headers.authorization;
+        if (authorization === `Bearer ${SCOPE_CHALLENGE_LOW_TOKEN}`) {
+          const metadata = scopeChallengeResourceMetadataUrl(serverUrl);
+          res.statusCode = 403;
+          res.setHeader('Content-Type', 'application/json');
+          res.setHeader(
+            'WWW-Authenticate',
+            `Bearer resource_metadata="${metadata}", error_description="Needs \\"both\\", scopes", scope="${fixture.requiredScopes.join(' ')} mcp:conformance:extra", error="insufficient_scope"`
+          );
+          res.end(
+            JSON.stringify({
+              jsonrpc: '2.0',
+              id: request.id,
+              error: { code: -32600, message: 'Insufficient scope' }
+            })
+          );
+          return;
+        }
+
+        if (authorization !== `Bearer ${SCOPE_CHALLENGE_FULL_TOKEN}`) {
+          res.statusCode = 401;
+          res.end();
+          return;
+        }
+
+        res.statusCode = 200;
+        res.setHeader('Content-Type', 'application/json');
+        res.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: request.id,
+            result: fixtureResult(request)
+          })
+        );
+      });
+    });
+    serverUrl = await listen(server);
+
+    const checks = await new ServerScopeChallengeScenario().run(
+      testContext(serverUrl, DRAFT_PROTOCOL_VERSION)
+    );
+
+    expect(checks).toHaveLength(16);
+    expect(checks.every((check) => check.status === 'SUCCESS')).toBe(true);
+    expect(
+      checks.filter((check) => check.id === 'sep-2350-server-single-challenge')
+    ).toHaveLength(4);
+  });
+
+  it('emits pinned warnings against a server that does not challenge any primitive', async () => {
+    const port = await getFreePort();
+    process = await startBrokenFixture(port);
+
+    const checks = await new ServerScopeChallengeScenario().run(
+      testContext(`http://127.0.0.1:${port}/mcp`, DRAFT_PROTOCOL_VERSION)
+    );
+
+    for (const id of [
+      'server-scope-challenge-http-403',
+      'server-scope-challenge-www-authenticate',
+      'sep-2350-server-single-challenge'
+    ]) {
+      const matching = checks.filter((check) => check.id === id);
+      expect(matching).toHaveLength(4);
+      expect(matching.every((check) => check.status === 'WARNING')).toBe(true);
+    }
+
+    const retries = checks.filter(
+      (check) => check.id === 'server-scope-challenge-upgraded-retry'
+    );
+    expect(retries).toHaveLength(4);
+    expect(retries.every((check) => check.status === 'SUCCESS')).toBe(true);
+  }, 40000);
+});

--- a/src/scenarios/server/scope-challenge.test.ts
+++ b/src/scenarios/server/scope-challenge.test.ts
@@ -10,6 +10,7 @@ import {
   SCOPE_CHALLENGE_FULL_TOKEN,
   SCOPE_CHALLENGE_LOW_TOKEN,
   ServerScopeChallengeScenario,
+  parseBearerChallenge,
   scopeChallengeResourceMetadataUrl
 } from './scope-challenge';
 
@@ -75,10 +76,10 @@ function findFixture(request: JsonRpcRequest) {
   });
 }
 
-async function listen(server: Server): Promise<string> {
+async function listen(server: Server, endpoint = '/mcp'): Promise<string> {
   await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
   const port = (server.address() as AddressInfo).port;
-  return `http://127.0.0.1:${port}/mcp`;
+  return `http://127.0.0.1:${port}${endpoint}`;
 }
 
 async function close(server: Server | undefined): Promise<void> {
@@ -150,6 +151,58 @@ function stopProcess(proc: ChildProcess | undefined): Promise<void> {
   });
 }
 
+describe('scope challenge header parsing', () => {
+  it('parses quoted URLs and bare token values', () => {
+    const parsed = parseBearerChallenge(
+      'Bearer error=insufficient_scope, mode=token-._~+, resource_metadata="https://example.com/.well-known/oauth-protected-resource/mcp?tenant=a,b"'
+    );
+
+    expect(parsed?.params).toMatchObject({
+      error: 'insufficient_scope',
+      mode: 'token-._~+',
+      resource_metadata:
+        'https://example.com/.well-known/oauth-protected-resource/mcp?tenant=a,b'
+    });
+  });
+
+  it('rejects URL separators in unquoted auth-param values', () => {
+    const parsed = parseBearerChallenge(
+      'Bearer error=insufficient_scope, scope=files:read, resource_metadata=https://example.com/.well-known/oauth-protected-resource'
+    );
+
+    expect(parsed?.params.error).toBe('insufficient_scope');
+    expect(parsed?.params.scope).toBeUndefined();
+    expect(parsed?.params.resource_metadata).toBeUndefined();
+  });
+});
+
+describe('scope challenge metadata URL derivation', () => {
+  it.each([
+    [
+      'endpoint path',
+      'https://example.com/tenant/mcp',
+      'https://example.com/.well-known/oauth-protected-resource/tenant/mcp'
+    ],
+    [
+      'trailing path slash',
+      'https://example.com/tenant/mcp/',
+      'https://example.com/.well-known/oauth-protected-resource/tenant/mcp/'
+    ],
+    [
+      'query component',
+      'https://example.com/tenant/mcp?tenant=blue%2Fgreen',
+      'https://example.com/.well-known/oauth-protected-resource/tenant/mcp?tenant=blue%2Fgreen'
+    ],
+    [
+      'root resource',
+      'https://example.com/',
+      'https://example.com/.well-known/oauth-protected-resource'
+    ]
+  ])('preserves %s semantics', (_case, resource, expected) => {
+    expect(scopeChallengeResourceMetadataUrl(resource)).toBe(expected);
+  });
+});
+
 describe('ServerScopeChallengeScenario', () => {
   let server: Server | undefined;
   let process: ChildProcess | undefined;
@@ -160,71 +213,93 @@ describe('ServerScopeChallengeScenario', () => {
     process = undefined;
   });
 
-  it('passes every primitive with a complete, parseable challenge and upgraded retry', async () => {
-    let serverUrl = '';
-    server = createServer((req, res) => {
-      let rawBody = '';
-      req.setEncoding('utf8');
-      req.on('data', (chunk) => {
-        rawBody += chunk;
-      });
-      req.on('end', () => {
-        const request = JSON.parse(rawBody) as JsonRpcRequest;
-        const fixture = findFixture(request);
-        if (!fixture) {
-          res.statusCode = 404;
-          res.end();
-          return;
-        }
+  const validMetadataCases: readonly [
+    label: string,
+    endpoint: string,
+    metadataLocation: 'derived' | 'root'
+  ][] = [
+    ['path-derived endpoint', '/tenant/mcp', 'derived'],
+    ['path-derived trailing slash', '/tenant/mcp/', 'derived'],
+    ['path-derived query', '/tenant/mcp?tenant=blue%2Fgreen', 'derived'],
+    ['root well-known alternative', '/tenant/mcp', 'root']
+  ];
 
-        const authorization = req.headers.authorization;
-        if (authorization === `Bearer ${SCOPE_CHALLENGE_LOW_TOKEN}`) {
-          const metadata = scopeChallengeResourceMetadataUrl(serverUrl);
-          res.statusCode = 403;
+  it.each(validMetadataCases)(
+    'passes every primitive with a %s metadata URL',
+    async (_label, endpoint, metadataLocation) => {
+      let serverUrl = '';
+      server = createServer((req, res) => {
+        let rawBody = '';
+        req.setEncoding('utf8');
+        req.on('data', (chunk) => {
+          rawBody += chunk;
+        });
+        req.on('end', () => {
+          const request = JSON.parse(rawBody) as JsonRpcRequest;
+          const fixture = findFixture(request);
+          if (!fixture) {
+            res.statusCode = 404;
+            res.end();
+            return;
+          }
+
+          const authorization = req.headers.authorization;
+          if (authorization === `Bearer ${SCOPE_CHALLENGE_LOW_TOKEN}`) {
+            const metadata =
+              metadataLocation === 'root'
+                ? new URL(
+                    '/.well-known/oauth-protected-resource',
+                    serverUrl
+                  ).toString()
+                : scopeChallengeResourceMetadataUrl(serverUrl);
+            res.statusCode = 403;
+            res.setHeader('Content-Type', 'application/json');
+            res.setHeader(
+              'WWW-Authenticate',
+              `Bearer resource_metadata="${metadata}", error_description="Needs \\"both\\", scopes", scope="${fixture.requiredScopes.join(' ')} mcp:conformance:extra", error="insufficient_scope"`
+            );
+            res.end(
+              JSON.stringify({
+                jsonrpc: '2.0',
+                id: request.id,
+                error: { code: -32600, message: 'Insufficient scope' }
+              })
+            );
+            return;
+          }
+
+          if (authorization !== `Bearer ${SCOPE_CHALLENGE_FULL_TOKEN}`) {
+            res.statusCode = 401;
+            res.end();
+            return;
+          }
+
+          res.statusCode = 200;
           res.setHeader('Content-Type', 'application/json');
-          res.setHeader(
-            'WWW-Authenticate',
-            `Bearer resource_metadata="${metadata}", error_description="Needs \\"both\\", scopes", scope="${fixture.requiredScopes.join(' ')} mcp:conformance:extra", error="insufficient_scope"`
-          );
           res.end(
             JSON.stringify({
               jsonrpc: '2.0',
               id: request.id,
-              error: { code: -32600, message: 'Insufficient scope' }
+              result: fixtureResult(request)
             })
           );
-          return;
-        }
-
-        if (authorization !== `Bearer ${SCOPE_CHALLENGE_FULL_TOKEN}`) {
-          res.statusCode = 401;
-          res.end();
-          return;
-        }
-
-        res.statusCode = 200;
-        res.setHeader('Content-Type', 'application/json');
-        res.end(
-          JSON.stringify({
-            jsonrpc: '2.0',
-            id: request.id,
-            result: fixtureResult(request)
-          })
-        );
+        });
       });
-    });
-    serverUrl = await listen(server);
+      serverUrl = await listen(server, endpoint);
 
-    const checks = await new ServerScopeChallengeScenario().run(
-      testContext(serverUrl, DRAFT_PROTOCOL_VERSION)
-    );
+      const checks = await new ServerScopeChallengeScenario().run(
+        testContext(serverUrl, DRAFT_PROTOCOL_VERSION)
+      );
 
-    expect(checks).toHaveLength(16);
-    expect(checks.every((check) => check.status === 'SUCCESS')).toBe(true);
-    expect(
-      checks.filter((check) => check.id === 'sep-2350-server-single-challenge')
-    ).toHaveLength(4);
-  });
+      expect(checks).toHaveLength(16);
+      expect(checks.every((check) => check.status === 'SUCCESS')).toBe(true);
+      expect(
+        checks.filter(
+          (check) => check.id === 'sep-2350-server-single-challenge'
+        )
+      ).toHaveLength(4);
+    }
+  );
 
   it('emits pinned warnings against a server that does not challenge any primitive', async () => {
     const port = await getFreePort();

--- a/src/scenarios/server/scope-challenge.ts
+++ b/src/scenarios/server/scope-challenge.ts
@@ -1,0 +1,433 @@
+import {
+  type ClientScenario,
+  type ConformanceCheck,
+  DRAFT_PROTOCOL_VERSION
+} from '../../types';
+import {
+  buildStandardHeaders,
+  sendStatelessRequest,
+  withRequestMeta,
+  type RunContext,
+  type StatelessResponse
+} from '../../connection';
+
+export const SCOPE_CHALLENGE_LOW_TOKEN = 'mcp-conformance-scope-low';
+export const SCOPE_CHALLENGE_FULL_TOKEN = 'mcp-conformance-scope-full';
+
+interface ScopeChallengeFixture {
+  key: string;
+  label: string;
+  method: string;
+  params: Record<string, unknown>;
+  requiredScopes: readonly [string, string];
+  validateResult(result: Record<string, unknown>): string | undefined;
+}
+
+function firstArrayItem(value: unknown): Record<string, unknown> | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const first = value[0];
+  return typeof first === 'object' && first !== null
+    ? (first as Record<string, unknown>)
+    : undefined;
+}
+
+export const SCOPE_CHALLENGE_FIXTURES: readonly ScopeChallengeFixture[] = [
+  {
+    key: 'tool',
+    label: 'Tool',
+    method: 'tools/call',
+    params: { name: 'test_simple_text' },
+    requiredScopes: [
+      'mcp:conformance:tools:call',
+      'mcp:conformance:tools:test_simple_text'
+    ],
+    validateResult: (result) => {
+      const content = firstArrayItem(result.content);
+      return content?.type === 'text' && typeof content.text === 'string'
+        ? undefined
+        : 'Expected the test_simple_text tool result';
+    }
+  },
+  {
+    key: 'static-resource',
+    label: 'Static resource',
+    method: 'resources/read',
+    params: { uri: 'test://static-text' },
+    requiredScopes: [
+      'mcp:conformance:resources:read',
+      'mcp:conformance:resources:static'
+    ],
+    validateResult: (result) => {
+      const content = firstArrayItem(result.contents);
+      return content?.uri === 'test://static-text' &&
+        typeof content.text === 'string'
+        ? undefined
+        : 'Expected the test://static-text resource result';
+    }
+  },
+  {
+    key: 'template-resource',
+    label: 'Template resource',
+    method: 'resources/read',
+    params: { uri: 'test://template/123/data' },
+    requiredScopes: [
+      'mcp:conformance:resources:read',
+      'mcp:conformance:resources:template:123'
+    ],
+    validateResult: (result) => {
+      const content = firstArrayItem(result.contents);
+      return content?.uri === 'test://template/123/data' &&
+        typeof content.text === 'string' &&
+        content.text.includes('123')
+        ? undefined
+        : 'Expected the template-expanded test://template/123/data resource result';
+    }
+  },
+  {
+    key: 'prompt',
+    label: 'Prompt',
+    method: 'prompts/get',
+    params: { name: 'test_simple_prompt' },
+    requiredScopes: [
+      'mcp:conformance:prompts:get',
+      'mcp:conformance:prompts:test_simple_prompt'
+    ],
+    validateResult: (result) => {
+      const message = firstArrayItem(result.messages);
+      return message?.role === 'user' &&
+        typeof message.content === 'object' &&
+        message.content !== null
+        ? undefined
+        : 'Expected the test_simple_prompt result';
+    }
+  }
+];
+
+const SPEC_REFERENCE = {
+  id: 'MCP-Authorization-Runtime-Insufficient-Scope',
+  url: 'https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization#runtime-insufficient-scope-errors'
+};
+
+interface ParsedChallenge {
+  scheme: string;
+  params: Record<string, string>;
+}
+
+interface ChallengeResponse {
+  status: number;
+  wwwAuthenticate: string | null;
+  body?: unknown;
+}
+
+function splitOutsideQuotes(value: string): string[] {
+  const parts: string[] = [];
+  let start = 0;
+  let quoted = false;
+  let escaped = false;
+
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+    if (quoted && char === '\\') {
+      escaped = true;
+      continue;
+    }
+    if (char === '"') {
+      quoted = !quoted;
+      continue;
+    }
+    if (!quoted && char === ',') {
+      parts.push(value.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+
+  parts.push(value.slice(start).trim());
+  return parts.filter(Boolean);
+}
+
+function parseAuthParam(part: string): [string, string] | undefined {
+  const match = part.match(
+    /^([!#$%&'*+\-.^_`|~0-9A-Za-z]+)\s*=\s*(?:"((?:\\.|[^"])*)"|([!#$%&'*+\-.^_`|~0-9A-Za-z:/]+))$/
+  );
+  if (!match) return undefined;
+  const value = match[2]?.replace(/\\(.)/g, '$1') ?? match[3];
+  return [match[1].toLowerCase(), value];
+}
+
+function parseBearerChallenge(
+  value: string | null
+): ParsedChallenge | undefined {
+  if (!value) return undefined;
+
+  let current: ParsedChallenge | undefined;
+  for (const part of splitOutsideQuotes(value)) {
+    const challenge = part.match(
+      /^([!#$%&'*+\-.^_`|~0-9A-Za-z]+)(?:\s+(.*))?$/
+    );
+    const parameter = parseAuthParam(part);
+
+    if (challenge && !parameter) {
+      if (current?.scheme.toLowerCase() === 'bearer') return current;
+      current = { scheme: challenge[1], params: {} };
+      const firstParam = challenge[2]
+        ? parseAuthParam(challenge[2])
+        : undefined;
+      if (firstParam) current.params[firstParam[0]] = firstParam[1];
+      continue;
+    }
+
+    if (current && parameter) {
+      current.params[parameter[0]] = parameter[1];
+    }
+  }
+
+  return current?.scheme.toLowerCase() === 'bearer' ? current : undefined;
+}
+
+export function scopeChallengeResourceMetadataUrl(serverUrl: string): string {
+  const url = new URL(serverUrl);
+  const resourcePath =
+    url.pathname === '/' ? '' : url.pathname.replace(/\/+$/, '');
+  url.pathname = `/.well-known/oauth-protected-resource${resourcePath}`;
+  url.search = '';
+  url.hash = '';
+  return url.toString();
+}
+
+async function sendChallengeRequest(
+  ctx: RunContext,
+  fixture: ScopeChallengeFixture
+): Promise<ChallengeResponse> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+  const request = {
+    jsonrpc: '2.0',
+    id: `scope-challenge-${fixture.key}`,
+    method: fixture.method,
+    params: withRequestMeta(fixture.params, ctx.specVersion)
+  };
+
+  try {
+    const response = await fetch(ctx.serverUrl, {
+      method: 'POST',
+      headers: buildStandardHeaders(fixture.method, fixture.params, {
+        specVersion: ctx.specVersion,
+        headers: {
+          Authorization: `Bearer ${SCOPE_CHALLENGE_LOW_TOKEN}`
+        }
+      }),
+      body: JSON.stringify(request),
+      signal: controller.signal
+    });
+
+    const wwwAuthenticate = response.headers.get('www-authenticate');
+    if (response.status !== 403) {
+      await response.body?.cancel().catch(() => {});
+      return { status: response.status, wwwAuthenticate };
+    }
+
+    const text = await response.text();
+    let body: unknown = text;
+    try {
+      body = text ? JSON.parse(text) : undefined;
+    } catch {
+      // The authorization spec does not constrain the 403 body.
+    }
+    return { status: response.status, wwwAuthenticate, body };
+  } finally {
+    clearTimeout(timeout);
+    controller.abort();
+  }
+}
+
+function check(
+  fixture: ScopeChallengeFixture,
+  id: string,
+  nameSuffix: string,
+  description: string,
+  passed: boolean,
+  severity: 'FAILURE' | 'WARNING',
+  errorMessage: string | undefined,
+  details: Record<string, unknown>
+): ConformanceCheck {
+  return {
+    id,
+    name: `${fixture.label.replace(/ /g, '')}${nameSuffix}`,
+    description,
+    status: passed ? 'SUCCESS' : severity,
+    timestamp: new Date().toISOString(),
+    errorMessage: passed ? undefined : errorMessage,
+    specReferences: [SPEC_REFERENCE],
+    details: {
+      fixture: fixture.key,
+      method: fixture.method,
+      params: fixture.params,
+      requiredScopes: fixture.requiredScopes,
+      ...details
+    }
+  };
+}
+
+function challengeChecks(
+  fixture: ScopeChallengeFixture,
+  response: ChallengeResponse | undefined,
+  requestError: unknown,
+  expectedResourceMetadata: string
+): ConformanceCheck[] {
+  const parsed = parseBearerChallenge(response?.wwwAuthenticate ?? null);
+  const scopes = parsed?.params.scope?.split(/\s+/).filter(Boolean) ?? [];
+  const hasAllScopes = fixture.requiredScopes.every((scope) =>
+    scopes.includes(scope)
+  );
+  const details = {
+    responseStatus: response?.status,
+    wwwAuthenticate: response?.wwwAuthenticate,
+    responseBody: response?.body
+  };
+  const requestErrorMessage =
+    requestError instanceof Error ? requestError.message : String(requestError);
+
+  return [
+    check(
+      fixture,
+      'server-scope-challenge-http-403',
+      'ScopeChallengeHttp403',
+      `${fixture.label} returns HTTP 403 for a valid under-scoped token`,
+      response?.status === 403,
+      'WARNING',
+      response
+        ? `Expected HTTP 403, got ${response.status}`
+        : `Request failed: ${requestErrorMessage}`,
+      details
+    ),
+    check(
+      fixture,
+      'server-scope-challenge-www-authenticate',
+      'ScopeChallengeWwwAuthenticate',
+      `${fixture.label} returns a Bearer insufficient_scope challenge with protected-resource metadata`,
+      parsed?.params.error === 'insufficient_scope' &&
+        parsed.params.resource_metadata === expectedResourceMetadata,
+      'WARNING',
+      parsed
+        ? `Expected error="insufficient_scope" and resource_metadata="${expectedResourceMetadata}", got ${response?.wwwAuthenticate ?? '(missing header)'}`
+        : `Expected a Bearer WWW-Authenticate challenge, got ${response?.wwwAuthenticate ?? '(missing header)'}`,
+      details
+    ),
+    check(
+      fixture,
+      'sep-2350-server-single-challenge',
+      'ScopeChallengeCompleteScopeSet',
+      `${fixture.label} includes all scopes required for the operation in one challenge`,
+      hasAllScopes,
+      'WARNING',
+      `Expected one challenge containing ${fixture.requiredScopes.join(' and ')}, got ${scopes.join(' ') || '(no scopes)'}`,
+      { ...details, challengedScopes: scopes }
+    )
+  ];
+}
+
+function retryCheck(
+  fixture: ScopeChallengeFixture,
+  response: StatelessResponse | undefined,
+  requestError: unknown
+): ConformanceCheck {
+  const result = response?.body?.result;
+  const resultError =
+    result === undefined
+      ? 'Response did not contain an MCP result'
+      : fixture.validateResult(result);
+  const passed =
+    response?.status === 200 &&
+    response.body?.error === undefined &&
+    resultError === undefined;
+  const requestErrorMessage =
+    requestError instanceof Error ? requestError.message : String(requestError);
+
+  return check(
+    fixture,
+    'server-scope-challenge-upgraded-retry',
+    'ScopeChallengeUpgradedRetry',
+    `${fixture.label} succeeds when the same operation is retried with the full-scope token`,
+    passed,
+    'FAILURE',
+    response
+      ? `Expected HTTP 200 with the normal MCP result, got HTTP ${response.status}: ${resultError ?? response.body?.error?.message ?? response.text ?? 'unknown response'}`
+      : `Retry failed: ${requestErrorMessage}`,
+    {
+      responseStatus: response?.status,
+      responseBody: response?.body,
+      responseText: response?.text
+    }
+  );
+}
+
+export class ServerScopeChallengeScenario implements ClientScenario {
+  name = 'sep-2350-server-scope-challenge';
+  readonly source = { introducedIn: DRAFT_PROTOCOL_VERSION } as const;
+  description = `Test request-time OAuth insufficient_scope challenges (SEP-2350).
+
+**Server fixture contract:**
+- Keep unauthenticated behavior unchanged for the existing conformance scenarios.
+- Treat \`${SCOPE_CHALLENGE_LOW_TOKEN}\` as a valid opaque token with only
+  \`mcp:conformance:baseline\`.
+- Treat \`${SCOPE_CHALLENGE_FULL_TOKEN}\` as a valid opaque token containing every
+  scope required below.
+- For the low token, return HTTP 403 and a Bearer \`WWW-Authenticate\` challenge
+  with \`error="insufficient_scope"\`, protected-resource metadata, and all scopes
+  required for the current operation in one challenge.
+- Accept the full token when the same operation is retried.
+
+The scenario exercises tools/call, resources/read for both the existing static and
+template-expanded fixtures, and prompts/get. See SDK_INTEGRATION.md for the fixed
+scope pairs and metadata URL rule.`;
+
+  async run(ctx: RunContext): Promise<ConformanceCheck[]> {
+    const checks: ConformanceCheck[] = [];
+    const expectedResourceMetadata = scopeChallengeResourceMetadataUrl(
+      ctx.serverUrl
+    );
+
+    for (const fixture of SCOPE_CHALLENGE_FIXTURES) {
+      let challengeResponse: ChallengeResponse | undefined;
+      let challengeError: unknown;
+      try {
+        challengeResponse = await sendChallengeRequest(ctx, fixture);
+      } catch (error) {
+        challengeError = error;
+      }
+      checks.push(
+        ...challengeChecks(
+          fixture,
+          challengeResponse,
+          challengeError,
+          expectedResourceMetadata
+        )
+      );
+
+      let retryResponse: StatelessResponse | undefined;
+      let retryError: unknown;
+      try {
+        retryResponse = await sendStatelessRequest(
+          ctx.serverUrl,
+          fixture.method,
+          fixture.params,
+          {
+            specVersion: ctx.specVersion,
+            headers: {
+              Authorization: `Bearer ${SCOPE_CHALLENGE_FULL_TOKEN}`
+            }
+          }
+        );
+      } catch (error) {
+        retryError = error;
+      }
+      checks.push(retryCheck(fixture, retryResponse, retryError));
+    }
+
+    return checks;
+  }
+}

--- a/src/scenarios/server/scope-challenge.ts
+++ b/src/scenarios/server/scope-challenge.ts
@@ -329,6 +329,33 @@ function challengeChecks(
   };
   const requestErrorMessage =
     requestError instanceof Error ? requestError.message : String(requestError);
+  const completenessCheck: ConformanceCheck = parsed
+    ? check(
+        fixture,
+        'sep-2350-server-single-challenge',
+        'ScopeChallengeCompleteScopeSet',
+        `${fixture.label} includes all scopes required for the operation in one challenge`,
+        hasAllScopes,
+        'WARNING',
+        `Expected one challenge containing ${fixture.requiredScopes.join(' and ')}, got ${scopes.join(' ') || '(no scopes)'}`,
+        { ...details, challengedScopes: scopes }
+      )
+    : {
+        id: 'sep-2350-server-single-challenge',
+        name: `${fixture.label.replace(/ /g, '')}ScopeChallengeCompleteScopeSet`,
+        description: `${fixture.label} includes all scopes required for the operation in one challenge`,
+        status: 'SKIPPED',
+        timestamp: new Date().toISOString(),
+        specReferences: [SPEC_REFERENCE],
+        details: {
+          fixture: fixture.key,
+          method: fixture.method,
+          params: fixture.params,
+          requiredScopes: fixture.requiredScopes,
+          ...details,
+          note: 'No parseable Bearer challenge; the prerequisite challenge check reports the missing or malformed header'
+        }
+      };
 
   return [
     check(
@@ -360,16 +387,7 @@ function challengeChecks(
         metadataError
       }
     ),
-    check(
-      fixture,
-      'sep-2350-server-single-challenge',
-      'ScopeChallengeCompleteScopeSet',
-      `${fixture.label} includes all scopes required for the operation in one challenge`,
-      hasAllScopes,
-      'WARNING',
-      `Expected one challenge containing ${fixture.requiredScopes.join(' and ')}, got ${scopes.join(' ') || '(no scopes)'}`,
-      { ...details, challengedScopes: scopes }
-    )
+    completenessCheck
   ];
 }
 

--- a/src/scenarios/server/scope-challenge.ts
+++ b/src/scenarios/server/scope-challenge.ts
@@ -108,7 +108,7 @@ const SPEC_REFERENCE = {
   url: 'https://modelcontextprotocol.io/specification/2026-07-28/basic/authorization#runtime-insufficient-scope-errors'
 };
 
-interface ParsedChallenge {
+export interface ParsedChallenge {
   scheme: string;
   params: Record<string, string>;
 }
@@ -151,14 +151,14 @@ function splitOutsideQuotes(value: string): string[] {
 
 function parseAuthParam(part: string): [string, string] | undefined {
   const match = part.match(
-    /^([!#$%&'*+\-.^_`|~0-9A-Za-z]+)\s*=\s*(?:"((?:\\.|[^"])*)"|([!#$%&'*+\-.^_`|~0-9A-Za-z:/]+))$/
+    /^([!#$%&'*+\-.^_`|~0-9A-Za-z]+)\s*=\s*(?:"((?:\\.|[^"])*)"|([!#$%&'*+\-.^_`|~0-9A-Za-z]+))$/
   );
   if (!match) return undefined;
   const value = match[2]?.replace(/\\(.)/g, '$1') ?? match[3];
   return [match[1].toLowerCase(), value];
 }
 
-function parseBearerChallenge(
+export function parseBearerChallenge(
   value: string | null
 ): ParsedChallenge | undefined {
   if (!value) return undefined;
@@ -189,13 +189,48 @@ function parseBearerChallenge(
 }
 
 export function scopeChallengeResourceMetadataUrl(serverUrl: string): string {
-  const url = new URL(serverUrl);
-  const resourcePath =
-    url.pathname === '/' ? '' : url.pathname.replace(/\/+$/, '');
-  url.pathname = `/.well-known/oauth-protected-resource${resourcePath}`;
-  url.search = '';
-  url.hash = '';
-  return url.toString();
+  const resource = new URL(serverUrl);
+  const metadata = new URL(resource.origin);
+  metadata.pathname = `/.well-known/oauth-protected-resource${
+    resource.pathname === '/' ? '' : resource.pathname
+  }`;
+  metadata.search = resource.search;
+  return metadata.toString();
+}
+
+function resourceMetadataUrlError(
+  resourceMetadata: string | undefined,
+  serverUrl: string
+): string | undefined {
+  if (!resourceMetadata) {
+    return 'The challenge did not include resource_metadata';
+  }
+
+  let metadata: URL;
+  try {
+    metadata = new URL(resourceMetadata);
+  } catch {
+    return `resource_metadata is not an absolute URL: ${resourceMetadata}`;
+  }
+
+  if (metadata.username || metadata.password) {
+    return 'resource_metadata must not contain user information';
+  }
+  if (metadata.hash) {
+    return 'resource_metadata must not contain a fragment';
+  }
+
+  const resource = new URL(serverUrl);
+  const isHttps = metadata.protocol === 'https:';
+  const isSameOriginHttpFixture =
+    metadata.protocol === 'http:' &&
+    resource.protocol === 'http:' &&
+    metadata.origin === resource.origin;
+  if (!isHttps && !isSameOriginHttpFixture) {
+    return 'resource_metadata must use HTTPS (same-origin HTTP is accepted for local conformance fixtures)';
+  }
+
+  return undefined;
 }
 
 async function sendChallengeRequest(
@@ -276,10 +311,14 @@ function challengeChecks(
   fixture: ScopeChallengeFixture,
   response: ChallengeResponse | undefined,
   requestError: unknown,
-  expectedResourceMetadata: string
+  serverUrl: string
 ): ConformanceCheck[] {
   const parsed = parseBearerChallenge(response?.wwwAuthenticate ?? null);
   const scopes = parsed?.params.scope?.split(/\s+/).filter(Boolean) ?? [];
+  const metadataError = resourceMetadataUrlError(
+    parsed?.params.resource_metadata,
+    serverUrl
+  );
   const hasAllScopes = fixture.requiredScopes.every((scope) =>
     scopes.includes(scope)
   );
@@ -310,12 +349,16 @@ function challengeChecks(
       'ScopeChallengeWwwAuthenticate',
       `${fixture.label} returns a Bearer insufficient_scope challenge with protected-resource metadata`,
       parsed?.params.error === 'insufficient_scope' &&
-        parsed.params.resource_metadata === expectedResourceMetadata,
+        metadataError === undefined,
       'WARNING',
       parsed
-        ? `Expected error="insufficient_scope" and resource_metadata="${expectedResourceMetadata}", got ${response?.wwwAuthenticate ?? '(missing header)'}`
+        ? `Expected error="insufficient_scope" and a valid resource_metadata URL, got ${response?.wwwAuthenticate ?? '(missing header)'}${metadataError ? ` (${metadataError})` : ''}`
         : `Expected a Bearer WWW-Authenticate challenge, got ${response?.wwwAuthenticate ?? '(missing header)'}`,
-      details
+      {
+        ...details,
+        resourceMetadata: parsed?.params.resource_metadata,
+        metadataError
+      }
     ),
     check(
       fixture,
@@ -387,9 +430,6 @@ scope pairs and metadata URL rule.`;
 
   async run(ctx: RunContext): Promise<ConformanceCheck[]> {
     const checks: ConformanceCheck[] = [];
-    const expectedResourceMetadata = scopeChallengeResourceMetadataUrl(
-      ctx.serverUrl
-    );
 
     for (const fixture of SCOPE_CHALLENGE_FIXTURES) {
       let challengeResponse: ChallengeResponse | undefined;
@@ -404,7 +444,7 @@ scope pairs and metadata URL rule.`;
           fixture,
           challengeResponse,
           challengeError,
-          expectedResourceMetadata
+          ctx.serverUrl
         )
       );
 

--- a/src/scenarios/server/session-lifecycle.test.ts
+++ b/src/scenarios/server/session-lifecycle.test.ts
@@ -227,7 +227,7 @@ describe('SessionLifecycleScenario', () => {
     });
   });
 
-  it('reports WARNING when DELETE returns 404 but the session still responds', async () => {
+  it('reports INFO when DELETE returns 404 but the session still responds', async () => {
     fetchMock
       .mockResolvedValueOnce(
         new Response(null, {
@@ -248,17 +248,17 @@ describe('SessionLifecycleScenario', () => {
     expect(checks).toHaveLength(3);
     expect(checks[1]).toMatchObject({
       id: 'server-session-delete-accepted',
-      status: 'WARNING',
+      status: 'INFO',
       details: { statusCode: 404 }
     });
-    expect(checks[1].errorMessage).toContain('still responds');
+    expect(checks[1].details?.message).toContain('still responds');
     expect(checks[2]).toMatchObject({
       id: 'server-session-terminated-returns-404',
       status: 'SKIPPED'
     });
   });
 
-  it('reports WARNING (not FAILURE) on an unexpected DELETE status and skips the 404 check', async () => {
+  it('reports INFO on an inconclusive DELETE status and skips the 404 check', async () => {
     fetchMock
       .mockResolvedValueOnce(
         new Response(null, {
@@ -276,10 +276,10 @@ describe('SessionLifecycleScenario', () => {
     expect(checks).toHaveLength(3);
     expect(checks[1]).toMatchObject({
       id: 'server-session-delete-accepted',
-      status: 'WARNING',
+      status: 'INFO',
       details: { statusCode: 500 }
     });
-    expect(checks[1].errorMessage).toContain('Expected 2xx, 404, or 405');
+    expect(checks[1].details?.message).toContain('Expected 2xx, 404, or 405');
     expect(checks[2]).toMatchObject({
       id: 'server-session-terminated-returns-404',
       status: 'SKIPPED'

--- a/src/scenarios/server/session-lifecycle.ts
+++ b/src/scenarios/server/session-lifecycle.ts
@@ -313,15 +313,14 @@ Servers without session management (stateless) are reported as SKIPPED.`;
       if (!deleteAccepted && !deleteReturned404) {
         // The spec only says the client SHOULD send DELETE and the server
         // MAY respond 405; it never pins a success status, so an unexpected
-        // status is a warning rather than a failure. Without a confirmed
+        // status is diagnostic rather than a conformance failure. Without a confirmed
         // termination the terminated-returns-404 check would be misleading.
-        const warningMessage = `Expected 2xx, 404, or 405 for DELETE, got ${deleteResponse.status}. The spec does not pin a success status for session termination, so this is reported as a warning.`;
+        const diagnosticMessage = `Expected 2xx, 404, or 405 for DELETE, got ${deleteResponse.status}. The spec does not pin a success status for session termination, so this is reported as diagnostic information.`;
         checks.push(
-          check(DELETE_ACCEPTED, 'WARNING', {
-            errorMessage: warningMessage,
+          check(DELETE_ACCEPTED, 'INFO', {
             details: {
               statusCode: deleteResponse.status,
-              message: warningMessage
+              message: diagnosticMessage
             }
           }),
           skipped(
@@ -350,11 +349,10 @@ Servers without session management (stateless) are reported as SKIPPED.`;
         // The 404 on DELETE was not a termination: the session still
         // answers. Most likely the server has no DELETE route (it should
         // return 405 in that case).
-        const warningMessage = `DELETE returned 404 but the session still responds (HTTP ${afterTerminationResponse.status} on a follow-up request). A server without explicit termination support should return 405.`;
+        const diagnosticMessage = `DELETE returned 404 but the session still responds (HTTP ${afterTerminationResponse.status} on a follow-up request). The spec permits servers not to support explicit termination and does not require a particular response other than allowing 405.`;
         checks.push(
-          check(DELETE_ACCEPTED, 'WARNING', {
-            errorMessage: warningMessage,
-            details: { statusCode: 404, message: warningMessage }
+          check(DELETE_ACCEPTED, 'INFO', {
+            details: { statusCode: 404, message: diagnosticMessage }
           }),
           skipped(
             TERMINATED_RETURNS_404,

--- a/src/scenarios/server/sse-multiple-streams.test.ts
+++ b/src/scenarios/server/sse-multiple-streams.test.ts
@@ -20,7 +20,9 @@ interface VersionEnforcingServer {
   close: () => Promise<void>;
 }
 
-async function startVersionEnforcingServer(): Promise<VersionEnforcingServer> {
+async function startVersionEnforcingServer(
+  useSession = true
+): Promise<VersionEnforcingServer> {
   let negotiated: string | undefined;
 
   const server = http.createServer((req, res) => {
@@ -49,7 +51,9 @@ async function startVersionEnforcingServer(): Promise<VersionEnforcingServer> {
 
       if (body.method === 'initialize') {
         negotiated = body.params?.protocolVersion;
-        res.setHeader('mcp-session-id', SESSION_ID);
+        if (useSession) {
+          res.setHeader('mcp-session-id', SESSION_ID);
+        }
         respond(200, {
           jsonrpc: '2.0',
           id: body.id,
@@ -127,6 +131,27 @@ describe('server-sse-multiple-streams — negotiated protocol version', () => {
       numStreamsAccepted: 3
     });
     expect(checks.every((c) => c.status !== 'FAILURE')).toBe(true);
+  });
+
+  test('keeps a conformant sessionless server green and exercises its requests', async () => {
+    const srv = await startVersionEnforcingServer(false);
+
+    const scenario = new ServerSSEMultipleStreamsScenario();
+    let checks: ConformanceCheck[];
+    try {
+      checks = await scenario.run(testContext(srv.url));
+    } finally {
+      await srv.close();
+    }
+
+    expect(
+      findAll(checks, 'server-sse-multiple-streams-session')[0]?.status
+    ).toBe('INFO');
+    expect(
+      findAll(checks, 'server-accepts-multiple-post-streams')[0]?.status
+    ).toBe('SUCCESS');
+    expect(checks.some((check) => check.status === 'WARNING')).toBe(false);
+    expect(checks.some((check) => check.status === 'FAILURE')).toBe(false);
   });
 
   test('fixture server rejects a supported but non-negotiated version', async () => {

--- a/src/scenarios/server/sse-multiple-streams.ts
+++ b/src/scenarios/server/sse-multiple-streams.ts
@@ -69,8 +69,9 @@ export class ServerSSEMultipleStreamsScenario implements ClientScenario {
           checks.push({
             id: 'server-sse-multiple-streams-session',
             name: 'ServerSSEMultipleStreamsSession',
-            description: 'Server provides session ID for multiple streams test',
-            status: 'WARNING',
+            description:
+              'Server does not use optional session management for the multiple streams test',
+            status: 'INFO',
             timestamp: new Date().toISOString(),
             specReferences: [
               {
@@ -80,10 +81,9 @@ export class ServerSSEMultipleStreamsScenario implements ClientScenario {
             ],
             details: {
               message:
-                'Server did not provide session ID - multiple streams test may not work correctly'
+                'Server did not provide an optional session ID; continuing without MCP-Session-Id'
             }
           });
-          return checks;
         }
       }
 
@@ -98,7 +98,7 @@ export class ServerSSEMultipleStreamsScenario implements ClientScenario {
         : {
             'Content-Type': 'application/json',
             Accept: 'text/event-stream, application/json',
-            'mcp-session-id': sessionId!,
+            ...(sessionId && { 'mcp-session-id': sessionId }),
             'mcp-protocol-version': negotiatedProtocolVersion ?? specVersion
           };
       const requestParams = stateless

--- a/src/scenarios/server/sse-polling.test.ts
+++ b/src/scenarios/server/sse-polling.test.ts
@@ -26,7 +26,9 @@ interface VersionEnforcingServer {
 // Down-negotiates every initialize to DOWN_NEGOTIATED_VERSION so a scenario
 // that hard-codes the latest version cannot pass, records each follow-up's
 // version header, and 400s any version or session mismatch.
-async function startVersionEnforcingServer(): Promise<VersionEnforcingServer> {
+async function startVersionEnforcingServer(
+  supportsReconnectionTool = true
+): Promise<VersionEnforcingServer> {
   let negotiated: string | undefined;
   const seen: SeenRequest[] = [];
 
@@ -117,6 +119,14 @@ async function startVersionEnforcingServer(): Promise<VersionEnforcingServer> {
         return;
       }
       if (body.method === 'tools/call') {
+        if (!supportsReconnectionTool) {
+          respond(404, {
+            jsonrpc: '2.0',
+            id: body.id,
+            error: { code: -32601, message: 'Tool not found' }
+          });
+          return;
+        }
         // Spec-shaped priming event (id + empty data), then close without
         // the result, so the scenario must reconnect via GET + Last-Event-ID.
         res.writeHead(200, sseHead);
@@ -179,6 +189,28 @@ describe('server-sse-polling — negotiated protocol version', () => {
     const resume = findAll(checks, 'server-sse-disconnect-resume')[0];
     expect(resume?.status).toBe('SUCCESS');
     expect(checks.filter((c) => c.status === 'FAILURE')).toEqual([]);
+  });
+
+  test('reports an unavailable fixture tool as diagnostic information', async () => {
+    const srv = await startVersionEnforcingServer(false);
+
+    let checks: ConformanceCheck[];
+    try {
+      checks = await new ServerSSEPollingScenario().run(
+        testContext(srv.url, LATEST_SPEC_VERSION)
+      );
+    } finally {
+      await srv.close();
+    }
+
+    expect(
+      findAll(checks, 'server-sse-test-reconnection-tool')[0]
+    ).toMatchObject({
+      status: 'INFO',
+      details: { statusCode: 404 }
+    });
+    expect(checks.some((check) => check.status === 'WARNING')).toBe(false);
+    expect(checks.some((check) => check.status === 'FAILURE')).toBe(false);
   });
 
   test('fixture rejects a supported but non-negotiated version', async () => {

--- a/src/scenarios/server/sse-polling.ts
+++ b/src/scenarios/server/sse-polling.ts
@@ -163,15 +163,19 @@ export class ServerSSEPollingScenario implements ClientScenario {
             name: 'ServerTestReconnectionTool',
             description:
               'Server implements test_reconnection tool for SSE polling tests',
-            status: 'WARNING',
+            status: 'INFO',
             timestamp: new Date().toISOString(),
-            errorMessage: `Server does not implement test_reconnection tool (HTTP ${postResponse.status}). This tool is recommended for testing SSE polling behavior.`,
             specReferences: [
               {
                 id: 'SEP-1699',
                 url: 'https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1699'
               }
-            ]
+            ],
+            details: {
+              statusCode: postResponse.status,
+              message:
+                'The non-normative test_reconnection fixture tool is unavailable, so polling behavior was not exercised'
+            }
           });
           return checks;
         }

--- a/src/scenarios/server/sse-polling.ts
+++ b/src/scenarios/server/sse-polling.ts
@@ -115,8 +115,9 @@ export class ServerSSEPollingScenario implements ClientScenario {
         checks.push({
           id: 'server-sse-polling-session',
           name: 'ServerSSEPollingSession',
-          description: 'Server provides session ID for SSE polling tests',
-          status: 'WARNING',
+          description:
+            'Server does not use optional session management for SSE polling tests',
+          status: 'INFO',
           timestamp: new Date().toISOString(),
           specReferences: [
             {
@@ -126,7 +127,7 @@ export class ServerSSEPollingScenario implements ClientScenario {
           ],
           details: {
             message:
-              'Server did not provide session ID - SSE polling tests may not work correctly'
+              'Server did not provide an optional session ID; polling checks continue without MCP-Session-Id'
           }
         });
       }

--- a/src/seps/sep-2350.yaml
+++ b/src/seps/sep-2350.yaml
@@ -4,8 +4,8 @@ requirements:
   - check: sep-2350-scope-union-on-reauth
     text: 'When re-authorizing, clients SHOULD include these scopes alongside any previously granted scopes to avoid losing permissions needed for other operations. / Clients SHOULD compute the union of previously requested scopes and newly challenged scopes when initiating re-authorization.'
     url: https://modelcontextprotocol.io/specification/draft/basic/authorization#protected-resource-metadata-discovery-requirements
-  - text: 'Regardless of the approach chosen, servers SHOULD include all scopes required for the current operation in a single challenge.'
-    excluded: '"All scopes required for the current operation" has no harness-observable ground truth; the challenge is the only place the server declares its requirements. Detecting the negative (incremental challenging) would need server-side auth scenarios that do not exist yet and would test the example app''s scope config rather than SDK behavior; the spec also permits dynamic per-request scope determination, so a second challenge is not conclusively non-conformant.'
+  - check: sep-2350-server-single-challenge
+    text: 'Regardless of the approach chosen, servers SHOULD include all scopes required for the current operation in a single challenge.'
 
   - text: 'When responding with insufficient scope errors, servers SHOULD include the scopes needed to satisfy the current operation in the scope parameter, consistent with RFC 6750 Section 3.1.'
     excluded: 'reword of pre-existing requirement (request->operation, +RFC6750 cite); no normative delta; harness already emits scope= in WWW-Authenticate'


### PR DESCRIPTION
## Summary

- add a language-neutral server conformance scenario for request-time OAuth `insufficient_scope` challenges
- exercise `tools/call`, static and templated `resources/read`, and `prompts/get` with a fixed cross-SDK fixture contract
- assert HTTP 403, ****** parameters, the complete required scope set in one challenge, and successful upgraded-token retries
- restore `sep-2350-server-single-challenge` traceability and document the portable SUT contract
- make normative server-side SHOULD warnings gate targeted conformance runs consistently while leaving optional/inconclusive diagnostics informational

The scenario uses existing primitive fixtures and opaque test tokens, so the negative result is observable wire behavior rather than a missing TypeScript API or test-only primitive. The core scenario does not import or depend on the TypeScript SDK.

## A/B proof

Both legs used this conformance branch's official `sdk ... --mode server --scenario sep-2350-server-scope-challenge --spec-version 2026-07-28` path.

| TypeScript SDK ref | Result |
| --- | --- |
| unmodified `modelcontextprotocol/typescript-sdk@main` (`dcc01028`) | `SUCCESS=5`, `WARNING=12`, exit `1`; four warnings each for HTTP 403, `WWW-Authenticate`, and `sep-2350-server-single-challenge`; all four full-token retries succeeded |
| `SamMorrowDrums/typescript-sdk@scope-challenge-server-sdk` (`54e8deda`) | `SUCCESS=17`, no warnings or failures, exit `0` |

The feature fixture adapter is part of [modelcontextprotocol/typescript-sdk#1624](https://github.com/modelcontextprotocol/typescript-sdk/pull/1624) and remains independent from this branch. The latest green run includes the maintainer-requested reuse of bearer-auth metadata configuration through verified `AuthInfo`.

## Validation

- `npm test` — 45 files, 541 tests passed
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- targeted compliant and deliberately broken scope-challenge fixture tests
- TypeScript SDK feature head `54e8deda` — 17/17 official scenario checks passed

## References

- Closes #480
- [SEP-2350](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2350)
- [TypeScript SDK implementation](https://github.com/modelcontextprotocol/typescript-sdk/pull/1624)
- Existing client-side coverage: #282
- Prior server-row traceability decision: #302