### PR TITLE
feat(client): validate safe integer range for x-mcp-header parameters (#445)

### DIFF
--- a/src/scenarios/client/http-custom-headers.test.ts
+++ b/src/scenarios/client/http-custom-headers.test.ts
@@ -86,6 +86,7 @@ describe('HttpCustomHeadersScenario (SEP-2243) check IDs', () => {
             arguments: {
               region: 'us-west1',
               priority: 42,
+              unsafe_integer_val: 9007199254740992,
               non_ascii_val: nonAscii,
               query: 'SELECT 1'
             }
@@ -188,6 +189,7 @@ describe('HttpCustomHeadersScenario (SEP-2243) check IDs', () => {
             arguments: {
               region: 'us-west1',
               priority: 42,
+              unsafe_integer_val: 9007199254740992,
               non_ascii_val: nonAscii,
               query: 'SELECT 1'
             }
@@ -236,6 +238,80 @@ describe('HttpCustomHeadersScenario (SEP-2243) check IDs', () => {
         expect(statuses.length, id).toBeGreaterThan(0);
         expect(statuses, id).not.toContain('FAILURE');
       }
+    } finally {
+      await scenario.stop();
+    }
+  });
+
+  it('FAILs safe-integer-range when a client mirrors an out-of-range integer header', async () => {
+    const scenario = new HttpCustomHeadersScenario();
+    const { serverUrl } = await scenario.start(testScenarioContext());
+    try {
+      await post(
+        serverUrl,
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: {
+            name: 'test_custom_headers',
+            arguments: {
+              region: 'us-west1',
+              priority: 42,
+              unsafe_integer_val: 9007199254740992,
+              query: 'SELECT 1'
+            }
+          }
+        },
+        {
+          'Mcp-Method': 'tools/call',
+          'Mcp-Name': 'test_custom_headers',
+          'Mcp-Param-Region': 'us-west1',
+          'Mcp-Param-Priority': '42',
+          'Mcp-Param-UnsafeInteger': '9007199254740992'
+        }
+      );
+      const checks = scenario.getChecks();
+      expect(
+        statusesFor(checks, 'sep-2243-x-mcp-header-integer-safe-range')
+      ).toContain('FAILURE');
+    } finally {
+      await scenario.stop();
+    }
+  });
+
+  it('PASSes safe-integer-range when a client omits the out-of-range integer header', async () => {
+    const scenario = new HttpCustomHeadersScenario();
+    const { serverUrl } = await scenario.start(testScenarioContext());
+    try {
+      await post(
+        serverUrl,
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: {
+            name: 'test_custom_headers',
+            arguments: {
+              region: 'us-west1',
+              priority: 42,
+              unsafe_integer_val: 9007199254740992,
+              query: 'SELECT 1'
+            }
+          }
+        },
+        {
+          'Mcp-Method': 'tools/call',
+          'Mcp-Name': 'test_custom_headers',
+          'Mcp-Param-Region': 'us-west1',
+          'Mcp-Param-Priority': '42'
+          // Mcp-Param-UnsafeInteger is deliberately omitted
+        }
+      );
+      const checks = scenario.getChecks();
+      expect(
+        statusesFor(checks, 'sep-2243-x-mcp-header-integer-safe-range')
+      ).toContain('SUCCESS');
     } finally {
       await scenario.stop();
     }

--- a/src/scenarios/client/http-custom-headers.ts
+++ b/src/scenarios/client/http-custom-headers.ts
@@ -42,7 +42,8 @@ export const CUSTOM_HEADERS_DECLARED_CHECK_IDS = [
   'sep-2243-client-mirrors-designated-params',
   'sep-2243-client-encode-values',
   'sep-2243-client-base64-unsafe',
-  'sep-2243-client-omit-null'
+  'sep-2243-client-omit-null',
+  'sep-2243-x-mcp-header-integer-safe-range'
 ] as const;
 
 /**
@@ -199,6 +200,7 @@ export class HttpCustomHeadersScenario extends BaseHttpScenario {
           arguments: {
             region: 'us-west1',
             priority: 42,
+            unsafe_integer_val: 9007199254740992,
             verbose: false,
             debug: true,
             empty_val: '',
@@ -297,6 +299,12 @@ export class HttpCustomHeadersScenario extends BaseHttpScenario {
                   type: 'integer',
                   description: 'Integer numeric value',
                   'x-mcp-header': 'Priority'
+                },
+                unsafe_integer_val: {
+                  type: 'integer',
+                  description:
+                    'Integer value outside IEEE754 safe range (-2^53+1 to 2^53-1) — MUST NOT be mirrored to an HTTP header',
+                  'x-mcp-header': 'UnsafeInteger'
                 },
                 verbose: {
                   type: 'boolean',
@@ -452,6 +460,37 @@ export class HttpCustomHeadersScenario extends BaseHttpScenario {
 
       // Check Mcp-Param-Priority header (integer)
       this.checkParamHeader(req, 'Priority', args.priority, 'integer');
+
+      // Check Mcp-Param-UnsafeInteger header:
+      // SEP-2243: "Integer values MUST be within the safe range for integers
+      // represented using IEEE754 double-precision floating point numbers (-2^53+1 to 2^53-1)"
+      // An out-of-range integer argument MUST NOT be mirrored into an HTTP header.
+      if (
+        args.unsafe_integer_val !== undefined &&
+        args.unsafe_integer_val !== null
+      ) {
+        const unsafeIntegerHeader = req.headers['mcp-param-unsafeinteger'] as
+          | string
+          | undefined;
+        this.checks.push({
+          id: 'sep-2243-x-mcp-header-integer-safe-range',
+          name: 'ClientCustomHeaderSafeIntegerRange',
+          description:
+            'Integer values outside IEEE754 safe range (-2^53+1 to 2^53-1) MUST NOT be mirrored into Mcp-Param headers',
+          status: unsafeIntegerHeader === undefined ? 'SUCCESS' : 'FAILURE',
+          timestamp: new Date().toISOString(),
+          errorMessage:
+            unsafeIntegerHeader !== undefined
+              ? `Client mirrored unsafe integer value '${unsafeIntegerHeader}' into Mcp-Param-UnsafeInteger header. Integer values MUST be within the safe range (-2^53+1 to 2^53-1).`
+              : undefined,
+          specReferences: [SPEC_REFERENCE_TOOL_DEF, SPEC_REFERENCE_CUSTOM],
+          details: {
+            headerName: 'Mcp-Param-UnsafeInteger',
+            rawHeaderValue: unsafeIntegerHeader,
+            bodyValue: args.unsafe_integer_val
+          }
+        });
+      }
 
       // Check Mcp-Param-Verbose header (boolean value)
       // checkParamHeader already FAILs on missing header, so this also covers

--- a/src/seps/sep-2243.yaml
+++ b/src/seps/sep-2243.yaml
@@ -25,6 +25,9 @@ requirements:
   - check: sep-2243-x-mcp-header-primitive-only
     text: 'x-mcp-header MUST only be applied to parameters with primitive types (integer, string, boolean). Parameters with type `number` are not permitted.'
     url: https://modelcontextprotocol.io/specification/draft/server/tools#custom-headers
+  - check: sep-2243-x-mcp-header-integer-safe-range
+    text: 'Integer values MUST be within the safe range for integers represented using IEEE754 double-precision floating point numbers (−2^53+1 to 2^53−1).'
+    url: https://modelcontextprotocol.io/specification/draft/server/tools#custom-headers
   - check: sep-2243-client-reject-invalid-tool
     text: 'Clients MUST reject tool definitions where any x-mcp-header value violates these constraints. Rejection means the client MUST exclude the invalid tool from the set of tools returned by tools/list.'
     url: https://modelcontextprotocol.io/specification/draft/server/tools#custom-headers

--- a/src/seps/traceability.json
+++ b/src/seps/traceability.json
@@ -213,6 +213,12 @@
           "url": "https://modelcontextprotocol.io/specification/draft/server/tools#custom-headers"
         },
         {
+          "check": "sep-2243-x-mcp-header-integer-safe-range",
+          "status": "tested",
+          "text": "Integer values MUST be within the safe range for integers represented using IEEE754 double-precision floating point numbers (−2^53+1 to 2^53−1).",
+          "url": "https://modelcontextprotocol.io/specification/draft/server/tools#custom-headers"
+        },
+        {
           "check": "sep-2243-client-reject-invalid-tool",
           "status": "tested",
           "text": "Clients MUST reject tool definitions where any x-mcp-header value violates these constraints. Rejection means the client MUST exclude the invalid tool from the set of tools returned by tools/list.",
@@ -289,7 +295,7 @@
         "sep-2243-server-no-xmcp-tool"
       ],
       "summary": {
-        "tested": 18,
+        "tested": 19,
         "untested": 2,
         "excluded": 4,
         "untracked": 3,


### PR DESCRIPTION
Related to #445.

An out-of-range integer in the ordinary `test_custom_headers` call can make a client reject that entire call before sending it, incorrectly failing several unrelated header requirements. This change gives the integer-range probe its own tool and places its `toolCalls` entry last, after the ordinary encoding and null-handling calls.

## Changes

- Declare `sep-2243-x-mcp-header-integer-safe-range` in `sep-2243.yaml` and the scenario's emitted check IDs.
- Advertise `test_custom_headers_unsafe_integer` with an annotated integer argument and request the exactly representable, out-of-safe-range value `9007199254740992` (`2^53`). The ordinary tool no longer contains this argument.
- Fail the range check if the dedicated call sends `Mcp-Param-UnsafeInteger`; retain the proposed wire-level success result when the requested argument arrives without that header.
- If the probe never arrives, emit a single range-check failure with `details.untestable: true` and a diagnostic naming the dedicated tool and possible local rejection. Absence alone cannot distinguish rejection from a skipped call. A missing or changed probe argument also cannot produce a success result.
- Cover isolation, tool ordering/schema, mirrored and omitted headers, altered/missing arguments, and idempotent backfill in regression tests.
- Leave the generated traceability manifest to the scheduled workflow; remove the hand-edited coverage entry from this PR.

## Specification decision still needed

The [discussion on #445](https://github.com/modelcontextprotocol/conformance/issues/445#issuecomment-5448966883) raises both definition-time versus call-time enforcement and error versus omission. This implementation exercises the proposed call-time, wire-level range constraint; it does **not** settle those questions or establish that silent omission is the normative recovery behavior.

A locally rejecting client still gets an **untestable failure for the range check**, following the harness's missing-prerequisite policy. Its ordinary header checks remain independently testable. Maintainer guidance is still needed before treating this proposal as the final conformance policy. The rejection validation below is a local fixture, not a C# SDK run.

## Validation

- `npm run check` — typecheck, ESLint, and Prettier pass.
- `npm run build` — passes.
- `npm test` — **45 test files, 595 tests pass**, including 15 custom-header tests.
- Real TypeScript SDK at `b65426158ed9f29aea8ef3dc09ca22d7d9d6f970`, using its unmodified `test/conformance/src/everythingClient.ts`, with the SDK packages built from source:

  ```sh
  node dist/index.js client \
    --command "node --import tsx .sdk-under-test/typescript-sdk/test/conformance/src/everythingClient.ts" \
    --scenario http-custom-headers --spec-version 2026-07-28 \
    -o results/pr-499-typescript
  ```

  **19/19 checks pass; client and runner exit 0.** The client used Node **22.14.0** on Windows. Node 24.19.0 produced the same 19 passing wire checks but crashed during client shutdown with a libuv assertion, so it is not counted as a passing end-to-end run.

- Negative CLI validation with the same SDK and a local fetch wrapper that injects `Mcp-Param-UnsafeInteger: 9007199254740992` only for the dedicated probe: **18/19 pass; only the integer-range check fails**, runner exit 1.
- Local-rejection CLI validation with the same SDK and a fetch wrapper that throws before transmitting the dedicated probe: **18/19 pass; only the integer-range check fails**, with `untestable: true` and the dedicated-tool diagnostic; client and runner exit 1.

AI assistance disclosure: Initial implementation used Antigravity; review fixes and validation used Codex.
