### PR TITLE
fix(tasks): validate cancelled terminal status

### DIFF
--- a/src/scenarios/server/tasks/lifecycle.test.ts
+++ b/src/scenarios/server/tasks/lifecycle.test.ts
@@ -3,6 +3,7 @@ import { testContext } from '../../../connection/testing';
 import { TasksLifecycleScenario } from './lifecycle';
 import { DRAFT_PROTOCOL_VERSION } from '../../../types';
 import type { ConformanceCheck } from '../../../types';
+import type { RunContext } from '../../../connection';
 
 /**
  * Pins the untestable-failure policy (issue #248) for the SEP-2663 lifecycle
@@ -61,6 +62,61 @@ function mockServer() {
   return 'http://mock-taskless-server.local';
 }
 
+function cancellationContext(): RunContext {
+  const request = async (method: string, params: any) => {
+    if (method === 'tools/call') {
+      if (params.name === 'greet') {
+        return {
+          resultType: 'complete',
+          content: [{ type: 'text', text: 'Hello, World!' }]
+        };
+      }
+      return {
+        resultType: 'task',
+        taskId:
+          params.name === 'failing_job'
+            ? 'failing'
+            : params.name === 'protocol_error_job'
+              ? 'protocol-error'
+              : params.arguments.label,
+        status: 'working',
+        createdAt: '2026-09-02T00:00:00Z',
+        lastUpdatedAt: '2026-09-02T00:00:00Z',
+        ttlMs: 60_000
+      };
+    }
+    if (method === 'tasks/cancel') return { resultType: 'complete' };
+    if (params.taskId === 'failing') {
+      return {
+        resultType: 'complete',
+        taskId: params.taskId,
+        status: 'completed',
+        result: { content: [], isError: true }
+      };
+    }
+    if (params.taskId === 'protocol-error') {
+      return {
+        resultType: 'complete',
+        taskId: params.taskId,
+        status: 'failed',
+        error: { code: -32603, message: 'Internal error' }
+      };
+    }
+    return {
+      resultType: 'complete',
+      taskId: params.taskId,
+      status: 'completed',
+      result: { content: [{ type: 'text', text: 'done' }] }
+    };
+  };
+
+  return {
+    serverUrl: 'http://unused.local',
+    specVersion: DRAFT_PROTOCOL_VERSION,
+    connect: async () => ({ request, close: async () => {} }) as any
+  };
+}
+
 describe('tasks-lifecycle — no task created', () => {
   test('downstream task checks fail as untestable instead of SKIPPED', async () => {
     const mockUrl = mockServer();
@@ -78,5 +134,25 @@ describe('tasks-lifecycle — no task created', () => {
       expect(check.details).toMatchObject({ untestable: true });
     }
     expect(checks.every((c) => c.status !== 'SKIPPED')).toBe(true);
+  });
+});
+
+describe('tasks-lifecycle — cancellation', () => {
+  test('fails when the cancellable fixture settles to completed', async () => {
+    const scenario = new TasksLifecycleScenario();
+    const checks = await scenario.run(cancellationContext());
+
+    expect(
+      checks.find((check) => check.id === 'sep-2663-cancel-ack-empty-result')
+    ).toMatchObject({
+      status: 'SUCCESS',
+      details: { statusAfterCancel: 'completed' }
+    });
+    expect(
+      checks.find((check) => check.id === 'sep-2663-tasks-get-status-cancelled')
+    ).toMatchObject({
+      status: 'FAILURE',
+      details: { statusAfterCancel: 'completed' }
+    });
   });
 });

--- a/src/scenarios/server/tasks/lifecycle.ts
+++ b/src/scenarios/server/tasks/lifecycle.ts
@@ -423,7 +423,7 @@ The server MUST advertise \`io.modelcontextprotocol/tasks\` under
       const id = 'sep-2663-cancel-ack-empty-result';
       const name = 'TasksCancelEmptyAck';
       const description =
-        'tasks/cancel returns {resultType:"complete"} ack; status settles to cancelled';
+        'tasks/cancel returns an empty {resultType:"complete"} acknowledgement';
       let cancelTaskId: string | undefined;
       try {
         const created = (await conn.request('tools/call', {
@@ -461,8 +461,6 @@ The server MUST advertise \`io.modelcontextprotocol/tasks\` under
               `cancel ack MUST NOT carry task-envelope fields; got: ${ackOffenders.join(', ')}`
             );
           }
-          // SEP-2663 §Task Cancellation: transition to `cancelled` is not
-          // guaranteed; record the settled status as diagnostic detail only.
           const after = await waitForTerminal(conn, cancelTaskId);
           checks.push({
             id,
@@ -473,6 +471,20 @@ The server MUST advertise \`io.modelcontextprotocol/tasks\` under
             errorMessage: errs.length > 0 ? errs.join('; ') : undefined,
             specReferences: [SEP_2663_REF, SEP_2322_REF],
             details: { cancelAck: ack, statusAfterCancel: after.status }
+          });
+          checks.push({
+            id: 'sep-2663-tasks-get-status-cancelled',
+            name: 'TasksGetCancelledStatus',
+            description:
+              'The cancellable slow_compute fixture settles to cancelled after tasks/cancel',
+            status: after.status === 'cancelled' ? 'SUCCESS' : 'FAILURE',
+            timestamp: new Date().toISOString(),
+            errorMessage:
+              after.status === 'cancelled'
+                ? undefined
+                : `expected status:"cancelled"; got ${JSON.stringify(after.status)}`,
+            specReferences: [SEP_2663_REF],
+            details: { statusAfterCancel: after.status }
           });
         }
       } catch (error) {


### PR DESCRIPTION
The `tasks-lifecycle` scenario could pass when its deterministic cancellable fixture settled to `completed`. The scenario waited for the terminal response but treated the observed status as diagnostic data.

This emits the existing `sep-2663-tasks-get-status-cancelled` check and fails it unless `slow_compute` settles to `cancelled`. The cancellation acknowledgement remains a separate check.

Closes https://github.com/modelcontextprotocol/conformance/issues/485

## Testing

The focused test was run on `74edef34d674f563537be8c6587cebaa58e830ca` with only the regression applied, then rerun with the implementation.

```sh
npm test -- --run src/scenarios/server/tasks/lifecycle.test.ts
npm run check
npm run build
npm test
```

<details>
<summary>Raw results</summary>

```text
# Current main with regression only
AssertionError: expected undefined to match object
Test Files  1 failed (1)
Tests       1 failed | 1 passed (2)
exit_code=1

# With the implementation
Test Files  1 passed (1)
Tests       2 passed (2)
exit_code=0

# Full suite
Test Files  44 passed (44)
Tests       525 passed (525)
exit_code=0

# Typecheck, lint, and format
All matched files use Prettier code style!
exit_code=0

# Build
Build complete
exit_code=0
```

</details>

A live SDK run is not available because the TypeScript and Python SDKs do not implement SEP-2663:

- https://github.com/modelcontextprotocol/typescript-sdk/issues/2189
- https://github.com/modelcontextprotocol/python-sdk/issues/3226

AI assistance disclosure: GitHub Copilot CLI was used for repository research, implementation, test generation, ownership checks, and verification. I reviewed and understand the final diff, reproduced the failure before the fix, and verified the corrected behavior locally.
