### PR TITLE
feat(tools-list): check deterministic tools/list ordering on the 2026-07-28 wire

### DIFF
--- a/examples/servers/typescript/tools-list-rotated-order.ts
+++ b/examples/servers/typescript/tools-list-rotated-order.ts
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+/**
+ * tools/list ordering negative test server.
+ *
+ * Speaks the sessionless 2026-07-28 wire (SEP-2575) and advertises the same
+ * four tools on every tools/list request, but rotates the list by one
+ * position each time (it keeps a call counter for that, nothing else). The set never changes, only the order, which violates the
+ * 2026-07-28 SHOULD "Servers SHOULD return tools in a deterministic order".
+ * The tools-list scenario should emit WARNING for
+ * tools-list-deterministic-order against this server while tools-list itself
+ * still passes, since every response is structurally valid.
+ */
+
+import express from 'express';
+
+const app = express();
+app.use(express.json());
+
+const TOOLS = ['alpha', 'bravo', 'charlie', 'delta'].map((name) => ({
+  name,
+  description: `Fixture tool ${name}`,
+  inputSchema: { type: 'object', properties: {} }
+}));
+
+let listCalls = 0;
+
+app.post('/mcp', (req, res) => {
+  const body = req.body || {};
+  const id = body.id ?? null;
+  const method = body.method;
+
+  switch (method) {
+    case 'server/discover':
+      return res.json({
+        jsonrpc: '2.0',
+        id,
+        result: {
+          resultType: 'complete',
+          ttlMs: 0,
+          cacheScope: 'private',
+          supportedVersions: ['2026-07-28'],
+          capabilities: { tools: {} },
+          serverInfo: { name: 'tools-list-rotated-order', version: '1.0.0' }
+        }
+      });
+    case 'tools/list': {
+      // Rotate by one position per call: the same set, never the same order.
+      const offset = listCalls++ % TOOLS.length;
+      const tools = [...TOOLS.slice(offset), ...TOOLS.slice(0, offset)];
+      return res.json({
+        jsonrpc: '2.0',
+        id,
+        result: {
+          resultType: 'complete',
+          ttlMs: 0,
+          cacheScope: 'private',
+          tools
+        }
+      });
+    }
+    default:
+      return res.status(404).json({
+        jsonrpc: '2.0',
+        id,
+        error: { code: -32601, message: 'Method not found' }
+      });
+  }
+});
+
+const PORT = parseInt(process.env.PORT || '3008', 10);
+app.listen(PORT, '127.0.0.1', () => {
+  console.log(
+    `tools/list rotated-order negative test server running on http://localhost:${PORT}/mcp`
+  );
+});

--- a/src/scenarios/server/negative.test.ts
+++ b/src/scenarios/server/negative.test.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import { DNSRebindingProtectionScenario } from './dns-rebinding';
 import { ResourcesNotFoundErrorScenario } from './resources';
 import { CachingScenario } from './caching';
+import { ToolsListScenario } from './tools';
 import {
   JsonSchema2020_12Scenario,
   sep2106KeywordCheckStatus
@@ -213,6 +214,43 @@ describe('Server scenario negative tests', () => {
         (c) => c.id === 'sep-2106-anchor-keyword-preserved'
       );
       expect(anchor?.status).toBe('SKIPPED');
+    }, 10000);
+  });
+
+  describe('tools-list-deterministic-order', () => {
+    let serverProcess: ChildProcess | null = null;
+    const PORT = 3008;
+
+    beforeAll(async () => {
+      serverProcess = await startServer(
+        path.join(
+          process.cwd(),
+          'examples/servers/typescript/tools-list-rotated-order.ts'
+        ),
+        PORT
+      );
+    }, 35000);
+
+    afterAll(async () => {
+      await stopServer(serverProcess);
+    });
+
+    it('emits WARNING for deterministic-order while tools-list still passes against a server that rotates its tool list', async () => {
+      const scenario = new ToolsListScenario();
+      const checks = await scenario.run(
+        testContext(`http://localhost:${PORT}/mcp`, DRAFT_PROTOCOL_VERSION)
+      );
+
+      const list = checks.find((c) => c.id === 'tools-list');
+      expect(list?.status).toBe('SUCCESS');
+
+      const order = checks.find(
+        (c) => c.id === 'tools-list-deterministic-order'
+      );
+      expect(order?.status).toBe('WARNING');
+      expect(order?.errorMessage).toMatch(/different order/);
+      expect(order?.details).toMatchObject({ toolCount: 4, probes: 3 });
+      expect(order?.details?.untestable).toBeUndefined();
     }, 10000);
   });
 

--- a/src/scenarios/server/tools.test.ts
+++ b/src/scenarios/server/tools.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { buildToolsNameFormatCheck, validateToolNameFormat } from './tools.js';
+import {
+  buildToolsListDeterministicOrderCheck,
+  buildToolsNameFormatCheck,
+  validateToolNameFormat
+} from './tools.js';
 
 describe('validateToolNameFormat', () => {
   it('accepts a typical snake_case name', () => {
@@ -103,5 +107,145 @@ describe('buildToolsNameFormatCheck', () => {
     const check = buildToolsNameFormatCheck([{ name: 'ok' }]);
     const ids = check.specReferences?.map((r) => r.id);
     expect(ids).toEqual(['MCP-Tools-List', 'SEP-986']);
+  });
+});
+
+describe('buildToolsListDeterministicOrderCheck', () => {
+  const names = (...ns: string[]) => ns.map((name) => ({ name }));
+
+  it('returns SUCCESS when every probe lists the same tools in the same order', () => {
+    const check = buildToolsListDeterministicOrderCheck([
+      names('a', 'b', 'c'),
+      names('a', 'b', 'c'),
+      names('a', 'b', 'c')
+    ]);
+    expect(check.id).toBe('tools-list-deterministic-order');
+    expect(check.status).toBe('SUCCESS');
+    expect(check.errorMessage).toBeUndefined();
+    expect(check.details).toEqual({
+      toolCount: 3,
+      probes: 3,
+      orders: [
+        ['a', 'b', 'c'],
+        ['a', 'b', 'c'],
+        ['a', 'b', 'c']
+      ]
+    });
+    expect(check.specReferences?.[0]?.url).toContain('2026-07-28/server/tools');
+  });
+
+  it('returns WARNING when the same tools come back in a different order', () => {
+    const check = buildToolsListDeterministicOrderCheck([
+      names('a', 'b', 'c'),
+      names('b', 'c', 'a'),
+      names('c', 'a', 'b')
+    ]);
+    expect(check.status).toBe('WARNING');
+    expect(check.errorMessage).toMatch(/different order/);
+    expect(check.errorMessage).toMatch(/index 0/);
+    expect(check.details).toMatchObject({ toolCount: 3, probes: 3 });
+    expect(check.details?.untestable).toBeUndefined();
+    expect(check.details?.orders).toEqual([
+      ['a', 'b', 'c'],
+      ['b', 'c', 'a'],
+      ['c', 'a', 'b']
+    ]);
+  });
+
+  it('flags a divergence that only appears on the last probe', () => {
+    const check = buildToolsListDeterministicOrderCheck([
+      names('a', 'b', 'c'),
+      names('a', 'b', 'c'),
+      names('a', 'c', 'b')
+    ]);
+    expect(check.status).toBe('WARNING');
+    expect(check.errorMessage).toMatch(/probe 3/);
+    expect(check.errorMessage).toMatch(/index 1/);
+  });
+
+  it('reports untestable (WARNING) when the set of tools changed between probes', () => {
+    const check = buildToolsListDeterministicOrderCheck([
+      names('a', 'b', 'c'),
+      names('a', 'b', 'd')
+    ]);
+    expect(check.status).toBe('WARNING');
+    expect(check.errorMessage).toMatch(/^Not testable: /);
+    expect(check.errorMessage).toMatch(/added: d/);
+    expect(check.errorMessage).toMatch(/removed: c/);
+    expect(check.details).toMatchObject({ untestable: true });
+  });
+
+  it('reports untestable (WARNING) when a probe returned no tools array', () => {
+    const check = buildToolsListDeterministicOrderCheck([
+      names('a', 'b'),
+      undefined
+    ]);
+    expect(check.status).toBe('WARNING');
+    expect(check.errorMessage).toMatch(/^Not testable: /);
+    expect(check.details).toMatchObject({ untestable: true });
+  });
+
+  it('reports untestable (WARNING) with fewer than two probes', () => {
+    const check = buildToolsListDeterministicOrderCheck([names('a', 'b')]);
+    expect(check.status).toBe('WARNING');
+    expect(check.errorMessage).toMatch(/^Not testable: /);
+  });
+
+  it('returns INFO when no probe saw two tools to order', () => {
+    const one = buildToolsListDeterministicOrderCheck([names('a'), names('a')]);
+    expect(one.status).toBe('INFO');
+    expect(one.errorMessage).toMatch(/nothing to compare/);
+    expect(one.details).toEqual({
+      toolCount: 1,
+      probes: 2,
+      orders: [['a'], ['a']]
+    });
+    const none = buildToolsListDeterministicOrderCheck([[], []]);
+    expect(none.status).toBe('INFO');
+  });
+
+  it('reports untestable when a probe grows from one tool to two', () => {
+    const check = buildToolsListDeterministicOrderCheck([
+      names('a'),
+      names('a', 'b')
+    ]);
+    expect(check.status).toBe('WARNING');
+    expect(check.errorMessage).toMatch(/^Not testable: /);
+    expect(check.errorMessage).toMatch(/added: b/);
+  });
+
+  it('treats a tool without a string name as one placeholder entry', () => {
+    const check = buildToolsListDeterministicOrderCheck([
+      [{ name: 'a' }, { name: 42 }],
+      [{ name: 42 }, { name: 'a' }]
+    ]);
+    expect(check.status).toBe('WARNING');
+    expect(check.errorMessage).toMatch(/different order/);
+    expect(check.details?.orders).toEqual([
+      ['a', '<tool missing name>'],
+      ['<tool missing name>', 'a']
+    ]);
+  });
+
+  it('treats duplicate names as a set change only when their multiplicity changes', () => {
+    const stable = buildToolsListDeterministicOrderCheck([
+      names('a', 'a', 'b'),
+      names('a', 'a', 'b')
+    ]);
+    expect(stable.status).toBe('SUCCESS');
+    const changed = buildToolsListDeterministicOrderCheck([
+      names('a', 'a', 'b'),
+      names('a', 'b', 'b')
+    ]);
+    expect(changed.status).toBe('WARNING');
+    expect(changed.errorMessage).toMatch(/^Not testable: /);
+  });
+
+  it('gates itself to the 2026-07-28 wire', () => {
+    const check = buildToolsListDeterministicOrderCheck([
+      names('a', 'b'),
+      names('a', 'b')
+    ]);
+    expect(check.source).toEqual({ introducedIn: '2026-07-28' });
   });
 });

--- a/src/scenarios/server/tools.ts
+++ b/src/scenarios/server/tools.ts
@@ -5,9 +5,11 @@
 import {
   ClientScenario,
   ConformanceCheck,
-  DRAFT_PROTOCOL_VERSION
+  DRAFT_PROTOCOL_VERSION,
+  specVersionAtLeast
 } from '../../types';
 import type { RunContext } from '../../connection';
+import { notTestable, untestableCheck } from '../untestable';
 import type {
   ListToolsResult,
   CallToolResult
@@ -98,6 +100,136 @@ export function buildToolsNameFormatCheck(
   };
 }
 
+export const TOOLS_LIST_ORDER_CHECK_ID = 'tools-list-deterministic-order';
+
+/** The revision that introduced the deterministic-order SHOULD. A published, dated revision, so written as a literal. */
+export const TOOLS_LIST_ORDER_INTRODUCED_IN = '2026-07-28' as const;
+
+/** How many consecutive tools/list snapshots the ordering check compares. */
+const TOOLS_LIST_ORDER_PROBES = 3;
+
+const TOOLS_LIST_ORDER_SPEC_REFS = [
+  {
+    id: 'MCP-Tools-Deterministic-Order',
+    url: 'https://modelcontextprotocol.io/specification/2026-07-28/server/tools#capabilities'
+  }
+];
+
+/**
+ * Build the tools-list-deterministic-order check from consecutive tools/list
+ * snapshots.
+ *
+ * 2026-07-28 server/tools.mdx: "Servers SHOULD return tools in a deterministic
+ * order (i.e., the same ordering across requests when the underlying set of
+ * tools has not changed)." SHOULD, so a violation is WARNING.
+ *
+ * The spec scopes the SHOULD to an unchanged set, so a set that differs
+ * between probes is reported as untestable (issue #248) rather than as a
+ * violation: from the outside, a sample cannot tell a nondeterministic server
+ * from one whose tools legitimately changed between two requests.
+ */
+export function buildToolsListDeterministicOrderCheck(
+  snapshots: ReadonlyArray<ReadonlyArray<{ name?: unknown }> | undefined>
+): ConformanceCheck {
+  const timestamp = new Date().toISOString();
+  const baseCheck = {
+    id: TOOLS_LIST_ORDER_CHECK_ID,
+    name: 'ToolsListDeterministicOrder',
+    description:
+      'Consecutive tools/list requests return the same tools in the same order',
+    specReferences: TOOLS_LIST_ORDER_SPEC_REFS,
+    source: { introducedIn: TOOLS_LIST_ORDER_INTRODUCED_IN },
+    timestamp
+  };
+  const untestable = (reason: string): ConformanceCheck => ({
+    ...baseCheck,
+    status: 'WARNING',
+    errorMessage: notTestable(reason),
+    details: { untestable: true, reason, probes: snapshots.length }
+  });
+
+  if (snapshots.length < 2) {
+    return untestable(
+      `needs at least two tools/list snapshots to compare, got ${snapshots.length}`
+    );
+  }
+  const missing = snapshots.findIndex((tools) => !Array.isArray(tools));
+  if (missing !== -1) {
+    return untestable(
+      `tools/list probe ${missing + 1} did not return a tools array`
+    );
+  }
+
+  // A position-independent placeholder, so that a nameless tool moving
+  // around reads as an order change rather than as a set change.
+  const orders = snapshots.map((tools) =>
+    (tools as ReadonlyArray<{ name?: unknown }>).map((tool) =>
+      typeof tool.name === 'string' ? tool.name : '<tool missing name>'
+    )
+  );
+
+  // Nothing to order when no probe saw two tools.
+  if (orders.every((order) => order.length < 2)) {
+    return {
+      ...baseCheck,
+      status: 'INFO',
+      errorMessage: `${orders[0].length} tool(s) advertised; nothing to compare`,
+      details: { toolCount: orders[0].length, probes: orders.length, orders }
+    };
+  }
+
+  // The SHOULD only binds while the set is unchanged: compare multisets first.
+  const countNames = (names: string[]): Map<string, number> => {
+    const counts = new Map<string, number>();
+    for (const name of names) counts.set(name, (counts.get(name) ?? 0) + 1);
+    return counts;
+  };
+  const baseline = countNames(orders[0]);
+  for (let probe = 1; probe < orders.length; probe++) {
+    const current = countNames(orders[probe]);
+    const added: string[] = [];
+    const removed: string[] = [];
+    for (const [name, count] of current) {
+      const before = baseline.get(name) ?? 0;
+      if (count > before) added.push(name);
+    }
+    for (const [name, count] of baseline) {
+      const now = current.get(name) ?? 0;
+      if (count > now) removed.push(name);
+    }
+    if (added.length > 0 || removed.length > 0) {
+      return untestable(
+        `the set of tools changed between tools/list probe 1 and probe ${probe + 1} ` +
+          `(added: ${added.join(', ') || 'none'}; removed: ${removed.join(', ') || 'none'}), ` +
+          'so the deterministic-order SHOULD does not apply to this sample'
+      );
+    }
+  }
+
+  const toolCount = orders[0].length;
+
+  for (let probe = 1; probe < orders.length; probe++) {
+    const index = orders[probe].findIndex((name, i) => name !== orders[0][i]);
+    if (index !== -1) {
+      return {
+        ...baseCheck,
+        status: 'WARNING',
+        errorMessage:
+          `tools/list returned the same ${toolCount} tools in a different order across ` +
+          `consecutive requests: probe ${probe + 1} diverges from probe 1 at index ${index} ` +
+          `(${orders[0][index]} vs ${orders[probe][index]})`,
+        details: { toolCount, probes: orders.length, orders }
+      };
+    }
+  }
+
+  return {
+    ...baseCheck,
+    status: 'SUCCESS',
+    details: { toolCount, probes: orders.length, orders }
+  };
+}
+
 export class ToolsListScenario implements ClientScenario {
   name = 'tools-list';
   readonly source = { introducedIn: '2025-06-18' } as const;
@@ -112,7 +244,9 @@ export class ToolsListScenario implements ClientScenario {
 - Each tool MUST have:
   - \`name\` (string, 1-64 chars, matching \`^[A-Za-z0-9_./-]+$\`)
   - \`description\` (string)
-  - \`inputSchema\` (valid JSON Schema object)`;
+  - \`inputSchema\` (valid JSON Schema object)
+- From 2026-07-28: return tools in a deterministic order across requests
+  when the set of tools has not changed (SHOULD)`;
 
   async run(ctx: RunContext): Promise<ConformanceCheck[]> {
     const checks: ConformanceCheck[] = [];
@@ -162,6 +296,38 @@ export class ToolsListScenario implements ClientScenario {
       // Validate tool name format per SEP-986:
       // names MUST be 1-64 chars matching ^[A-Za-z0-9_./-]+$
       checks.push(buildToolsNameFormatCheck(result.tools));
+
+      // 2026-07-28: tools SHOULD come back in a deterministic order across
+      // requests. Take two more consecutive tools/list snapshots and compare.
+      if (specVersionAtLeast(ctx.specVersion, TOOLS_LIST_ORDER_INTRODUCED_IN)) {
+        const snapshots: Array<ListToolsResult['tools'] | undefined> = [
+          result.tools
+        ];
+        let probeError: unknown;
+        try {
+          while (snapshots.length < TOOLS_LIST_ORDER_PROBES) {
+            const again = await conn.request<ListToolsResult>('tools/list');
+            snapshots.push(again.tools);
+          }
+        } catch (error) {
+          probeError = error;
+        }
+        checks.push(
+          probeError === undefined
+            ? buildToolsListDeterministicOrderCheck(snapshots)
+            : {
+                ...untestableCheck(
+                  TOOLS_LIST_ORDER_CHECK_ID,
+                  'ToolsListDeterministicOrder',
+                  'Consecutive tools/list requests return the same tools in the same order',
+                  `repeated tools/list request failed: ${probeError instanceof Error ? probeError.message : String(probeError)}`,
+                  TOOLS_LIST_ORDER_SPEC_REFS,
+                  'WARNING'
+                ),
+                source: { introducedIn: TOOLS_LIST_ORDER_INTRODUCED_IN }
+              }
+        );
+      }
 
       await conn.close();
     } catch (error) {

--- a/src/scenarios/server/tools.ts
+++ b/src/scenarios/server/tools.ts
@@ -100,11 +100,6 @@ export function buildToolsNameFormatCheck(
   };
 }
 
-export const TOOLS_LIST_ORDER_CHECK_ID = 'tools-list-deterministic-order';
-
-/** The revision that introduced the deterministic-order SHOULD. A published, dated revision, so written as a literal. */
-export const TOOLS_LIST_ORDER_INTRODUCED_IN = '2026-07-28' as const;
-
 /** How many consecutive tools/list snapshots the ordering check compares. */
 const TOOLS_LIST_ORDER_PROBES = 3;
 
@@ -133,12 +128,12 @@ export function buildToolsListDeterministicOrderCheck(
 ): ConformanceCheck {
   const timestamp = new Date().toISOString();
   const baseCheck = {
-    id: TOOLS_LIST_ORDER_CHECK_ID,
+    id: 'tools-list-deterministic-order',
     name: 'ToolsListDeterministicOrder',
     description:
       'Consecutive tools/list requests return the same tools in the same order',
     specReferences: TOOLS_LIST_ORDER_SPEC_REFS,
-    source: { introducedIn: TOOLS_LIST_ORDER_INTRODUCED_IN },
+    source: { introducedIn: '2026-07-28' as const },
     timestamp
   };
   const untestable = (reason: string): ConformanceCheck => ({
@@ -299,7 +294,7 @@ export class ToolsListScenario implements ClientScenario {
 
       // 2026-07-28: tools SHOULD come back in a deterministic order across
       // requests. Take two more consecutive tools/list snapshots and compare.
-      if (specVersionAtLeast(ctx.specVersion, TOOLS_LIST_ORDER_INTRODUCED_IN)) {
+      if (specVersionAtLeast(ctx.specVersion, '2026-07-28')) {
         const snapshots: Array<ListToolsResult['tools'] | undefined> = [
           result.tools
         ];
@@ -317,14 +312,14 @@ export class ToolsListScenario implements ClientScenario {
             ? buildToolsListDeterministicOrderCheck(snapshots)
             : {
                 ...untestableCheck(
-                  TOOLS_LIST_ORDER_CHECK_ID,
+                  'tools-list-deterministic-order',
                   'ToolsListDeterministicOrder',
                   'Consecutive tools/list requests return the same tools in the same order',
                   `repeated tools/list request failed: ${probeError instanceof Error ? probeError.message : String(probeError)}`,
                   TOOLS_LIST_ORDER_SPEC_REFS,
                   'WARNING'
                 ),
-                source: { introducedIn: TOOLS_LIST_ORDER_INTRODUCED_IN }
+                source: { introducedIn: '2026-07-28' }
               }
         );
       }


### PR DESCRIPTION
Discussion: #491.

## Requirement

`docs/specification/2026-07-28/server/tools.mdx`, "Capabilities", lines 71 to 74:

> Servers **SHOULD** return tools in a deterministic order (i.e., the same ordering across requests when the underlying set of tools has not changed). Deterministic ordering enables clients to reliably cache the tool list and improves LLM prompt cache hit rates when tools are included in model context.

https://modelcontextprotocol.io/specification/2026-07-28/server/tools#capabilities

New in 2026-07-28 (absent from 2025-11-25), introduced by modelcontextprotocol/modelcontextprotocol#2516 (not a SEP, so no `src/seps/` row). No scenario exercised it before this PR.

## What changes

One check added to the existing `tools-list` scenario (`src/scenarios/server/tools.ts`), no new scenario, no change to `requirements/*.yaml`, no `src/seps/` row since the sentence does not come from a SEP.

| Check | Keyword | Severity | Stimulus | Outcome |
| --- | --- | --- | --- | --- |
| `tools-list-deterministic-order` | SHOULD | `WARNING` | three consecutive `tools/list` requests, from the 2026-07-28 wire on (`source.introducedIn: '2026-07-28'`, a literal since the revision is published and dated) | `SUCCESS` when the three name sequences are identical; `WARNING` when the same multiset of names comes back in a different order (first divergent probe and index in `errorMessage`, the three orders in `details.orders`); untestable under the #248 policy (`Not testable: ...`, `details.untestable: true`, WARNING severity) when the multiset changed between probes, since the spec scopes the SHOULD to an unchanged set; `INFO` when no probe saw two tools |

The helper `buildToolsListDeterministicOrderCheck(snapshots)` is exported and unit-tested, following `buildToolsNameFormatCheck`. A failure of a repeated `tools/list` request is reported as untestable on the new check (via `untestableCheck()`) instead of turning `tools-list` itself red. The neighbouring MUST NOT on connection-invariance is deliberately left out, following #332.

## Prove it passes and fails

- Passing: `all-scenarios.test.ts` already runs `tools-list` against the everything-server on both wires; on 2026-07-28 the new check is `SUCCESS`.
- Failing: `examples/servers/typescript/tools-list-rotated-order.ts` speaks the sessionless 2026-07-28 wire, advertises the same four tools and rotates the list by one position on every `tools/list`. The new `negative.test.ts` case asserts `WARNING` on `tools-list-deterministic-order` and `SUCCESS` on `tools-list` against it.

```
node dist/index.js server --url http://localhost:3124/mcp --scenario tools-list --spec-version 2026-07-28
[tools-list                    ] SUCCESS Server lists available tools with valid structure
[tools-name-format             ] SUCCESS Tool names are 1-64 characters and match ^[A-Za-z0-9_./-]+$
[tools-list-deterministic-order] WARNING Consecutive tools/list requests return the same tools in the same order
[wire-schema-valid             ] SUCCESS Every JSON-RPC message the implementation sent is valid per the spec JSON schema for the negotiated spec version
Passed: 3/3, 0 failed, 1 warnings
```

## Runs against real SDKs

typescript-sdk `main` as of 2026-09-05 (5119ee7fd779), `npm start -- sdk typescript-sdk --mode server --scenario tools-list --spec-version 2026-07-28`:

```

Passed: 4/4, 0 failed, 0 warnings
```

python-sdk `main` as of 2026-09-05 (7bb486a10fa6), `npm start -- sdk python-sdk --mode server --scenario tools-list --spec-version 2026-07-28`:

```
[server] [09/05/26 20:20:35] INFO     Starting MCP Everything Server on     server.py:805
[server] [09/05/26 20:20:36] INFO     Created new          streamable_http_manager.py:325
[server] [09/05/26 20:20:37] INFO     StreamableHTTP       streamable_http_manager.py:166
Passed: 4/4, 0 failed, 0 warnings
```

## Local CI

`npm run check` and `npm run build` pass. `npm test`: 44 files, 536 passed, 0 failed (524 on `main` plus the 12 added here). The three "Unhandled Rejection" entries vitest reports are present on `main` before this change.

## Notes for review

- Three probes rather than two, so that a shuffling server cannot pass by repeating one order by chance as easily; happy to change the count.
- The set-changed case is reported as untestable rather than skipped, per the #248 policy, and rather than as a violation, because the spec text itself carves it out. This is where #332's sampling concern applied to connection-invariance; here the carve-out is normative, not heuristic. It still surfaces as a WARNING, which CI treats as a failure; `SKIPPED` or a retry until the set is stable are the alternatives if you prefer.
- `requirements/2026-07-28.yaml` lists `tools-list` as scored and is frozen at scenario granularity, so this check raises the bar for a shipped revision. The requirement is 2026-07-28 text, so I left the file untouched; see #491 for the question, and I will follow whatever you decide.
- The new check id will appear in `untracked` in `src/seps/traceability.json` at the next refresh, for lack of a yaml row.

## AI disclosure

Per `AI_POLICY.md`: this PR, the fixture and the tests were written primarily by Claude Code, pointed at this one SHOULD as `AGENTS.md` asks, under my direction. Review replies may be AI-assisted as well.
